### PR TITLE
fix(frontend): add broker connection resilience with retry and polling

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,5 @@
 import { useState, useCallback, useEffect } from 'react';
-import { RefreshCw, Shield, Sparkles } from 'lucide-react';
+import { RefreshCw, Shield, Sparkles, WifiOff } from 'lucide-react';
 import NetworkGraph from './components/NetworkGraph';
 import NamespaceSelector from './components/NamespaceSelector';
 import DataTable from './components/DataTable';
@@ -32,7 +32,7 @@ function App() {
   const [showTraffic, setShowTraffic] = useState(true);
   const [layoutDirection, setLayoutDirection] = useState<'LR' | 'TB'>('LR');
 
-  const { namespaces } = useNamespaces();
+  const { namespaces, connected } = useNamespaces();
   const { pods, allPodsLookup, services, loading, error, togglePodExpansion, refreshData } = usePodData(namespace);
 
   // Calculate the right padding for content when AI panel is docked (in pixels)
@@ -169,6 +169,13 @@ function App() {
 
       {/* Main Content */}
       <div className="flex-1 flex flex-col overflow-hidden">
+        {!connected && (
+          <div className="bg-amber-500/20 border border-amber-500/50 text-amber-300 px-6 py-2 flex items-center gap-2">
+            <WifiOff className="w-4 h-4 flex-shrink-0" />
+            <p className="text-sm">Broker unavailable — retrying connection&hellip;</p>
+          </div>
+        )}
+
         {error && (
           <div className="bg-hubble-error/20 border border-hubble-error text-hubble-error px-6 py-3">
             <p className="text-sm">Error: {error}</p>

--- a/frontend/src/hooks/useNamespaces.ts
+++ b/frontend/src/hooks/useNamespaces.ts
@@ -1,28 +1,63 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef, useCallback } from 'react';
 import { apiClient } from '../services/api';
+
+const POLL_INTERVAL_MS = 30_000;
+const RETRY_INTERVAL_MS = 5_000;
 
 export const useNamespaces = () => {
   const [namespaces, setNamespaces] = useState<string[]>(['default']);
   const [loading, setLoading] = useState<boolean>(true);
+  const [connected, setConnected] = useState<boolean>(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
 
-  useEffect(() => {
-    const fetchNamespaces = async () => {
-      setLoading(true);
-      try {
-        const ns = await apiClient.getNamespaces();
-        if (ns.length > 0) {
-          setNamespaces(ns);
-        }
-      } catch (error) {
-        console.error('Error fetching namespaces:', error);
-        // Keep default namespace on error
-      } finally {
-        setLoading(false);
+  const fetchNamespaces = useCallback(async () => {
+    try {
+      const ns = await apiClient.getNamespaces();
+      if (ns.length > 0) {
+        setNamespaces(ns);
+        setConnected(true);
+        return true;
       }
-    };
-
-    fetchNamespaces();
+    } catch (error) {
+      console.error('Error fetching namespaces:', error);
+    }
+    setConnected(false);
+    return false;
   }, []);
 
-  return { namespaces, loading };
+  useEffect(() => {
+    let cancelled = false;
+
+    const poll = async () => {
+      if (cancelled) return;
+      setLoading((prev) => prev); // keep existing loading state for polls
+      const ok = await fetchNamespaces();
+      if (cancelled) return;
+      setLoading(false);
+      // Poll faster when disconnected so we recover quickly
+      const interval = ok ? POLL_INTERVAL_MS : RETRY_INTERVAL_MS;
+      timerRef.current = setTimeout(poll, interval);
+    };
+
+    // Initial fetch
+    setLoading(true);
+    poll();
+
+    // Re-fetch when the broker reconnects after an outage
+    const onConnectionChange = (isConnected: boolean) => {
+      if (isConnected && !cancelled) {
+        // Clear pending timer and fetch immediately
+        clearTimeout(timerRef.current);
+        poll();
+      }
+    };
+    apiClient.onConnectionChange(onConnectionChange);
+
+    return () => {
+      cancelled = true;
+      clearTimeout(timerRef.current);
+    };
+  }, [fetchNamespaces]);
+
+  return { namespaces, loading, connected };
 };

--- a/frontend/src/hooks/usePodData.ts
+++ b/frontend/src/hooks/usePodData.ts
@@ -1,6 +1,8 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import type { PodInfo, PodNodeData, ServiceInfo } from '../types';
 import { apiClient } from '../services/api';
+
+const POLL_INTERVAL_MS = 30_000;
 
 async function withConcurrencyLimit<T>(tasks: (() => Promise<T>)[], limit: number): Promise<T[]> {
   const results: T[] = new Array(tasks.length);
@@ -24,6 +26,7 @@ export const usePodData = (namespace: string) => {
   const [services, setServices] = useState<ServiceInfo[]>([]);
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
+  const timerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
 
   const fetchPodData = useCallback(async () => {
     setLoading(true);
@@ -100,7 +103,21 @@ export const usePodData = (namespace: string) => {
   }, [namespace]);
 
   useEffect(() => {
-    fetchPodData();
+    let cancelled = false;
+
+    const poll = async () => {
+      if (cancelled) return;
+      await fetchPodData();
+      if (cancelled) return;
+      timerRef.current = setTimeout(poll, POLL_INTERVAL_MS);
+    };
+
+    poll();
+
+    return () => {
+      cancelled = true;
+      clearTimeout(timerRef.current);
+    };
   }, [fetchPodData]);
 
   const togglePodExpansion = useCallback((podId: string) => {
@@ -112,6 +129,7 @@ export const usePodData = (namespace: string) => {
   }, []);
 
   const refreshData = useCallback(() => {
+    clearTimeout(timerRef.current);
     fetchPodData();
   }, [fetchPodData]);
 

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,9 +1,33 @@
 import axios from 'axios';
-import type { AxiosInstance } from 'axios';
+import type { AxiosInstance, AxiosError, InternalAxiosRequestConfig } from 'axios';
 import type { PodInfo, NetworkTraffic, SyscallInfo, ServiceInfo } from '../types';
+
+interface RetryConfig extends InternalAxiosRequestConfig {
+  _retryCount?: number;
+}
+
+const MAX_RETRIES = 3;
+const RETRY_BASE_DELAY_MS = 1000;
+
+function isRetryable(error: AxiosError): boolean {
+  // Retry on network errors (ECONNREFUSED, ECONNRESET, etc.)
+  if (!error.response) return true;
+  // Retry on 502, 503, 504 (broker temporarily unavailable)
+  const status = error.response.status;
+  return status === 502 || status === 503 || status === 504;
+}
+
+function retryDelay(retryCount: number): number {
+  // Exponential backoff: 1s, 2s, 4s + jitter
+  const delay = RETRY_BASE_DELAY_MS * Math.pow(2, retryCount);
+  const jitter = delay * 0.2 * Math.random();
+  return delay + jitter;
+}
 
 class BrokerAPIClient {
   private client: AxiosInstance;
+  private _connected = false;
+  private _onConnectionChange?: (connected: boolean) => void;
 
   constructor(baseURL?: string) {
     // Use provided baseURL or default to relative /api path
@@ -17,6 +41,47 @@ class BrokerAPIClient {
         'Content-Type': 'application/json',
       },
     });
+
+    // Retry interceptor for transient failures
+    this.client.interceptors.response.use(
+      (response) => {
+        this.setConnected(true);
+        return response;
+      },
+      async (error: AxiosError) => {
+        const config = error.config as RetryConfig | undefined;
+        if (!config || !isRetryable(error)) {
+          this.setConnected(false);
+          return Promise.reject(error);
+        }
+
+        const retryCount = config._retryCount ?? 0;
+        if (retryCount >= MAX_RETRIES) {
+          this.setConnected(false);
+          return Promise.reject(error);
+        }
+
+        config._retryCount = retryCount + 1;
+        const delay = retryDelay(retryCount);
+        await new Promise((resolve) => setTimeout(resolve, delay));
+        return this.client(config);
+      },
+    );
+  }
+
+  private setConnected(connected: boolean) {
+    if (this._connected !== connected) {
+      this._connected = connected;
+      this._onConnectionChange?.(connected);
+    }
+  }
+
+  get connected(): boolean {
+    return this._connected;
+  }
+
+  onConnectionChange(callback: (connected: boolean) => void) {
+    this._onConnectionChange = callback;
   }
 
   /**


### PR DESCRIPTION
## Summary

- **Axios retry interceptor**: Automatically retries failed requests (network errors, 502/503/504) with exponential backoff (up to 3 attempts). Handles both startup race conditions and runtime broker restarts transparently.
- **Namespace polling**: Polls every 30s normally, 5s when disconnected, so the namespace list self-heals after broker recovery without requiring a pod restart.
- **Pod data polling**: Refreshes pod data every 30s to keep the UI current and recover from transient outages.
- **Connection state banner**: Shows a visible "Broker unavailable" banner when the API is unreachable, and dismisses it automatically when connectivity is restored.
- **Immediate refetch on reconnect**: When the broker comes back, pending timers are cleared and data is fetched immediately rather than waiting for the next poll interval.

## Problem

When the frontend and broker pods start simultaneously, the Vite preview server's proxy gets ECONNREFUSED before the broker is ready. All subsequent API calls silently return empty data, leaving the UI stuck with no namespaces or pods. The only recovery was manually restarting the frontend pod. The same issue occurred during any broker restart at runtime.

## Test plan
- [ ] Verify namespaces load correctly on fresh deployment
- [ ] Stop the broker pod and confirm the disconnection banner appears
- [ ] Restart the broker pod and confirm data recovers automatically within ~5s
- [ ] Verify no excessive API calls during normal operation (30s intervals)
- [ ] TypeScript compiles cleanly (`tsc --noEmit`)
- [ ] Production build succeeds (`npm run build`)