### PR TITLE
fix: implement P0-P2 audit findings across all components

### DIFF
--- a/.github/workflows/controller-release.yaml
+++ b/.github/workflows/controller-release.yaml
@@ -72,7 +72,7 @@ jobs:
 
           cd controller
 
-          cargo install cross --git https://github.com/cross-rs/cross
+          cargo install cross --git https://github.com/cross-rs/cross --tag v0.2.5
 
           cross build --target ${{ steps.args.outputs.BUILD }} --release
 

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -111,7 +111,7 @@ jobs:
           sudo apt update -y
           sudo apt install linux-tools-common linux-tools-generic linux-tools-$(uname -r) -y
           cd controller
-          cargo install cross --git https://github.com/cross-rs/cross --force
+          cargo install cross --git https://github.com/cross-rs/cross --tag v0.2.5
           cross build --target ${{ steps.args.outputs.BUILD }} --release
 
       - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7

--- a/.github/workflows/security-scan.yaml
+++ b/.github/workflows/security-scan.yaml
@@ -112,7 +112,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install checkov
-        run: pip install checkov
+        run: pip install checkov==3.2.446
 
       - name: Run checkov on Helm templates
         run: |

--- a/advisor/cmd/networkpolicy.go
+++ b/advisor/cmd/networkpolicy.go
@@ -54,8 +54,14 @@ var networkPolicyCmd = &cobra.Command{
 		config, err := k8s.GetConfig(dryRun)
 		if err != nil {
 			log.Error().Err(err).Msg("Error retrieving Kubernetes configuration")
-			fmt.Fprintf(os.Stderr, "Failed to get Kubernetes configuration: %v\n", err)
-			fmt.Fprintf(os.Stderr, "If running directly as 'advisor', try using kubectl plugin mode: kubectl guardian gen networkpolicy\n")
+			fmt.Fprintf(os.Stderr, "Failed to get Kubernetes configuration: %v\n\n", err)
+			fmt.Fprintf(os.Stderr, "Diagnosis:\n")
+			fmt.Fprintf(os.Stderr, "  Verify your kubeconfig is valid:\n")
+			fmt.Fprintf(os.Stderr, "    kubectl cluster-info\n")
+			fmt.Fprintf(os.Stderr, "  Check your current context:\n")
+			fmt.Fprintf(os.Stderr, "    kubectl config current-context\n")
+			fmt.Fprintf(os.Stderr, "\nIf running directly as 'advisor', try kubectl plugin mode:\n")
+			fmt.Fprintf(os.Stderr, "  kubectl guardian gen networkpolicy\n")
 			os.Exit(1)
 		}
 
@@ -75,7 +81,12 @@ var networkPolicyCmd = &cobra.Command{
 			targetNamespace, err = k8s.GetCurrentNamespace(config)
 			if err != nil {
 				log.Error().Err(err).Msg("Error getting current namespace from context")
-				fmt.Fprintf(os.Stderr, "Failed to get current namespace: %v\n", err)
+				fmt.Fprintf(os.Stderr, "Failed to get current namespace: %v\n\n", err)
+				fmt.Fprintf(os.Stderr, "Diagnosis:\n")
+				fmt.Fprintf(os.Stderr, "  Check your kubeconfig context has a namespace set:\n")
+				fmt.Fprintf(os.Stderr, "    kubectl config view --minify\n")
+				fmt.Fprintf(os.Stderr, "  Or specify a namespace explicitly:\n")
+				fmt.Fprintf(os.Stderr, "    kubectl guardian gen networkpolicy --namespace <namespace> <pod-name>\n")
 				os.Exit(1)
 			}
 		}
@@ -90,12 +101,27 @@ var networkPolicyCmd = &cobra.Command{
 			log.Debug().Msg("Port forwarding setup completed")
 		case err := <-errChan:
 			log.Error().Err(err).Msg("Port forwarding failed")
-			fmt.Fprintf(os.Stderr, "Failed to setup port forwarding: %v\n", err)
-			fmt.Fprintf(os.Stderr, "If running directly as 'advisor', try using kubectl plugin mode: kubectl guardian gen networkpolicy\n")
+			fmt.Fprintf(os.Stderr, "Port forwarding failed: %v\n\n", err)
+			fmt.Fprintf(os.Stderr, "Diagnosis:\n")
+			fmt.Fprintf(os.Stderr, "  Ensure the broker pod is running:\n")
+			fmt.Fprintf(os.Stderr, "    kubectl get pods -n kguardian -l app=kguardian-broker\n")
+			fmt.Fprintf(os.Stderr, "  Check the broker service exists:\n")
+			fmt.Fprintf(os.Stderr, "    kubectl get svc -n kguardian\n")
+			fmt.Fprintf(os.Stderr, "  Verify connectivity manually:\n")
+			fmt.Fprintf(os.Stderr, "    kubectl port-forward -n kguardian svc/kguardian-broker 9090:9090\n")
+			fmt.Fprintf(os.Stderr, "  Check broker pod logs for errors:\n")
+			fmt.Fprintf(os.Stderr, "    kubectl logs -n kguardian -l app=kguardian-broker\n")
 			os.Exit(1)
 		case <-ctx.Done():
 			log.Error().Msg("Timeout waiting for port forwarding")
-			fmt.Fprintf(os.Stderr, "Timeout waiting for port forwarding setup\n")
+			fmt.Fprintf(os.Stderr, "Timed out waiting for port forwarding to become ready.\n\n")
+			fmt.Fprintf(os.Stderr, "Diagnosis:\n")
+			fmt.Fprintf(os.Stderr, "  Ensure the broker pod is running and healthy:\n")
+			fmt.Fprintf(os.Stderr, "    kubectl get pods -n kguardian -l app=kguardian-broker\n")
+			fmt.Fprintf(os.Stderr, "  Check broker pod logs:\n")
+			fmt.Fprintf(os.Stderr, "    kubectl logs -n kguardian -l app=kguardian-broker\n")
+			fmt.Fprintf(os.Stderr, "  Verify the broker service is reachable:\n")
+			fmt.Fprintf(os.Stderr, "    kubectl port-forward -n kguardian svc/kguardian-broker 9090:9090\n")
 			os.Exit(1)
 		}
 
@@ -116,6 +142,11 @@ var networkPolicyCmd = &cobra.Command{
 		// Initialize output directory
 		if err := policyService.InitOutputDirectory(); err != nil {
 			log.Error().Err(err).Msg("Failed to initialize output directory")
+			fmt.Fprintf(os.Stderr, "Failed to create output directory %q: %v\n\n", outputDir, err)
+			fmt.Fprintf(os.Stderr, "Next steps:\n")
+			fmt.Fprintf(os.Stderr, "  Check directory permissions in the current working directory.\n")
+			fmt.Fprintf(os.Stderr, "  Specify a different output directory:\n")
+			fmt.Fprintf(os.Stderr, "    kubectl guardian gen networkpolicy --output-dir /tmp/network-policies <pod-name>\n")
 			os.Exit(1)
 		}
 
@@ -126,6 +157,10 @@ var networkPolicyCmd = &cobra.Command{
 			pods, err := k8s.GetAllPodsInAllNamespaces(ctx, config)
 			if err != nil {
 				log.Error().Err(err).Msg("Error getting pods in all namespaces")
+				fmt.Fprintf(os.Stderr, "Failed to list pods across all namespaces: %v\n\n", err)
+				fmt.Fprintf(os.Stderr, "Diagnosis:\n")
+				fmt.Fprintf(os.Stderr, "  Verify cluster-wide pod list permissions:\n")
+				fmt.Fprintf(os.Stderr, "    kubectl auth can-i list pods --all-namespaces\n")
 				os.Exit(1)
 			}
 			processPods(pods, policyService, policyServiceType)
@@ -136,6 +171,12 @@ var networkPolicyCmd = &cobra.Command{
 			pods, err := k8s.GetPodsInNamespace(ctx, config, targetNamespace)
 			if err != nil {
 				log.Error().Err(err).Msgf("Error getting pods in namespace %s", targetNamespace)
+				fmt.Fprintf(os.Stderr, "Failed to list pods in namespace %q: %v\n\n", targetNamespace, err)
+				fmt.Fprintf(os.Stderr, "Diagnosis:\n")
+				fmt.Fprintf(os.Stderr, "  Check the namespace exists:\n")
+				fmt.Fprintf(os.Stderr, "    kubectl get namespace %s\n", targetNamespace)
+				fmt.Fprintf(os.Stderr, "  Verify pod list permissions in the namespace:\n")
+				fmt.Fprintf(os.Stderr, "    kubectl auth can-i list pods -n %s\n", targetNamespace)
 				os.Exit(1)
 			}
 			processPods(pods, policyService, policyServiceType)
@@ -143,7 +184,11 @@ var networkPolicyCmd = &cobra.Command{
 			// Check if a pod name was provided
 			if len(args) != 1 {
 				log.Error().Msg("Pod name is required when not using --all or --all-namespaces flags")
-				fmt.Fprintf(os.Stderr, "Error: pod name argument is required. Use --all to generate for all pods in a namespace.\n")
+				fmt.Fprintf(os.Stderr, "Error: pod name argument is required.\n\n")
+				fmt.Fprintf(os.Stderr, "Usage:\n")
+				fmt.Fprintf(os.Stderr, "  kubectl guardian gen networkpolicy <pod-name>\n")
+				fmt.Fprintf(os.Stderr, "  kubectl guardian gen networkpolicy --all             # all pods in current namespace\n")
+				fmt.Fprintf(os.Stderr, "  kubectl guardian gen networkpolicy --all-namespaces  # all pods in all namespaces\n")
 				os.Exit(1)
 			}
 
@@ -151,6 +196,12 @@ var networkPolicyCmd = &cobra.Command{
 			log.Info().Msgf("Generating policy for pod %s in namespace %s", podName, targetNamespace)
 			if err := policyService.GenerateAndHandlePolicy(podName, policyServiceType); err != nil {
 				log.Error().Err(err).Msgf("Error generating policy for pod %s", podName)
+				fmt.Fprintf(os.Stderr, "Failed to generate policy for pod %q: %v\n\n", podName, err)
+				fmt.Fprintf(os.Stderr, "Diagnosis:\n")
+				fmt.Fprintf(os.Stderr, "  Verify the pod exists and is running:\n")
+				fmt.Fprintf(os.Stderr, "    kubectl get pod %s -n %s\n", podName, targetNamespace)
+				fmt.Fprintf(os.Stderr, "  Confirm the broker has traffic data for this pod:\n")
+				fmt.Fprintf(os.Stderr, "    kubectl logs -n kguardian -l app=kguardian-broker | grep %s\n", podName)
 				os.Exit(1)
 			}
 		}
@@ -202,12 +253,12 @@ func (a *k8sConfigAdapter) GetOutputDir() string {
 
 func init() {
 	// Add flags
-	networkPolicyCmd.Flags().StringP("namespace", "n", "", "Namespace (defaults to current context namespace)")
+	networkPolicyCmd.Flags().StringP("namespace", "n", "", "Kubernetes namespace to target (defaults to current context namespace, e.g. default, kube-system)")
 	networkPolicyCmd.Flags().BoolVarP(&allInNamespace, "all", "a", false, "Generate policies for all pods in the specified or current namespace")
 	networkPolicyCmd.Flags().BoolVarP(&allNamespaces, "all-namespaces", "A", false, "Generate policies for all pods in all namespaces")
-	networkPolicyCmd.Flags().StringVarP(&policyType, "type", "t", "kubernetes", "Type of network policy to generate (kubernetes or cilium)")
-	networkPolicyCmd.Flags().BoolVar(&dryRun, "dry-run", true, "Only generate policies and save to files without applying them to the cluster")
-	networkPolicyCmd.Flags().StringVar(&outputDir, "output-dir", "network-policies", "Directory to store generated network policies")
+	networkPolicyCmd.Flags().StringVarP(&policyType, "type", "t", "kubernetes", "Type of network policy to generate (kubernetes, cilium)")
+	networkPolicyCmd.Flags().BoolVar(&dryRun, "dry-run", true, "Only generate policies and save to files without applying them to the cluster (true, false)")
+	networkPolicyCmd.Flags().StringVar(&outputDir, "output-dir", "network-policies", "Directory to store generated network policy YAML files")
 
 	// Add completion for the policy type flag
 	_ = networkPolicyCmd.RegisterFlagCompletionFunc("type", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {

--- a/advisor/cmd/root.go
+++ b/advisor/cmd/root.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"time"
 
@@ -35,7 +36,7 @@ func init() {
 	kubeConfigFlags.AddFlags(rootCmd.PersistentFlags())
 
 	// Add debug flag to rootCmd so it's available for all sub-commands
-	rootCmd.PersistentFlags().BoolVar(&debug, "debug", false, "sets log level to debug")
+	rootCmd.PersistentFlags().BoolVar(&debug, "debug", false, "Enable debug-level logging (default: false)")
 
 	// Add broker override flags
 	rootCmd.PersistentFlags().StringVar(&brokerNamespace, "broker-namespace", "", "Namespace where the kguardian broker is installed (default \"kguardian\")")
@@ -59,16 +60,36 @@ func init() {
 		// Initialize Kubernetes config and logging
 		config, err := k8s.NewConfig(kubeConfigFlags)
 		if err != nil {
+			fmt.Fprintf(os.Stderr, "Failed to initialize Kubernetes client: %v\n\n", err)
+			fmt.Fprintf(os.Stderr, "Diagnosis:\n")
+			fmt.Fprintf(os.Stderr, "  Verify your kubeconfig is valid:\n")
+			fmt.Fprintf(os.Stderr, "    kubectl cluster-info\n")
+			fmt.Fprintf(os.Stderr, "  Check your current context:\n")
+			fmt.Fprintf(os.Stderr, "    kubectl config current-context\n")
+			fmt.Fprintf(os.Stderr, "  Ensure KUBECONFIG or ~/.kube/config is set correctly.\n")
 			log.Fatal().Err(err).Msg("Error initializing Kubernetes client")
 		}
 
 		kubeconfigPath := kubeConfigFlags.ToRawKubeConfigLoader().ConfigAccess().GetDefaultFilename()
 		if err != nil {
+			fmt.Fprintf(os.Stderr, "Failed to initialize Kubernetes client: %v\n\n", err)
+			fmt.Fprintf(os.Stderr, "Diagnosis:\n")
+			fmt.Fprintf(os.Stderr, "  Verify your kubeconfig is valid:\n")
+			fmt.Fprintf(os.Stderr, "    kubectl cluster-info\n")
+			fmt.Fprintf(os.Stderr, "  Check your current context:\n")
+			fmt.Fprintf(os.Stderr, "    kubectl config current-context\n")
+			fmt.Fprintf(os.Stderr, "  Ensure KUBECONFIG or ~/.kube/config is set correctly.\n")
 			log.Fatal().Err(err).Msg("Error initializing Kubernetes client")
 		}
 
 		namespace, _, err := kubeConfigFlags.ToRawKubeConfigLoader().Namespace()
 		if err != nil {
+			fmt.Fprintf(os.Stderr, "Failed to get namespace from kubeconfig: %v\n\n", err)
+			fmt.Fprintf(os.Stderr, "Diagnosis:\n")
+			fmt.Fprintf(os.Stderr, "  Check your kubeconfig context has a namespace set:\n")
+			fmt.Fprintf(os.Stderr, "    kubectl config view --minify\n")
+			fmt.Fprintf(os.Stderr, "  Or pass --namespace explicitly:\n")
+			fmt.Fprintf(os.Stderr, "    kubectl guardian gen networkpolicy --namespace <namespace> <pod-name>\n")
 			log.Fatal().Err(err).Msg("Failed to get namespace")
 		}
 

--- a/advisor/cmd/seccomp.go
+++ b/advisor/cmd/seccomp.go
@@ -1,6 +1,10 @@
 package cmd
 
 import (
+	"context"
+	"fmt"
+	"os"
+
 	log "github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 	"github.com/kguardian-dev/kguardian/advisor/pkg/k8s"
@@ -17,8 +21,8 @@ func init() {
 	seccompCmd.Flags().BoolVar(&allInNamespace, "all", false, "Generate profiles for all pods in the current namespace")
 
 	// Add seccomp-specific flags
-	seccompCmd.Flags().StringVar(&outputDir, "output-dir", "seccomp-profiles", "Directory to store generated seccomp profiles")
-	seccompCmd.Flags().StringVar(&defaultAction, "default-action", "SCMP_ACT_ERRNO", "Default action for seccomp profile (SCMP_ACT_ERRNO|SCMP_ACT_KILL|SCMP_ACT_LOG)")
+	seccompCmd.Flags().StringVar(&outputDir, "output-dir", "seccomp-profiles", "Directory to store generated seccomp profile JSON files")
+	seccompCmd.Flags().StringVar(&defaultAction, "default-action", "SCMP_ACT_ERRNO", "Default seccomp action for unmatched syscalls (SCMP_ACT_ERRNO, SCMP_ACT_KILL, SCMP_ACT_LOG)")
 }
 
 var seccompCmd = &cobra.Command{
@@ -38,6 +42,14 @@ var seccompCmd = &cobra.Command{
 
 		config, ok := cmd.Context().Value(k8s.ConfigKey).(*k8s.Config)
 		if !ok {
+			fmt.Fprintf(os.Stderr, "Failed to retrieve Kubernetes configuration from context.\n\n")
+			fmt.Fprintf(os.Stderr, "Diagnosis:\n")
+			fmt.Fprintf(os.Stderr, "  Verify your kubeconfig is valid:\n")
+			fmt.Fprintf(os.Stderr, "    kubectl cluster-info\n")
+			fmt.Fprintf(os.Stderr, "  Check your current context:\n")
+			fmt.Fprintf(os.Stderr, "    kubectl config current-context\n")
+			fmt.Fprintf(os.Stderr, "\nIf running directly as 'advisor', try kubectl plugin mode:\n")
+			fmt.Fprintf(os.Stderr, "  kubectl guardian gen seccomp\n")
 			log.Fatal().Msg("Failed to retrieve Kubernetes configuration")
 		}
 
@@ -48,6 +60,12 @@ var seccompCmd = &cobra.Command{
 		// Get the namespace from kubeConfigFlags
 		namespace, _, err := kubeConfigFlags.ToRawKubeConfigLoader().Namespace()
 		if err != nil {
+			fmt.Fprintf(os.Stderr, "Failed to get namespace: %v\n\n", err)
+			fmt.Fprintf(os.Stderr, "Diagnosis:\n")
+			fmt.Fprintf(os.Stderr, "  Check your kubeconfig context has a namespace set:\n")
+			fmt.Fprintf(os.Stderr, "    kubectl config view --minify\n")
+			fmt.Fprintf(os.Stderr, "  Or specify a namespace explicitly:\n")
+			fmt.Fprintf(os.Stderr, "    kubectl guardian gen seccomp --namespace <namespace> <pod-name>\n")
 			log.Fatal().Err(err).Msg("Failed to get namespace")
 		}
 
@@ -69,18 +87,54 @@ var seccompCmd = &cobra.Command{
 			options.Namespace = namespace
 		}
 
+		// Create a cancellable context so we can propagate cancellation to the
+		// profile generator and cleanly shut down the error-watching goroutine.
+		ctx, cancel := context.WithCancel(cmd.Context())
+		defer cancel()
+
 		// Set up port forwarding
 		stopChan, errChan, done := k8s.PortForward(config, brokerNamespace, brokerService)
 		<-done // Block until port-forwarding is set up
-		go func() {
-			for err := range errChan {
-				log.Fatal().Err(err).Msg("Error setting up port-forwarding")
-			}
-		}()
 		log.Debug().Msg("Port forwarding set up successfully.")
 
+		// Watch port-forwarding errors without blocking: if an error arrives
+		// while profile generation is running we log it and cancel the context
+		// so the generator can exit early. We never call log.Fatal() here so
+		// the deferred cleanup (close(stopChan)) still runs.
+		pfErrChan := make(chan error, 1)
+		go func() {
+			select {
+			case err, ok := <-errChan:
+				if ok && err != nil {
+					log.Error().Err(err).Msg("Port-forwarding error during seccomp profile generation")
+					pfErrChan <- err
+					cancel()
+				}
+			case <-ctx.Done():
+				// Context cancelled externally; nothing to do.
+			}
+		}()
+
 		// Generate seccomp profiles
-		k8s.GenerateSeccompProfile(options, config)
+		k8s.GenerateSeccompProfile(ctx, options, config)
 		close(stopChan)
+
+		// Surface any port-forwarding error that was captured above so the
+		// process exits with a non-zero status.
+		select {
+		case pfErr := <-pfErrChan:
+			fmt.Fprintf(os.Stderr, "Port-forwarding error: %v\n\n", pfErr)
+			fmt.Fprintf(os.Stderr, "Diagnosis:\n")
+			fmt.Fprintf(os.Stderr, "  Ensure the broker pod is running:\n")
+			fmt.Fprintf(os.Stderr, "    kubectl get pods -n kguardian -l app=kguardian-broker\n")
+			fmt.Fprintf(os.Stderr, "  Check the broker service exists:\n")
+			fmt.Fprintf(os.Stderr, "    kubectl get svc -n kguardian\n")
+			fmt.Fprintf(os.Stderr, "  Verify connectivity manually:\n")
+			fmt.Fprintf(os.Stderr, "    kubectl port-forward -n kguardian svc/kguardian-broker 9090:9090\n")
+			fmt.Fprintf(os.Stderr, "  Check broker pod logs for errors:\n")
+			fmt.Fprintf(os.Stderr, "    kubectl logs -n kguardian -l app=kguardian-broker\n")
+			os.Exit(1)
+		default:
+		}
 	},
 }

--- a/advisor/pkg/api/pod_syscall.go
+++ b/advisor/pkg/api/pod_syscall.go
@@ -1,11 +1,13 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/rs/zerolog/log"
 )
@@ -25,8 +27,20 @@ type PodSysCallResponse struct {
 func GetPodSysCall(podName string) (PodSysCall, error) {
 	apiURL := "http://127.0.0.1:9090/pod/syscalls/" + podName
 
-	resp, err := http.Get(apiURL)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL, nil)
 	if err != nil {
+		return PodSysCall{}, fmt.Errorf("GetPodSysCall: failed to build request: %w", err)
+	}
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		if ctx.Err() != nil {
+			log.Error().Err(err).Msg("GetPodSysCall: request timed out")
+			return PodSysCall{}, ErrTimeout
+		}
 		log.Error().Err(err).Msg("GetPodSysCall: Error making GET request")
 		return PodSysCall{}, err
 	}
@@ -36,8 +50,12 @@ func GetPodSysCall(podName string) (PodSysCall, error) {
 		}
 	}()
 
+	if resp.StatusCode == http.StatusNotFound {
+		log.Debug().Msgf("GetPodSysCall: resource not found (404) for pod %s", podName)
+		return PodSysCall{}, ErrNotFound
+	}
 	if resp.StatusCode != http.StatusOK {
-		return PodSysCall{}, fmt.Errorf("GetPodSysCall: received non-OK HTTP status code: %v", resp.StatusCode)
+		return PodSysCall{}, classifyStatusError(resp.StatusCode)
 	}
 
 	body, err := io.ReadAll(resp.Body)

--- a/advisor/pkg/api/pod_traffic.go
+++ b/advisor/pkg/api/pod_traffic.go
@@ -1,15 +1,36 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
+	"time"
 
 	log "github.com/rs/zerolog/log"
 
 	v1 "k8s.io/api/core/v1"
 )
+
+// Sentinel errors for distinct API failure modes.
+var (
+	ErrNotFound          = errors.New("resource not found")
+	ErrBrokerUnavailable = errors.New("broker unavailable")
+	ErrTimeout           = errors.New("request timeout")
+)
+
+// httpClient is a package-level shared client with connection pooling and a
+// default timeout. Individual call-sites may still wrap it with a context.
+var httpClient = &http.Client{
+	Transport: &http.Transport{
+		MaxIdleConns:        100,
+		MaxIdleConnsPerHost: 100,
+		IdleConnTimeout:     90 * time.Second,
+	},
+	Timeout: 30 * time.Second,
+}
 
 type PodTraffic struct {
 	UUID string `yaml:"uuid" json:"uuid"`
@@ -66,14 +87,35 @@ func GetSvcSpec(svcIP string) (*SvcDetail, error) {
 	return GetSvcSpecFunc(svcIP)
 }
 
+// classifyStatusError maps an HTTP status code to a sentinel error.
+func classifyStatusError(statusCode int) error {
+	if statusCode == http.StatusNotFound {
+		return ErrNotFound
+	}
+	if statusCode >= 500 {
+		return ErrBrokerUnavailable
+	}
+	return fmt.Errorf("unexpected HTTP status: %d", statusCode)
+}
+
 // Real implementations
 func getRealPodTraffic(podName string) ([]PodTraffic, error) {
-	// Specify the URL of the REST API endpoint you want to invoke.
 	apiURL := "http://127.0.0.1:9090/pod/traffic/" + podName
 
-	// Send an HTTP GET request to the API endpoint.
-	resp, err := http.Get(apiURL)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL, nil)
 	if err != nil {
+		return nil, fmt.Errorf("GetPodTraffic: failed to build request: %w", err)
+	}
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		if ctx.Err() != nil {
+			log.Error().Err(err).Msg("GetPodTraffic: request timed out")
+			return nil, ErrTimeout
+		}
 		log.Error().Err(err).Msg("GetPodTraffic: Error making GET request")
 		return nil, err
 	}
@@ -82,10 +124,11 @@ func getRealPodTraffic(podName string) ([]PodTraffic, error) {
 			log.Error().Err(closeErr).Msg("GetPodTraffic: Error closing response body")
 		}
 	}()
-	// Check the HTTP status code.
+
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("GetPodTraffic: received non-OK HTTP status code: %v", resp.StatusCode)
+		return nil, classifyStatusError(resp.StatusCode)
 	}
+
 	var podTraffic []PodTraffic
 
 	body, err := io.ReadAll(resp.Body)
@@ -94,13 +137,11 @@ func getRealPodTraffic(podName string) ([]PodTraffic, error) {
 		return nil, err
 	}
 
-	// Parse the JSON response and unmarshal it into the Go struct.
-	if err := json.Unmarshal([]byte(body), &podTraffic); err != nil {
+	if err := json.Unmarshal(body, &podTraffic); err != nil {
 		log.Error().Err(err).Msg("GetPodTraffic: Error unmarshal JSON")
 		return nil, err
 	}
 
-	// If no pod traffic is found, return err
 	if len(podTraffic) == 0 {
 		return nil, fmt.Errorf("GetPodTraffic: No pod traffic found in database")
 	}
@@ -110,12 +151,22 @@ func getRealPodTraffic(podName string) ([]PodTraffic, error) {
 
 // Should we just get the pod spec directly from the cluster and only use the DB for the SaaS version where it contains the pod spec? Would this help with reducing unnecessary chatter?And just let the client do it?
 func getRealPodSpec(ip string) (*PodDetail, error) {
-	// Specify the URL of the REST API endpoint you want to invoke.
 	apiURL := "http://127.0.0.1:9090/pod/ip/" + ip
 
-	// Send an HTTP GET request to the API endpoint.
-	resp, err := http.Get(apiURL)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL, nil)
 	if err != nil {
+		return nil, fmt.Errorf("getRealPodSpec: failed to build request: %w", err)
+	}
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		if ctx.Err() != nil {
+			log.Error().Err(err).Msg("getRealPodSpec: request timed out")
+			return nil, ErrTimeout
+		}
 		log.Error().Err(err).Msg("Error making GET request")
 		return nil, err
 	}
@@ -125,21 +176,21 @@ func getRealPodSpec(ip string) (*PodDetail, error) {
 		}
 	}()
 
-	// Check the HTTP status code.
+	if resp.StatusCode == http.StatusNotFound {
+		log.Debug().Msgf("getRealPodSpec: resource not found (404) for IP %s", ip)
+		return nil, ErrNotFound
+	}
 	if resp.StatusCode != http.StatusOK {
-		log.Debug().Msgf("received non-OK HTTP status code: %v", resp.StatusCode)
-		return nil, nil
+		return nil, classifyStatusError(resp.StatusCode)
 	}
 
 	var details *PodDetail
 
-	// Parse the JSON response and unmarshal it into the Go struct.
 	if err := json.NewDecoder(resp.Body).Decode(&details); err != nil {
 		log.Error().Err(err).Msg("Error decoding JSON")
 		return nil, err
 	}
 
-	// If no pod details are found, return err
 	if details == nil {
 		return nil, fmt.Errorf("no pod details found in database")
 	}
@@ -148,12 +199,22 @@ func getRealPodSpec(ip string) (*PodDetail, error) {
 }
 
 func getRealSvcSpec(svcIp string) (*SvcDetail, error) {
-	// Specify the URL of the RESTAPI endpoint you want to invoke.
 	apiURL := "http://127.0.0.1:9090/svc/ip/" + svcIp
 
-	// Send an HTTP GET request to the API endpoint.
-	resp, err := http.Get(apiURL)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL, nil)
 	if err != nil {
+		return nil, fmt.Errorf("getRealSvcSpec: failed to build request: %w", err)
+	}
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		if ctx.Err() != nil {
+			log.Error().Err(err).Msg("getRealSvcSpec: request timed out")
+			return nil, ErrTimeout
+		}
 		log.Error().Err(err).Msg("Error making GET request")
 		return nil, err
 	}
@@ -163,15 +224,16 @@ func getRealSvcSpec(svcIp string) (*SvcDetail, error) {
 		}
 	}()
 
-	// Check the HTTP status code.
+	if resp.StatusCode == http.StatusNotFound {
+		log.Debug().Msgf("getRealSvcSpec: resource not found (404) for IP %s", svcIp)
+		return nil, ErrNotFound
+	}
 	if resp.StatusCode != http.StatusOK {
-		log.Debug().Msgf("received non-OK HTTP status code: %v", resp.StatusCode)
-		return nil, nil
+		return nil, classifyStatusError(resp.StatusCode)
 	}
 
 	var details SvcDetail
 
-	// Parse the JSON response and unmarshal it into the Go struct.
 	if err := json.NewDecoder(resp.Body).Decode(&details); err != nil {
 		log.Error().Err(err).Msg("Error decoding JSON")
 		return nil, err

--- a/advisor/pkg/k8s/networkpolicies.go
+++ b/advisor/pkg/k8s/networkpolicies.go
@@ -99,8 +99,11 @@ func processIngressRules(traffic api.PodTraffic, config *Config) (*networkingv1.
 		return nil, fmt.Errorf("error determining peer for ingress traffic from %s: %w", traffic.DstIP, err)
 	}
 
-	portInt := 0
-	_, _ = fmt.Sscanf(traffic.SrcPodPort, "%d", &portInt)
+	var portInt int
+	if _, err := fmt.Sscanf(traffic.SrcPodPort, "%d", &portInt); err != nil {
+		log.Warn().Str("port", traffic.SrcPodPort).Msg("processIngressRules: failed to parse port, skipping traffic entry")
+		return nil, fmt.Errorf("processIngressRules: invalid port %q: %w", traffic.SrcPodPort, err)
+	}
 	port := intstr.FromInt(portInt)
 	protocol := traffic.Protocol
 
@@ -124,8 +127,11 @@ func processEgressRules(traffic api.PodTraffic, config *Config) (*networkingv1.N
 		return nil, fmt.Errorf("error determining peer for egress traffic to %s: %w", traffic.DstIP, err)
 	}
 
-	portInt := 0
-	_, _ = fmt.Sscanf(traffic.DstPort, "%d", &portInt)
+	var portInt int
+	if _, err := fmt.Sscanf(traffic.DstPort, "%d", &portInt); err != nil {
+		log.Warn().Str("port", traffic.DstPort).Msg("processEgressRules: failed to parse port, skipping traffic entry")
+		return nil, fmt.Errorf("processEgressRules: invalid port %q: %w", traffic.DstPort, err)
+	}
 	port := intstr.FromInt(portInt)
 	protocol := traffic.Protocol
 

--- a/advisor/pkg/k8s/seccomp.go
+++ b/advisor/pkg/k8s/seccomp.go
@@ -1,6 +1,7 @@
 package k8s
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -30,7 +31,10 @@ type ProfileOptions struct {
 	Architectures []string
 }
 
-func GenerateSeccompProfile(options GenerateOptions, config *Config) {
+// GenerateSeccompProfile generates seccomp profiles for pods selected by options.
+// The context is used to detect cancellation (e.g. from a port-forwarding failure)
+// so the function exits early instead of continuing through remaining pods.
+func GenerateSeccompProfile(ctx context.Context, options GenerateOptions, config *Config) {
 
 	var Architectures = map[string][]string{
 		"x86_64": {"SCMP_ARCH_X86_64"},
@@ -53,6 +57,14 @@ func GenerateSeccompProfile(options GenerateOptions, config *Config) {
 
 	// Generate seccompprofile for each pod in pods
 	for _, pod := range pods {
+		// Honour context cancellation between pods.
+		select {
+		case <-ctx.Done():
+			log.Debug().Err(ctx.Err()).Msg("GenerateSeccompProfile: context cancelled, stopping early")
+			return
+		default:
+		}
+
 		podSysCalls, err := api.GetPodSysCall(pod.Name)
 		if err != nil {
 			log.Debug().Err(err).Msgf("Error retrieving %s pod syscall", pod.Name)

--- a/broker/Cargo.lock
+++ b/broker/Cargo.lock
@@ -282,6 +282,9 @@ dependencies = [
  "diesel",
  "diesel_migrations",
  "dotenv",
+ "futures-util",
+ "r2d2",
+ "regex",
  "serde",
  "serde_json",
  "thiserror",
@@ -642,6 +645,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
+name = "futures-macro"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -660,6 +674,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-core",
+ "futures-macro",
  "futures-task",
  "pin-project-lite",
  "pin-utils",

--- a/broker/Cargo.toml
+++ b/broker/Cargo.toml
@@ -27,6 +27,7 @@ dotenv = "0.15"
 actix-web = "4.11"
 actix-cors = "0.7"
 diesel = { version = "2.3.6", features = ["postgres","chrono","serde_json","r2d2"] }
+r2d2 = "0.8"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
 uuid = { version = "1.21.0", features = ["v4", "serde"] }
@@ -35,3 +36,5 @@ tracing = {version = "0.1.44", features = ['log']}
 chrono = { version = "0.4.43", features = ["serde"] }
 diesel_migrations = "2.1.0"
 tracing-subscriber = { version = "0.3.22", features = ["json", "env-filter"] }
+futures-util = "0.3"
+regex = "1"

--- a/broker/Dockerfile
+++ b/broker/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:latest  AS build
+FROM rust:1.83-bookworm AS build
 
 COPY Cargo.lock /app/
 
@@ -15,6 +15,7 @@ COPY db  /app/broker/db
 
 RUN --mount=type=cache,target=/usr/local/cargo/registry  cargo build --release
 
+# Pin to a specific digest in production: debian:bookworm-slim@sha256:<digest>
 FROM debian:bookworm-slim AS app
 
 RUN apt update && apt install libpq5 -y

--- a/broker/Dockerfile
+++ b/broker/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.86-bookworm AS build
+FROM rust:1.88-bookworm AS build
 
 COPY Cargo.lock /app/
 

--- a/broker/Dockerfile
+++ b/broker/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.83-bookworm AS build
+FROM rust:1.86-bookworm AS build
 
 COPY Cargo.lock /app/
 

--- a/broker/db/migrations/2026-04-13-000000_add_performance_indexes/down.sql
+++ b/broker/db/migrations/2026-04-13-000000_add_performance_indexes/down.sql
@@ -1,0 +1,5 @@
+DROP INDEX IF EXISTS idx_pod_traffic_lookup;
+DROP INDEX IF EXISTS idx_pod_traffic_name;
+DROP INDEX IF EXISTS idx_pod_details_node;
+DROP INDEX IF EXISTS idx_pod_syscalls_name;
+DROP INDEX IF EXISTS idx_svc_details_name;

--- a/broker/db/migrations/2026-04-13-000000_add_performance_indexes/up.sql
+++ b/broker/db/migrations/2026-04-13-000000_add_performance_indexes/up.sql
@@ -1,0 +1,5 @@
+CREATE INDEX IF NOT EXISTS idx_pod_traffic_lookup ON pod_traffic(pod_ip, traffic_type, decision);
+CREATE INDEX IF NOT EXISTS idx_pod_traffic_name ON pod_traffic(pod_name);
+CREATE INDEX IF NOT EXISTS idx_pod_details_node ON pod_details(node_name, is_dead);
+CREATE INDEX IF NOT EXISTS idx_pod_syscalls_name ON pod_syscalls(pod_name);
+CREATE INDEX IF NOT EXISTS idx_svc_details_name ON svc_details(svc_name, svc_namespace);

--- a/broker/src/add.rs
+++ b/broker/src/add.rs
@@ -1,5 +1,5 @@
-use crate::{schema, PodDetail, PodInputSyscalls, PodSyscalls, PodTraffic, SvcDetail};
-use actix_web::{post, web, Error, HttpResponse};
+use crate::{schema, Error, PodDetail, PodInputSyscalls, PodSyscalls, PodTraffic, SvcDetail};
+use actix_web::{post, web, HttpResponse};
 use diesel::pg::PgConnection;
 use diesel::r2d2::{self, ConnectionManager};
 use std::clone::Clone;
@@ -8,7 +8,6 @@ use diesel::prelude::*;
 use tracing::{debug, info};
 
 type DbPool = r2d2::Pool<ConnectionManager<PgConnection>>;
-type DbError = Box<dyn std::error::Error + Send + Sync>;
 
 #[post("/pod/traffic/batch")]
 pub async fn add_pods_batch(
@@ -18,12 +17,18 @@ pub async fn add_pods_batch(
     let count = form.len();
     debug!("Received batch of {} network traffic events", count);
 
+    // Validate all entries before touching the DB
+    for (i, entry) in form.iter().enumerate() {
+        if let Err(msg) = entry.validate_required_fields() {
+            return Err(Error::UserInputError(format!("item {i}: {msg}")));
+        }
+    }
+
     let result = web::block(move || {
         let mut conn = pool.get()?;
         create_pod_traffic_batch(&mut conn, form)
     })
-    .await?
-    .map_err(actix_web::error::ErrorInternalServerError)?;
+    .await??;
 
     info!(
         "Successfully inserted batch of {} network traffic events",
@@ -35,7 +40,7 @@ pub async fn add_pods_batch(
 fn create_pod_traffic_batch(
     conn: &mut PgConnection,
     batch: web::Json<Vec<PodTraffic>>,
-) -> Result<usize, DbError> {
+) -> Result<usize, Error> {
     use schema::pod_traffic::dsl::*;
 
     if batch.is_empty() {
@@ -44,37 +49,39 @@ fn create_pod_traffic_batch(
 
     debug!("Processing batch of {} network traffic events", batch.len());
 
-    // Filter out duplicates by checking each event against existing records
-    let mut events_to_insert = Vec::new();
-    for event in batch.iter() {
-        if event.get_row(conn)?.is_none() {
-            events_to_insert.push(event.clone());
-        } else {
-            debug!(
-                "Skipping duplicate traffic event for pod: {:?}",
-                event.pod_name
-            );
+    conn.transaction(|conn| {
+        // Filter out duplicates by checking each event against existing records
+        let mut events_to_insert = Vec::new();
+        for event in batch.iter() {
+            if event.get_row(conn)?.is_none() {
+                events_to_insert.push(event.clone());
+            } else {
+                debug!(
+                    "Skipping duplicate traffic event for pod: {:?}",
+                    event.pod_name
+                );
+            }
         }
-    }
 
-    if events_to_insert.is_empty() {
-        debug!("All events in batch were duplicates, nothing to insert");
-        return Ok(0);
-    }
+        if events_to_insert.is_empty() {
+            debug!("All events in batch were duplicates, nothing to insert");
+            return Ok(0);
+        }
 
-    debug!(
-        "Inserting {} new network traffic events (filtered {} duplicates)",
-        events_to_insert.len(),
-        batch.len() - events_to_insert.len()
-    );
+        debug!(
+            "Inserting {} new network traffic events (filtered {} duplicates)",
+            events_to_insert.len(),
+            batch.len() - events_to_insert.len()
+        );
 
-    // Bulk insert only the new events
-    let inserted = diesel::insert_into(pod_traffic)
-        .values(&events_to_insert)
-        .execute(conn)?;
+        // Bulk insert only the new events
+        let inserted = diesel::insert_into(pod_traffic)
+            .values(&events_to_insert)
+            .execute(conn)?;
 
-    debug!("Successfully inserted {} network traffic events", inserted);
-    Ok(inserted)
+        debug!("Successfully inserted {} network traffic events", inserted);
+        Ok(inserted)
+    })
 }
 
 #[post("/pod/traffic")]
@@ -82,12 +89,15 @@ pub async fn add_pods(
     pool: web::Data<DbPool>,
     form: web::Json<PodTraffic>,
 ) -> Result<HttpResponse, Error> {
+    if let Err(msg) = form.validate_required_fields() {
+        return Err(Error::UserInputError(msg));
+    }
+
     let pods = web::block(move || {
         let mut conn = pool.get()?;
         create_pod_traffic(&mut conn, form)
     })
-    .await?
-    .map_err(actix_web::error::ErrorInternalServerError)?;
+    .await??;
 
     Ok(HttpResponse::Ok().json(pods))
 }
@@ -95,7 +105,7 @@ pub async fn add_pods(
 fn create_pod_traffic(
     conn: &mut PgConnection,
     w: web::Json<PodTraffic>,
-) -> Result<PodTraffic, DbError> {
+) -> Result<PodTraffic, Error> {
     use schema::pod_traffic::dsl::*;
     debug!(
         "storing the pod details {:?} into pod_traffic table",
@@ -113,7 +123,7 @@ fn create_pod_traffic(
 }
 
 impl PodTraffic {
-    pub fn get_row(&self, conn: &mut PgConnection) -> Result<Option<PodTraffic>, DbError> {
+    pub fn get_row(&self, conn: &mut PgConnection) -> Result<Option<PodTraffic>, Error> {
         use schema::pod_traffic::dsl::*;
         if self.ip_protocol.eq(&Some("UDP".to_string())) {
             let out: Option<PodTraffic> = pod_traffic
@@ -161,15 +171,14 @@ pub async fn add_pod_details(
         let mut conn = pool.get()?;
         upsert_pod_details(&mut conn, form)
     })
-    .await?
-    .map_err(actix_web::error::ErrorInternalServerError)?;
+    .await??;
     Ok(HttpResponse::Ok().json(pods))
 }
 
 pub fn upsert_pod_details(
     conn: &mut PgConnection,
     w: web::Json<PodDetail>,
-) -> Result<PodDetail, DbError> {
+) -> Result<PodDetail, Error> {
     use schema::pod_details::dsl::*;
     debug!(
         "storing the pod details {:?} into pod_details table",
@@ -201,13 +210,12 @@ pub async fn mark_pod_dead(
         let mut conn = pool.get()?;
         mark_pod_as_dead(&mut conn, &form.pod_name)
     })
-    .await?
-    .map_err(actix_web::error::ErrorInternalServerError)?;
+    .await??;
 
     Ok(HttpResponse::Ok().json(result))
 }
 
-fn mark_pod_as_dead(conn: &mut PgConnection, pod: &str) -> Result<usize, DbError> {
+fn mark_pod_as_dead(conn: &mut PgConnection, pod: &str) -> Result<usize, Error> {
     use schema::pod_details::dsl::*;
 
     let updated = diesel::update(pod_details)
@@ -229,15 +237,14 @@ pub async fn add_svc_details(
         let mut conn = pool.get()?;
         upsert_svc_details(&mut conn, form)
     })
-    .await?
-    .map_err(actix_web::error::ErrorInternalServerError)?;
+    .await??;
     Ok(HttpResponse::Ok().json(pods))
 }
 
 pub fn upsert_svc_details(
     conn: &mut PgConnection,
     w: web::Json<SvcDetail>,
-) -> Result<SvcDetail, DbError> {
+) -> Result<SvcDetail, Error> {
     use schema::svc_details::dsl::*;
     debug!(
         "storing the service details {:?} into svc_details table",
@@ -254,7 +261,7 @@ pub fn upsert_svc_details(
 }
 
 impl PodInputSyscalls {
-    pub fn get_row(&self, conn: &mut PgConnection) -> Result<Option<PodSyscalls>, DbError> {
+    pub fn get_row(&self, conn: &mut PgConnection) -> Result<Option<PodSyscalls>, Error> {
         use schema::pod_syscalls::dsl::*;
 
         debug!(
@@ -283,8 +290,7 @@ pub async fn add_pods_syscalls(
         let mut conn = pool.get()?;
         create_pod_syscalls(&mut conn, form)
     })
-    .await?
-    .map_err(actix_web::error::ErrorInternalServerError)?;
+    .await??;
 
     Ok(HttpResponse::Ok().json(pods))
 }
@@ -292,7 +298,7 @@ pub async fn add_pods_syscalls(
 pub fn create_pod_syscalls(
     conn: &mut PgConnection,
     w: web::Json<Vec<PodInputSyscalls>>,
-) -> Result<(), DbError> {
+) -> Result<(), Error> {
     use schema::pod_syscalls::dsl::*;
 
     conn.transaction(|conn| {

--- a/broker/src/auth.rs
+++ b/broker/src/auth.rs
@@ -1,0 +1,108 @@
+use actix_web::{
+    body::EitherBody,
+    dev::{forward_ready, Service, ServiceRequest, ServiceResponse, Transform},
+    Error, HttpResponse,
+};
+use futures_util::future::LocalBoxFuture;
+use std::{
+    env,
+    future::{ready, Ready},
+    rc::Rc,
+};
+use tracing::warn;
+
+pub struct ApiKeyAuth;
+
+impl<S, B> Transform<S, ServiceRequest> for ApiKeyAuth
+where
+    S: Service<ServiceRequest, Response = ServiceResponse<B>, Error = Error> + 'static,
+    B: 'static,
+{
+    type Response = ServiceResponse<EitherBody<B>>;
+    type Error = Error;
+    type InitError = ();
+    type Transform = ApiKeyAuthMiddleware<S>;
+    type Future = Ready<Result<Self::Transform, Self::InitError>>;
+
+    fn new_transform(&self, service: S) -> Self::Future {
+        let api_key = match env::var("API_KEY") {
+            Ok(k) if !k.is_empty() => {
+                Some(k)
+            }
+            _ => {
+                warn!("API_KEY env var is not set; all requests will be allowed (set API_KEY to enable authentication)");
+                None
+            }
+        };
+
+        ready(Ok(ApiKeyAuthMiddleware {
+            service: Rc::new(service),
+            api_key,
+        }))
+    }
+}
+
+pub struct ApiKeyAuthMiddleware<S> {
+    service: Rc<S>,
+    api_key: Option<String>,
+}
+
+impl<S, B> Service<ServiceRequest> for ApiKeyAuthMiddleware<S>
+where
+    S: Service<ServiceRequest, Response = ServiceResponse<B>, Error = Error> + 'static,
+    B: 'static,
+{
+    type Response = ServiceResponse<EitherBody<B>>;
+    type Error = Error;
+    type Future = LocalBoxFuture<'static, Result<Self::Response, Self::Error>>;
+
+    forward_ready!(service);
+
+    fn call(&self, req: ServiceRequest) -> Self::Future {
+        // /health is exempt from auth
+        if req.path() == "/health" {
+            let svc = Rc::clone(&self.service);
+            return Box::pin(async move {
+                let res = svc.call(req).await?;
+                Ok(res.map_into_left_body())
+            });
+        }
+
+        let expected = match &self.api_key {
+            None => {
+                // No key configured — pass all requests through
+                let svc = Rc::clone(&self.service);
+                return Box::pin(async move {
+                    let res = svc.call(req).await?;
+                    Ok(res.map_into_left_body())
+                });
+            }
+            Some(k) => k.clone(),
+        };
+
+        let provided = req
+            .headers()
+            .get("X-API-Key")
+            .and_then(|v| v.to_str().ok())
+            .map(|s| s.to_owned());
+
+        let authed = provided.as_deref() == Some(expected.as_str());
+
+        if authed {
+            let svc = Rc::clone(&self.service);
+            Box::pin(async move {
+                let res = svc.call(req).await?;
+                Ok(res.map_into_left_body())
+            })
+        } else {
+            Box::pin(async move {
+                let (req, _payload) = req.into_parts();
+                let response = HttpResponse::Unauthorized()
+                    .content_type("application/json")
+                    .body(r#"{"error":"Unauthorized: missing or invalid API key"}"#)
+                    .map_into_right_body();
+                Ok(ServiceResponse::new(req, response))
+            })
+        }
+    }
+}

--- a/broker/src/conn.rs
+++ b/broker/src/conn.rs
@@ -5,9 +5,12 @@ use diesel::r2d2::ConnectionManager;
 use dotenv::dotenv;
 use std::env;
 
-pub fn establish_connection() -> ConnectionManager<PgConnection> {
+/// Returns a connection manager for PostgreSQL, reading `DATABASE_URL` from the environment.
+/// Returns an error string if `DATABASE_URL` is not set.
+pub fn establish_connection() -> Result<ConnectionManager<PgConnection>, String> {
     dotenv().ok();
 
-    let database_url = env::var("DATABASE_URL").expect("DATABASE_URL must be set");
-    ConnectionManager::<PgConnection>::new(database_url)
+    let database_url = env::var("DATABASE_URL")
+        .map_err(|_| "DATABASE_URL must be set".to_string())?;
+    Ok(ConnectionManager::<PgConnection>::new(database_url))
 }

--- a/broker/src/error.rs
+++ b/broker/src/error.rs
@@ -1,5 +1,6 @@
 use actix_web::error::BlockingError;
-use diesel::r2d2;
+use actix_web::http::StatusCode;
+use diesel::result::DatabaseErrorKind;
 
 /// All errors possible to occur during reconciliation
 #[derive(Debug, thiserror::Error)]
@@ -14,21 +15,16 @@ pub enum Error {
         #[from]
         source: diesel::result::Error,
     },
-    /// Any error originating from the `actix` crate
-    #[error("Actix Web Error: {source}")]
-    ActixWebError {
-        #[from]
-        source: actix_web::Error,
-    },
 
-    /// Any error originating from the `kube-rs` crate
+    /// Any error originating from the `actix` blocking thread pool
     #[error("BlockingError: {source}")]
     BlockingError {
         #[from]
         source: BlockingError,
     },
-    /// Any error originating from the `diesel` crate
-    #[error("SQL Error: {source}")]
+
+    /// Any error originating from the `r2d2` connection pool
+    #[error("Connection pool error: {source}")]
     R2D2Error {
         #[from]
         source: r2d2::Error,
@@ -38,5 +34,27 @@ pub enum Error {
 impl From<String> for Error {
     fn from(s: String) -> Self {
         Error::UserInputError(s)
+    }
+}
+
+impl actix_web::ResponseError for Error {
+    fn status_code(&self) -> StatusCode {
+        match self {
+            Error::UserInputError(_) => StatusCode::BAD_REQUEST,
+            Error::SQLError { source } => match source {
+                diesel::result::Error::DatabaseError(DatabaseErrorKind::UniqueViolation, _) => {
+                    StatusCode::CONFLICT
+                }
+                _ => StatusCode::INTERNAL_SERVER_ERROR,
+            },
+            Error::R2D2Error { .. } => StatusCode::SERVICE_UNAVAILABLE,
+            Error::BlockingError { .. } => StatusCode::SERVICE_UNAVAILABLE,
+        }
+    }
+
+    fn error_response(&self) -> actix_web::HttpResponse {
+        let status = self.status_code();
+        let body = serde_json::json!({ "error": self.to_string() });
+        actix_web::HttpResponse::build(status).json(body)
     }
 }

--- a/broker/src/get.rs
+++ b/broker/src/get.rs
@@ -1,21 +1,56 @@
-use crate::{schema, PodDetail, PodSyscalls, PodTraffic, SvcDetail};
+use crate::{schema, Error, PodDetail, PodSyscalls, PodTraffic, SvcDetail};
 use actix_web::{get, web, HttpResponse, Responder};
 use diesel::prelude::*;
 use diesel::r2d2::{self, ConnectionManager};
+use regex::Regex;
+use std::net::IpAddr;
+use std::str::FromStr;
+use std::sync::LazyLock;
 use tracing::{debug, info};
 
 type DbPool = r2d2::Pool<ConnectionManager<PgConnection>>;
-type DbError = Box<dyn std::error::Error + Send + Sync>;
+
+// ---------------------------------------------------------------------------
+// Validation helpers
+// ---------------------------------------------------------------------------
+
+/// RFC 1123 DNS subdomain pattern for pod/node names.
+static POD_NAME_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^[a-z0-9]([a-z0-9.\-]*[a-z0-9])?$").unwrap());
+
+/// Validates a Kubernetes pod/node name against RFC 1123 DNS subdomain rules.
+fn validate_pod_name(name: &str) -> Result<(), String> {
+    if name.is_empty() {
+        return Err("name must not be empty".to_string());
+    }
+    if POD_NAME_RE.is_match(name) {
+        Ok(())
+    } else {
+        Err(format!(
+            "invalid name '{name}': must match RFC 1123 DNS subdomain (lowercase alphanumeric, '-', '.')"
+        ))
+    }
+}
+
+/// Validates that `ip` is a syntactically valid IPv4 or IPv6 address.
+fn validate_ip(ip: &str) -> Result<(), String> {
+    IpAddr::from_str(ip)
+        .map(|_| ())
+        .map_err(|_| format!("invalid IP address '{ip}'"))
+}
+
+// ---------------------------------------------------------------------------
+// Handlers
+// ---------------------------------------------------------------------------
 
 #[get("/pod/traffic")]
-pub async fn get_pod_traffic(pool: web::Data<DbPool>) -> actix_web::Result<impl Responder> {
+pub async fn get_pod_traffic(pool: web::Data<DbPool>) -> Result<impl Responder, Error> {
     debug!("select pod traffic table");
     let pod_traffic = web::block(move || {
         let mut conn = pool.get()?;
-        pod_traffic(&mut conn)
+        pod_traffic_all(&mut conn)
     })
-    .await?
-    .map_err(actix_web::error::ErrorInternalServerError)?;
+    .await??;
 
     Ok(match pod_traffic {
         Some(p) => HttpResponse::Ok().json(p),
@@ -23,7 +58,7 @@ pub async fn get_pod_traffic(pool: web::Data<DbPool>) -> actix_web::Result<impl 
     })
 }
 
-pub fn pod_traffic(conn: &mut PgConnection) -> Result<Option<Vec<PodTraffic>>, DbError> {
+pub fn pod_traffic_all(conn: &mut PgConnection) -> Result<Option<Vec<PodTraffic>>, Error> {
     use schema::pod_traffic::dsl::*;
 
     let pod = pod_traffic.load::<PodTraffic>(conn).optional()?;
@@ -32,14 +67,13 @@ pub fn pod_traffic(conn: &mut PgConnection) -> Result<Option<Vec<PodTraffic>>, D
 }
 
 #[get("/pod/info")]
-pub async fn get_pod_details(pool: web::Data<DbPool>) -> actix_web::Result<impl Responder> {
+pub async fn get_pod_details(pool: web::Data<DbPool>) -> Result<impl Responder, Error> {
     debug!("select pod details table");
     let pod_detail = web::block(move || {
         let mut conn = pool.get()?;
-        pod_details(&mut conn)
+        pod_details_all(&mut conn)
     })
-    .await?
-    .map_err(actix_web::error::ErrorInternalServerError)?;
+    .await??;
 
     Ok(match pod_detail {
         Some(p) => HttpResponse::Ok().json(p),
@@ -47,7 +81,7 @@ pub async fn get_pod_details(pool: web::Data<DbPool>) -> actix_web::Result<impl 
     })
 }
 
-pub fn pod_details(conn: &mut PgConnection) -> Result<Option<Vec<PodDetail>>, DbError> {
+pub fn pod_details_all(conn: &mut PgConnection) -> Result<Option<Vec<PodDetail>>, Error> {
     use schema::pod_details::dsl::*;
     let pod = pod_details.load::<PodDetail>(conn).optional()?;
     Ok(pod)
@@ -58,20 +92,22 @@ pub fn pod_details(conn: &mut PgConnection) -> Result<Option<Vec<PodDetail>>, Db
 pub async fn get_pods_by_node(
     pool: web::Data<DbPool>,
     node: web::Path<String>,
-) -> actix_web::Result<impl Responder> {
-    debug!("Getting pods for node: {}", node);
+) -> Result<impl Responder, Error> {
     let node_name = node.into_inner();
+    if let Err(msg) = validate_pod_name(&node_name) {
+        return Err(Error::UserInputError(msg));
+    }
+    debug!("Getting pods for node: {}", node_name);
     let pods = web::block(move || {
         let mut conn = pool.get()?;
         pods_by_node(&mut conn, &node_name)
     })
-    .await?
-    .map_err(actix_web::error::ErrorInternalServerError)?;
+    .await??;
 
     Ok(HttpResponse::Ok().json(pods))
 }
 
-pub fn pods_by_node(conn: &mut PgConnection, node: &str) -> Result<Vec<PodDetail>, DbError> {
+pub fn pods_by_node(conn: &mut PgConnection, node: &str) -> Result<Vec<PodDetail>, Error> {
     use schema::pod_details::dsl::*;
     let pods = pod_details
         .filter(node_name.eq(node))
@@ -81,14 +117,13 @@ pub fn pods_by_node(conn: &mut PgConnection, node: &str) -> Result<Vec<PodDetail
 }
 
 #[get("/svc/info")]
-pub async fn get_svc_details(pool: web::Data<DbPool>) -> actix_web::Result<impl Responder> {
+pub async fn get_svc_details(pool: web::Data<DbPool>) -> Result<impl Responder, Error> {
     debug!("select svc details table");
     let svc_detail = web::block(move || {
         let mut conn = pool.get()?;
         svc_details_all(&mut conn)
     })
-    .await?
-    .map_err(actix_web::error::ErrorInternalServerError)?;
+    .await??;
 
     Ok(match svc_detail {
         Some(s) => HttpResponse::Ok().json(s),
@@ -96,25 +131,27 @@ pub async fn get_svc_details(pool: web::Data<DbPool>) -> actix_web::Result<impl 
     })
 }
 
-pub fn svc_details_all(conn: &mut PgConnection) -> Result<Option<Vec<SvcDetail>>, DbError> {
+pub fn svc_details_all(conn: &mut PgConnection) -> Result<Option<Vec<SvcDetail>>, Error> {
     use schema::svc_details::dsl::*;
     let svcs = svc_details.load::<SvcDetail>(conn).optional()?;
     Ok(svcs)
 }
 
 #[get("/svc/ip/{ip}")]
-pub async fn get_svc_by_ip<'a>(
+pub async fn get_svc_by_ip(
     pool: web::Data<DbPool>,
     ip: web::Path<String>,
-) -> actix_web::Result<impl Responder> {
-    info!("select svc details by ip");
+) -> Result<impl Responder, Error> {
     let ip = ip.into_inner();
+    if let Err(msg) = validate_ip(&ip) {
+        return Err(Error::UserInputError(msg));
+    }
+    info!("select svc details by ip");
     let svc_detail = web::block(move || {
         let mut conn = pool.get()?;
         svc_ip(&mut conn, &ip)
     })
-    .await?
-    .map_err(actix_web::error::ErrorInternalServerError)?;
+    .await??;
 
     Ok(match svc_detail {
         Some(p) => HttpResponse::Ok().json(p),
@@ -122,7 +159,7 @@ pub async fn get_svc_by_ip<'a>(
     })
 }
 
-pub fn svc_ip(conn: &mut PgConnection, ip: &str) -> Result<Option<SvcDetail>, DbError> {
+pub fn svc_ip(conn: &mut PgConnection, ip: &str) -> Result<Option<SvcDetail>, Error> {
     use schema::svc_details::dsl::*;
     let svc = svc_details
         .filter(svc_ip.eq(ip.to_string()))
@@ -133,18 +170,20 @@ pub fn svc_ip(conn: &mut PgConnection, ip: &str) -> Result<Option<SvcDetail>, Db
 
 // POD BY NAME
 #[get("/pod/name/{name}")]
-pub async fn get_pod_by_name<'a>(
+pub async fn get_pod_by_name(
     pool: web::Data<DbPool>,
     name: web::Path<String>,
-) -> actix_web::Result<impl Responder> {
-    info!("select pod details by name");
+) -> Result<impl Responder, Error> {
     let name = name.into_inner();
+    if let Err(msg) = validate_pod_name(&name) {
+        return Err(Error::UserInputError(msg));
+    }
+    info!("select pod details by name");
     let pod_detail = web::block(move || {
         let mut conn = pool.get()?;
         pod_name(&mut conn, &name)
     })
-    .await?
-    .map_err(actix_web::error::ErrorInternalServerError)?;
+    .await??;
 
     Ok(match pod_detail {
         Some(p) => HttpResponse::Ok().json(p),
@@ -152,7 +191,7 @@ pub async fn get_pod_by_name<'a>(
     })
 }
 
-pub fn pod_name(conn: &mut PgConnection, name: &str) -> Result<Option<PodDetail>, DbError> {
+pub fn pod_name(conn: &mut PgConnection, name: &str) -> Result<Option<PodDetail>, Error> {
     use schema::pod_details::dsl::*;
     let pod = pod_details
         .filter(pod_name.eq(name.to_string()))
@@ -163,18 +202,20 @@ pub fn pod_name(conn: &mut PgConnection, name: &str) -> Result<Option<PodDetail>
 
 // POD BY IP
 #[get("/pod/ip/{ip}")]
-pub async fn get_pod_by_ip<'a>(
+pub async fn get_pod_by_ip(
     pool: web::Data<DbPool>,
     ip: web::Path<String>,
-) -> actix_web::Result<impl Responder> {
-    info!("select pod details by ip");
+) -> Result<impl Responder, Error> {
     let ip = ip.into_inner();
+    if let Err(msg) = validate_ip(&ip) {
+        return Err(Error::UserInputError(msg));
+    }
+    info!("select pod details by ip");
     let pod_detail = web::block(move || {
         let mut conn = pool.get()?;
         pod_ip(&mut conn, &ip)
     })
-    .await?
-    .map_err(actix_web::error::ErrorInternalServerError)?;
+    .await??;
 
     Ok(match pod_detail {
         Some(p) => HttpResponse::Ok().json(p),
@@ -182,7 +223,7 @@ pub async fn get_pod_by_ip<'a>(
     })
 }
 
-pub fn pod_ip(conn: &mut PgConnection, ip: &str) -> Result<Option<PodDetail>, DbError> {
+pub fn pod_ip(conn: &mut PgConnection, ip: &str) -> Result<Option<PodDetail>, Error> {
     use schema::pod_details::dsl::*;
     let pod = pod_details
         .filter(pod_ip.eq(ip.to_string()))
@@ -193,18 +234,20 @@ pub fn pod_ip(conn: &mut PgConnection, ip: &str) -> Result<Option<PodDetail>, Db
 
 // POD TRAFFIC BY PODNAME
 #[get("/pod/traffic/{name}")]
-pub async fn get_pod_traffic_name<'a>(
+pub async fn get_pod_traffic_name(
     pool: web::Data<DbPool>,
     name: web::Path<String>,
-) -> actix_web::Result<impl Responder> {
-    info!("select pod traffic for the pod name");
+) -> Result<impl Responder, Error> {
     let pod_name = name.into_inner();
+    if let Err(msg) = validate_pod_name(&pod_name) {
+        return Err(Error::UserInputError(msg));
+    }
+    info!("select pod traffic for the pod name");
     let pod_detail = web::block(move || {
         let mut conn = pool.get()?;
         pod_traffic_by_name(&mut conn, &pod_name)
     })
-    .await?
-    .map_err(actix_web::error::ErrorInternalServerError)?;
+    .await??;
 
     Ok(match pod_detail {
         Some(p) => HttpResponse::Ok().json(p),
@@ -215,7 +258,7 @@ pub async fn get_pod_traffic_name<'a>(
 pub fn pod_traffic_by_name(
     conn: &mut PgConnection,
     name: &str,
-) -> Result<Option<Vec<PodTraffic>>, DbError> {
+) -> Result<Option<Vec<PodTraffic>>, Error> {
     use schema::pod_traffic::dsl::*;
     let pod_tr = pod_traffic
         .filter(pod_name.eq(name.to_string()))
@@ -226,18 +269,20 @@ pub fn pod_traffic_by_name(
 
 // POD SYS CALLS BY PODNAME
 #[get("/pod/syscalls/{name}")]
-pub async fn get_pod_syscall_name<'a>(
+pub async fn get_pod_syscall_name(
     pool: web::Data<DbPool>,
     name: web::Path<String>,
-) -> actix_web::Result<impl Responder> {
-    info!("select pod syscall for the pod name");
+) -> Result<impl Responder, Error> {
     let pod_name = name.into_inner();
+    if let Err(msg) = validate_pod_name(&pod_name) {
+        return Err(Error::UserInputError(msg));
+    }
+    info!("select pod syscall for the pod name");
     let pod_syscalls = web::block(move || {
         let mut conn = pool.get()?;
         pod_syscalls_by_name(&mut conn, &pod_name)
     })
-    .await?
-    .map_err(actix_web::error::ErrorInternalServerError)?;
+    .await??;
 
     Ok(match pod_syscalls {
         Some(p) => HttpResponse::Ok().json(p),
@@ -248,7 +293,7 @@ pub async fn get_pod_syscall_name<'a>(
 pub fn pod_syscalls_by_name(
     conn: &mut PgConnection,
     name: &str,
-) -> Result<Option<Vec<PodSyscalls>>, DbError> {
+) -> Result<Option<Vec<PodSyscalls>>, Error> {
     use schema::pod_syscalls::dsl::*;
     let pod_tr = pod_syscalls
         .filter(pod_name.eq(name.to_string()))

--- a/broker/src/main.rs
+++ b/broker/src/main.rs
@@ -1,4 +1,6 @@
 use std::error::Error;
+use std::env;
+use std::time::Duration;
 
 use actix_cors::Cors;
 use actix_web::{get, web, App, HttpResponse, HttpServer};
@@ -11,10 +13,11 @@ use api::{
 
 use diesel::r2d2;
 use telemetry::init_logging;
+mod auth;
 mod telemetry;
 
 use diesel_migrations::{embed_migrations, EmbeddedMigrations, MigrationHarness};
-use tracing::{info, warn};
+use tracing::{error, info, warn};
 pub const MIGRATIONS: EmbeddedMigrations = embed_migrations!("./db/migrations");
 
 type DB = diesel::pg::Pg;
@@ -29,10 +32,33 @@ fn run_migrations(
 #[actix_web::main]
 async fn main() -> Result<(), std::io::Error> {
     init_logging();
-    let manager = establish_connection();
-    let pool = r2d2::Pool::builder()
+
+    let manager = match establish_connection() {
+        Ok(m) => m,
+        Err(e) => {
+            error!("{}", e);
+            std::process::exit(1);
+        }
+    };
+
+    let max_size = env::var("DB_POOL_MAX_SIZE")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(32u32);
+
+    let pool = match r2d2::Pool::builder()
+        .max_size(max_size)
+        .min_idle(Some(4))
+        .max_lifetime(Some(Duration::from_secs(1800)))
         .build(manager)
-        .expect("Failed to create pool.");
+    {
+        Ok(p) => p,
+        Err(e) => {
+            error!("Failed to create connection pool: {}", e);
+            std::process::exit(1);
+        }
+    };
+
     // RUN the migration schema with retries
     let max_retries = 5;
     for attempt in 1..=max_retries {
@@ -44,7 +70,8 @@ async fn main() -> Result<(), std::io::Error> {
                 }
                 Err(e) => {
                     if attempt == max_retries {
-                        panic!("DB migration failed after {} attempts: {}", max_retries, e);
+                        error!("DB migration failed after {} attempts: {}", max_retries, e);
+                        std::process::exit(1);
                     }
                     warn!(
                         "DB migration attempt {}/{} failed: {}. Retrying in 2s...",
@@ -54,10 +81,11 @@ async fn main() -> Result<(), std::io::Error> {
             },
             Err(e) => {
                 if attempt == max_retries {
-                    panic!(
+                    error!(
                         "Failed to get DB connection after {} attempts: {}",
                         max_retries, e
                     );
+                    std::process::exit(1);
                 }
                 warn!(
                     "DB connection attempt {}/{} failed: {}. Retrying in 2s...",
@@ -67,15 +95,17 @@ async fn main() -> Result<(), std::io::Error> {
         }
         std::thread::sleep(std::time::Duration::from_secs(2));
     }
+
     HttpServer::new(move || {
-        let cors = Cors::default()
-            .allow_any_origin()
-            .allow_any_method()
-            .allow_any_header()
-            .max_age(3600);
+        let cors = build_cors();
 
         App::new()
+            .wrap(auth::ApiKeyAuth)
             .wrap(cors)
+            .app_data(
+                web::JsonConfig::default()
+                    .limit(1_048_576),
+            )
             .app_data(web::Data::new(pool.clone()))
             .service(add_pods)
             .service(add_pods_batch)
@@ -99,16 +129,46 @@ async fn main() -> Result<(), std::io::Error> {
     .await
 }
 
+/// Build a CORS configuration.
+///
+/// If `ALLOWED_ORIGINS` is set (comma-separated list), only those origins are allowed.
+/// Otherwise, all origins are permitted with a warning.
+fn build_cors() -> Cors {
+    match env::var("ALLOWED_ORIGINS") {
+        Ok(origins) if !origins.is_empty() => {
+            let mut cors = Cors::default()
+                .allow_any_method()
+                .allow_any_header()
+                .max_age(3600);
+            for origin in origins.split(',').map(str::trim).filter(|s| !s.is_empty()) {
+                cors = cors.allowed_origin(origin);
+            }
+            cors
+        }
+        _ => {
+            warn!("ALLOWED_ORIGINS env var is not set; CORS will allow any origin (set ALLOWED_ORIGINS to restrict)");
+            Cors::default()
+                .allow_any_origin()
+                .allow_any_method()
+                .allow_any_header()
+                .max_age(3600)
+        }
+    }
+}
+
 #[get("/health")]
 pub async fn health_check(
     pool: web::Data<r2d2::Pool<r2d2::ConnectionManager<diesel::PgConnection>>>,
 ) -> HttpResponse {
     match pool.get() {
-        Ok(_) => HttpResponse::Ok()
-            .content_type("application/json")
-            .body("Healthy!"),
-        Err(_) => HttpResponse::ServiceUnavailable()
-            .content_type("application/json")
-            .body("Database unavailable"),
+        Ok(_) => HttpResponse::Ok().json(serde_json::json!({
+            "status": "healthy",
+            "database": "connected",
+            "version": env!("CARGO_PKG_VERSION"),
+        })),
+        Err(_) => HttpResponse::ServiceUnavailable().json(serde_json::json!({
+            "status": "unhealthy",
+            "database": "disconnected",
+        })),
     }
 }

--- a/broker/src/types.rs
+++ b/broker/src/types.rs
@@ -17,6 +17,7 @@ use serde::{Deserialize, Serialize};
 )]
 #[diesel(table_name = pod_traffic)]
 #[diesel(primary_key(uuid))]
+#[serde(deny_unknown_fields)]
 pub struct PodTraffic {
     pub uuid: String,
     pub pod_name: Option<String>,
@@ -29,6 +30,22 @@ pub struct PodTraffic {
     pub traffic_in_out_port: Option<String>,
     pub decision: Option<String>,
     pub time_stamp: NaiveDateTime,
+}
+
+impl PodTraffic {
+    /// Returns an error string if the required fields (pod_name, pod_ip, traffic_type) are absent.
+    pub fn validate_required_fields(&self) -> Result<(), String> {
+        if self.pod_name.is_none() {
+            return Err("pod_name is required".to_string());
+        }
+        if self.pod_ip.is_none() {
+            return Err("pod_ip is required".to_string());
+        }
+        if self.traffic_type.is_none() {
+            return Err("traffic_type is required".to_string());
+        }
+        Ok(())
+    }
 }
 
 #[derive(

--- a/charts/kguardian/README.md
+++ b/charts/kguardian/README.md
@@ -85,12 +85,13 @@ The following table lists the configurable parameters of the kguardian chart and
 | broker.image.sha | string | `""` | Overrides the image tag using SHA digest |
 | broker.image.tag | string | `"1.7.1"` | Broker version tag (auto-updated by release-please) |
 | broker.imagePullSecrets | list | `[]` | List of image pull secrets for private registries |
-| broker.initContainer.image.pullPolicy | string | `"Always"` | Broker init container image pull policy |
+| broker.initContainer.image.pullPolicy | string | `"IfNotPresent"` | Broker init container image pull policy |
 | broker.initContainer.image.repository | string | `"busybox"` | Broker init container image repository |
 | broker.initContainer.image.sha | string | `""` | Overrides the init container image tag using SHA digest |
-| broker.initContainer.image.tag | string | `"latest"` | Broker init container image tag |
+| broker.initContainer.image.tag | string | `"1.37.0"` | Broker init container image tag |
 | broker.initContainer.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsNonRoot":true,"runAsUser":65534}` | Broker init container security context |
 | broker.nameOverride | string | `""` | Override the name of the broker resources |
+| broker.networkPolicy | object | `{"enabled":false}` | NetworkPolicy configuration for broker (requires a CNI that supports NetworkPolicy) |
 | broker.nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Node labels for the kguardian broker pod assignment |
 | broker.podAnnotations | object | `{}` | Annotations to add to broker pods |
 | broker.podSecurityContext | object | `{"fsGroup":1000,"fsGroupChangePolicy":"OnRootMismatch","runAsGroup":1000,"runAsUser":1000,"seccompProfile":{"type":"RuntimeDefault"},"supplementalGroups":[1000]}` | Broker pod security context. Runs as non-root user 1000 |
@@ -115,15 +116,16 @@ The following table lists the configurable parameters of the kguardian chart and
 | controller.containerdSockPath | string | `"/run/containerd/containerd.sock"` | Path to the containerd socket on the host node. For k3s clusters, set to: /run/k3s/containerd/containerd.sock |
 | controller.excludedNamespaces | list | `["kguardian","kube-system"]` | Namespaces to be excluded from monitoring (comma-separated list) |
 | controller.fullnameOverride | string | `""` | Override the full name of the controller resources |
+| controller.healthProbe | object | `{"enabled":true,"livenessProbe":{"httpGet":{"path":"/healthz","port":8081},"initialDelaySeconds":30,"periodSeconds":10},"port":8081,"readinessProbe":{"httpGet":{"path":"/readyz","port":8081},"initialDelaySeconds":10,"periodSeconds":5}}` | Health probe configuration for the controller |
 | controller.ignoreDaemonSet | bool | `true` | Ignore traffic from daemonset pods to reduce noise |
 | controller.image.pullPolicy | string | `"IfNotPresent"` | Controller image pull policy |
 | controller.image.repository | string | `"ghcr.io/kguardian-dev/kguardian/controller"` | Controller container image repository |
 | controller.image.sha | string | `""` | Overrides the image tag using SHA digest |
 | controller.image.tag | string | `"1.8.1"` | Controller version tag (auto-updated by release-please) |
 | controller.imagePullSecrets | list | `[]` | List of image pull secrets for private registries |
-| controller.initContainer.image.pullPolicy | string | `"Always"` | Init container image pull policy |
+| controller.initContainer.image.pullPolicy | string | `"IfNotPresent"` | Init container image pull policy |
 | controller.initContainer.image.repository | string | `"busybox"` | Init container image repository |
-| controller.initContainer.image.tag | string | `"latest"` | Init container image tag |
+| controller.initContainer.image.tag | string | `"1.37.0"` | Init container image tag |
 | controller.initContainer.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsNonRoot":true,"runAsUser":65534}` | Init container security context |
 | controller.nameOverride | string | `""` | Override the name of the controller resources |
 | controller.nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Node labels for the kguardian controller pod assignment |
@@ -145,17 +147,20 @@ The following table lists the configurable parameters of the kguardian chart and
 | database.autoscaling.minReplicas | int | `1` | Minimum number of database replicas |
 | database.autoscaling.targetCPUUtilizationPercentage | int | `80` | Target CPU utilization percentage for autoscaling |
 | database.container.port | int | `5432` | PostgreSQL container port |
+| database.existingSecret | string | `""` |  |
 | database.fullnameOverride | string | `""` | Override the full name of the database resources |
-| database.image.pullPolicy | string | `"Always"` | PostgreSQL image pull policy |
+| database.image.pullPolicy | string | `"IfNotPresent"` | PostgreSQL image pull policy |
 | database.image.repository | string | `"postgres"` | PostgreSQL container image repository |
 | database.image.sha | string | `""` | Overrides the image tag using SHA digest |
-| database.image.tag | string | `"latest"` | PostgreSQL image tag |
+| database.image.tag | string | `"17.2"` | PostgreSQL image tag |
 | database.imagePullSecrets | list | `[]` | List of image pull secrets for private registries |
 | database.name | string | `"kguardian-db"` | Database name for PostgreSQL |
 | database.nameOverride | string | `""` | Override the name of the database resources |
 | database.nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Node labels for the kguardian database pod assignment |
 | database.persistence.enabled | bool | `false` | Enable persistent storage for database |
 | database.persistence.existingClaim | string | `""` | Use an existing PersistentVolumeClaim instead of creating a new one |
+| database.persistence.size | string | `"10Gi"` |  |
+| database.persistence.storageClass | string | `""` |  |
 | database.podAnnotations | object | `{}` | Annotations to add to database pods |
 | database.podSecurityContext | object | `{"fsGroup":999,"fsGroupChangePolicy":"OnRootMismatch","runAsGroup":999,"runAsUser":999,"seccompProfile":{"type":"RuntimeDefault"},"supplementalGroups":[999]}` | Database pod security context. Runs as postgres user (999) |
 | database.priorityClassName | string | `""` | Priority class to be used for the kguardian database pods |
@@ -193,7 +198,7 @@ The following table lists the configurable parameters of the kguardian chart and
 | frontend.priorityClassName | string | `""` | Priority class to be used for the kguardian frontend pods |
 | frontend.replicaCount | int | `1` | Number of frontend replicas to deploy |
 | frontend.resources | object | `{"limits":{"memory":"256Mi"},"requests":{"cpu":"50m","memory":"128Mi"}}` | Frontend pod resource requests and limits |
-| frontend.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"privileged":false,"readOnlyRootFilesystem":false,"runAsNonRoot":true,"runAsUser":1337}` | Frontend container security context. Hardened with read-only root filesystem |
+| frontend.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"privileged":false,"readOnlyRootFilesystem":true,"runAsNonRoot":true,"runAsUser":1337}` | Frontend container security context. Hardened with read-only root filesystem |
 | frontend.service.name | string | `"kguardian-frontend"` | Frontend service name |
 | frontend.service.port | int | `5173` | Frontend service port |
 | frontend.service.type | string | `"ClusterIP"` | Frontend service type |

--- a/charts/kguardian/templates/broker/networkpolicy.yaml
+++ b/charts/kguardian/templates/broker/networkpolicy.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.broker.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "kguardian.fullname" . }}-broker
+  labels:
+    {{- include "kguardian.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      app: kguardian-broker
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app: kguardian-controller
+        - podSelector:
+            matchLabels:
+              app: kguardian-frontend
+        {{- if .Values.mcpServer.enabled }}
+        - podSelector:
+            matchLabels:
+              app: kguardian-mcp-server
+        {{- end }}
+        {{- if .Values.llmBridge.enabled }}
+        - podSelector:
+            matchLabels:
+              app: kguardian-llm-bridge
+        {{- end }}
+      ports:
+        - port: 9090
+          protocol: TCP
+{{- end }}

--- a/charts/kguardian/templates/clusterrole.yaml
+++ b/charts/kguardian/templates/clusterrole.yaml
@@ -6,18 +6,30 @@ metadata:
     {{- include "kguardian.labels" . | nindent 4 }}
     {{- include "kguardian.annotations" . | nindent 2 }}
 rules:
+# Core API group resources watched by the controller
 - apiGroups: [""]
-  resources: ["namespaces", "pods", "services"]
+  resources:
+    # namespaces: read to filter pods by excluded namespace list (pod_watcher.rs)
+    - namespaces
+    # pods: watched cluster-wide to track container lifecycle and inode mappings (pod_watcher.rs, pod_reconciler.rs)
+    - pods
+    # services: watched cluster-wide to correlate service IPs with network traffic (service_watcher.rs)
+    - services
   verbs:
     - get
     - watch
     - list
+# apps/v1 workload resources fetched to resolve pod owner references and extract selector labels
 - apiGroups: ["apps"]
   resources:
-  - deployments
-  - replicasets
-  - statefulsets
-  - daemonsets
+    # deployments: fetched by name to read .spec.selector.matchLabels for pod identity resolution (pod_watcher.rs)
+    - deployments
+    # replicasets: fetched by name to trace back to the parent Deployment (pod_watcher.rs)
+    - replicasets
+    # statefulsets: fetched by name to read .spec.selector.matchLabels for pod identity resolution (pod_watcher.rs)
+    - statefulsets
+    # daemonsets: fetched by name to read .spec.selector.matchLabels for pod identity resolution (pod_watcher.rs)
+    - daemonsets
   verbs:
   - get
   - list

--- a/charts/kguardian/templates/controller/daemonset.yaml
+++ b/charts/kguardian/templates/controller/daemonset.yaml
@@ -76,6 +76,12 @@ spec:
           - mountPath: /proc
             name: hostproc
             readOnly: true
+          {{- if .Values.controller.healthProbe.enabled }}
+          livenessProbe:
+            {{- toYaml .Values.controller.healthProbe.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.controller.healthProbe.readinessProbe | nindent 12 }}
+          {{- end }}
           {{- with .Values.controller.resources }}
           resources:
             {{- toYaml . | nindent 12 }}

--- a/charts/kguardian/templates/database/deployment.yaml
+++ b/charts/kguardian/templates/database/deployment.yaml
@@ -33,6 +33,11 @@ spec:
             - containerPort: 5432
           securityContext:
             {{- toYaml .Values.database.securityContext | nindent 12 }}
+          {{- if .Values.database.existingSecret }}
+          envFrom:
+            - secretRef:
+                name: {{ .Values.database.existingSecret }}
+          {{- else }}
           env:
             - name: POSTGRES_USER
               value: rust
@@ -43,6 +48,7 @@ spec:
                   key: password
             - name: POSTGRES_DB
               value: kube
+          {{- end }}
           livenessProbe:
             exec:
               command:

--- a/charts/kguardian/templates/frontend/deployment.yaml
+++ b/charts/kguardian/templates/frontend/deployment.yaml
@@ -70,8 +70,12 @@ spec:
           volumeMounts:
             - name: tmp
               mountPath: /tmp
+            - name: vite-temp
+              mountPath: /app/node_modules/.vite-temp
       volumes:
         - name: tmp
+          emptyDir: {}
+        - name: vite-temp
           emptyDir: {}
       {{- with .Values.frontend.nodeSelector }}
       nodeSelector:

--- a/charts/kguardian/templates/frontend/deployment.yaml
+++ b/charts/kguardian/templates/frontend/deployment.yaml
@@ -67,6 +67,12 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}
       {{- with .Values.frontend.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/kguardian/values.yaml
+++ b/charts/kguardian/values.yaml
@@ -33,9 +33,9 @@ controller:
       # -- Init container image repository
       repository: busybox
       # -- Init container image pull policy
-      pullPolicy: Always
+      pullPolicy: IfNotPresent
       # -- Init container image tag
-      tag: latest
+      tag: "1.37.0"
     # -- Init container security context
     securityContext:
       runAsNonRoot: true
@@ -78,6 +78,9 @@ controller:
 
   # -- Controller container security context. Requires privileged mode for eBPF
   securityContext:
+    # Required for eBPF: loading BPF programs and accessing kernel maps
+    # requires CAP_BPF + CAP_PERFMON at minimum, or privileged mode.
+    # See: https://docs.kernel.org/bpf/bpf_design_QA.html
     privileged: true
     readOnlyRootFilesystem: true
     capabilities:
@@ -143,6 +146,23 @@ controller:
   # -- Ignore traffic from daemonset pods to reduce noise
   ignoreDaemonSet: true
 
+  # -- Health probe configuration for the controller
+  healthProbe:
+    enabled: true
+    port: 8081
+    livenessProbe:
+      httpGet:
+        path: /healthz
+        port: 8081
+      initialDelaySeconds: 30
+      periodSeconds: 10
+    readinessProbe:
+      httpGet:
+        path: /readyz
+        port: 8081
+      initialDelaySeconds: 10
+      periodSeconds: 5
+
 broker:
   # -- Number of broker replicas to deploy
   replicaCount: 1
@@ -160,9 +180,9 @@ broker:
       # -- Broker init container image repository
       repository: busybox
       # -- Broker init container image pull policy
-      pullPolicy: Always
+      pullPolicy: IfNotPresent
       # -- Broker init container image tag
-      tag: latest
+      tag: "1.37.0"
       # -- Overrides the init container image tag using SHA digest
       sha: ""
     # -- Broker init container security context
@@ -261,24 +281,35 @@ broker:
   # -- Priority class to be used for the kguardian broker pods
   priorityClassName: ""
 
+  # -- NetworkPolicy configuration for broker (requires a CNI that supports NetworkPolicy)
+  networkPolicy:
+    enabled: false  # Enable on clusters with CNI NetworkPolicy support
+
 database:
   # -- Database name for PostgreSQL
   name: kguardian-db
+  # Use an existing Kubernetes Secret for database credentials instead of generating one.
+  # The secret must contain keys: POSTGRES_USER, POSTGRES_PASSWORD, POSTGRES_DB
+  existingSecret: ""
   image:
     # -- PostgreSQL container image repository
     repository: postgres
     # -- PostgreSQL image pull policy
-    pullPolicy: Always
+    pullPolicy: IfNotPresent
     # -- PostgreSQL image tag
-    tag: "latest"
+    tag: "17.2"
     # -- Overrides the image tag using SHA digest
     sha: ""
 
   persistence:
+    # WARNING: With persistence disabled, ALL telemetry data is lost on pod restart.
+    # For production deployments, set enabled: true and configure storageClass.
     # -- Enable persistent storage for database
     enabled: false
     # -- Use an existing PersistentVolumeClaim instead of creating a new one
     existingClaim: ""
+    storageClass: ""
+    size: 10Gi
 
   container:
     # -- PostgreSQL container port
@@ -419,7 +450,7 @@ frontend:
     capabilities:
       drop:
       - ALL
-    readOnlyRootFilesystem: false
+    readOnlyRootFilesystem: true
     runAsNonRoot: true
     runAsUser: 1337
     allowPrivilegeEscalation: false

--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -11,6 +11,7 @@ RUN mkdir -p linux/amd64 linux/arm64
 COPY linux/amd64/kguardian linux/amd64/
 COPY linux/arm64/kguardian linux/arm64/
 
+# Pin to a specific digest in production: debian:${DEBIAN_VERSION}-slim@sha256:<digest>
 FROM debian:${DEBIAN_VERSION}-slim
 
 ARG TARGETPLATFORM

--- a/controller/src/bpf.rs
+++ b/controller/src/bpf.rs
@@ -247,7 +247,7 @@ pub fn ebpf_handle(
 
         loop {
             // Poll all ring buffers with a single call (much more efficient!)
-            if let Err(e) = ring_buffer.poll(std::time::Duration::from_millis(100)) {
+            if let Err(e) = ring_buffer.poll(std::time::Duration::from_millis(20)) {
                 eprintln!("Error polling ring buffer: {}", e);
                 continue;
             }

--- a/controller/src/client.rs
+++ b/controller/src/client.rs
@@ -1,17 +1,20 @@
 use crate::Error;
 use serde_json::Value;
 use std::env;
+use std::sync::LazyLock;
 use tracing::debug;
 
-use lazy_static::lazy_static;
-
-lazy_static! {
-    static ref CLIENT: reqwest::Client = reqwest::Client::builder()
+// reqwest::Client::builder().timeout(...).connect_timeout(...).build() can only fail
+// if the TLS backend fails to initialise. We use the default TLS backend (native-tls /
+// rustls) which is compiled-in and has no runtime prerequisites, so this cannot fail in
+// practice. The `expect` message is kept to surface the unlikely OS-level failure clearly.
+static CLIENT: LazyLock<reqwest::Client> = LazyLock::new(|| {
+    reqwest::Client::builder()
         .timeout(std::time::Duration::from_secs(30))
         .connect_timeout(std::time::Duration::from_secs(10))
         .build()
-        .expect("Failed to create HTTP client");
-}
+        .expect("Failed to create HTTP client: TLS backend initialisation failed")
+});
 
 pub(crate) async fn api_post_call(v: Value, path: &str) -> Result<(), Error> {
     let api_endpoint = env::var("API_ENDPOINT")

--- a/controller/src/container.rs
+++ b/controller/src/container.rs
@@ -49,7 +49,10 @@ impl PodInspect {
         let mut client = TasksClient::new(channel.clone());
 
         let req = GetRequest {
-            container_id: self.container_id.to_owned().unwrap(),
+            // container_id is always Some here: get_pid is only called after set_container_id.
+            // unwrap_or_default produces an empty string on the (impossible) None path, which
+            // the containerd gRPC call will reject gracefully via the Err arm below.
+            container_id: self.container_id.to_owned().unwrap_or_default(),
             ..Default::default()
         };
 

--- a/controller/src/log.rs
+++ b/controller/src/log.rs
@@ -5,7 +5,7 @@ pub fn init_logger() {
     if env::var("RUST_LOG").is_err() {
         env::set_var("RUST_LOG", "info")
     }
-    if std::env::var("RUST_LOG").unwrap().to_lowercase().eq("info") {
+    if std::env::var("RUST_LOG").unwrap_or_default().to_lowercase().eq("info") {
         std::env::set_var("RUST_LOG", "info,kube_client=off");
     } else {
         std::env::set_var(

--- a/controller/src/main.rs
+++ b/controller/src/main.rs
@@ -19,7 +19,7 @@ use kguardian::{
 
 #[tokio::main]
 async fn main() -> Result<(), Error> {
-    
+
     rustls::crypto::ring::default_provider()
         .install_default()
         .expect("Failed to install rustls crypto provider");
@@ -43,9 +43,14 @@ async fn main() -> Result<(), Error> {
         .parse::<bool>()
         .unwrap_or(true);
 
-    let (tx, rx) = mpsc::channel(1000); // Use tokio's mpsc channel
+    let channel_size: usize = env::var("CHANNEL_BUFFER_SIZE")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(1000);
 
-    let (sender_ip, recv_ip) = mpsc::channel(1000); // Use tokio's mpsc channel
+    let (tx, rx) = mpsc::channel(channel_size); // Use tokio's mpsc channel
+
+    let (sender_ip, recv_ip) = mpsc::channel(channel_size); // Use tokio's mpsc channel
 
     // Use DashMap for lock-free concurrent access (much faster than Mutex<BTreeMap>)
     let container_map: Arc<DashMap<u64, PodInspect>> = Arc::new(DashMap::new());
@@ -68,9 +73,9 @@ async fn main() -> Result<(), Error> {
     // Start pod reconciliation task
     let pod_reconciler = reconcile_pods_task(node_name, broker_url);
 
-    let (network_event_sender, network_event_receiver) = mpsc::channel::<NetworkEventData>(1000);
-    let (syscall_event_sender, syscall_event_receiver) = mpsc::channel::<SyscallEventData>(1000);
-    let (netpolicy_drop_sender, netpolicy_drop_receiver) = mpsc::channel::<PolicyDropEvent>(1000);
+    let (network_event_sender, network_event_receiver) = mpsc::channel::<NetworkEventData>(channel_size);
+    let (syscall_event_sender, syscall_event_receiver) = mpsc::channel::<SyscallEventData>(channel_size);
+    let (netpolicy_drop_sender, netpolicy_drop_receiver) = mpsc::channel::<PolicyDropEvent>(channel_size);
 
     let network_event_handler = handle_network_events(network_event_receiver, network_map);
     let netpolicy_drop_handler =

--- a/controller/src/network.rs
+++ b/controller/src/network.rs
@@ -3,8 +3,10 @@ use chrono::Utc;
 use dashmap::DashMap;
 use moka::future::Cache;
 use serde_json::json;
+use std::env;
 use std::net::{IpAddr, Ipv4Addr};
 use std::sync::Arc;
+use std::time::Duration;
 use tracing::{debug, error};
 use uuid::Uuid;
 
@@ -14,7 +16,17 @@ const KIND_INGRESS_TCP: u16 = 2;
 const KIND_EGRESS_UDP: u16 = 3;
 
 lazy_static::lazy_static! {
-    static ref TRAFFIC_CACHE: Arc<Cache<TrafficKey, ()>> = Arc::new(Cache::new(10000));
+    static ref TRAFFIC_CACHE: Arc<Cache<TrafficKey, ()>> = Arc::new(
+        Cache::builder()
+            .max_capacity(
+                env::var("TRAFFIC_CACHE_SIZE")
+                    .ok()
+                    .and_then(|v| v.parse().ok())
+                    .unwrap_or(10_000),
+            )
+            .time_to_live(Duration::from_secs(300))
+            .build(),
+    );
 }
 
 pub mod network_probe {

--- a/controller/src/service_watcher.rs
+++ b/controller/src/service_watcher.rs
@@ -64,7 +64,7 @@ async fn update_serviceinfo(svc: Service) -> Result<(), Error> {
 }
 
 fn svc_unready(p: &Service) -> Option<String> {
-    let status = p.status.as_ref().unwrap();
+    let status = p.status.as_ref()?;
     info!("Service Status {:?}", status);
     if let Some(conds) = &status.conditions {
         let failed = conds

--- a/controller/src/syscall.rs
+++ b/controller/src/syscall.rs
@@ -1,11 +1,9 @@
 use chrono::Utc;
-use dashmap::DashMap;
+use dashmap::{DashMap, DashSet};
 use libseccomp::{ScmpArch, ScmpSyscall};
 use moka::future::Cache;
 use serde_json::json;
-use std::collections::HashSet;
 use std::sync::Arc;
-use tokio::sync::Mutex;
 use tracing::{debug, error};
 
 use crate::{api_post_call, Error, PodInspect, SyscallData};
@@ -17,7 +15,8 @@ pub mod sycallprobe {
     ));
 }
 
-type SyscallCache = Cache<String, Arc<Mutex<HashSet<String>>>>;
+// Each pod maps to a lock-free set of observed syscall names.
+type SyscallCache = Cache<String, Arc<DashSet<String>>>;
 
 lazy_static::lazy_static! {
     static ref SYSCALL_CACHE: SyscallCache = Cache::new(10_000);
@@ -51,24 +50,24 @@ pub async fn process_syscall_event(
 ) -> Result<(), Error> {
     let pod_name = pod_data.status.pod_name.to_string();
     let syscall_number = data.sysnbr;
-    let syscall_name = get_syscall_name(syscall_number.try_into().unwrap())
-        .unwrap_or_else(|| format!("{}", syscall_number));
+    // u32 -> i32: values above i32::MAX are not valid Linux syscall numbers;
+    // fall back to the raw number string on conversion failure.
+    let syscall_name =
+        i32::try_from(syscall_number)
+            .ok()
+            .and_then(get_syscall_name)
+            .unwrap_or_else(|| format!("{}", syscall_number));
 
     let syscalls = SYSCALL_CACHE
-        .get_with(pod_name.clone(), async {
-            Arc::new(Mutex::new(HashSet::new()))
-        })
+        .get_with(pod_name.clone(), async { Arc::new(DashSet::new()) })
         .await;
 
-    let mut syscalls_lock = syscalls.lock().await;
-
-    if syscalls_lock.contains(&syscall_name) {
+    // DashSet::insert returns false when the value was already present.
+    if !syscalls.insert(syscall_name.clone()) {
         debug!(
             "Skipping duplicate syscall: {} for pod: {}",
             syscall_name, pod_name
         );
-    } else {
-        syscalls_lock.insert(syscall_name.clone());
     }
 
     Ok(())
@@ -81,26 +80,34 @@ pub async fn send_syscall_cache_periodically() -> Result<(), Error> {
         let mut batch = Vec::new();
 
         for (pod_name, syscalls) in SYSCALL_CACHE.iter() {
-            let syscalls_lock = syscalls.lock().await;
             let last_sent = LAST_SENT_CACHE
-                .get_with(pod_name.to_string(), async {
-                    Arc::new(Mutex::new(HashSet::new()))
-                })
+                .get_with(pod_name.to_string(), async { Arc::new(DashSet::new()) })
                 .await;
-            let mut last_sent_lock = last_sent.lock().await;
 
-            if *syscalls_lock != *last_sent_lock {
-                let syscall_names: Vec<String> = syscalls_lock.iter().cloned().collect();
+            // Collect current and last-sent syscall names for comparison.
+            // DashSet iteration is unordered, so sort both for a stable diff check.
+            let mut current: Vec<String> = syscalls.iter().map(|s| s.clone()).collect();
+            current.sort_unstable();
+
+            let mut previously_sent: Vec<String> = last_sent.iter().map(|s| s.clone()).collect();
+            previously_sent.sort_unstable();
+
+            if current != previously_sent {
                 let z = json!(SyscallData {
                     pod_name: pod_name.to_string(),
                     pod_namespace: "".to_string(), // We will not store the namespace and rather read it from the pod_details table
-                    syscalls: syscall_names,
+                    syscalls: current.clone(),
                     arch: std::env::consts::ARCH.to_string(),
                     time_stamp: Utc::now().naive_utc()
                 });
                 batch.push(z);
                 debug!("Sending batch of {} syscalls to API", batch.len());
-                *last_sent_lock = syscalls_lock.clone();
+
+                // Update the last-sent snapshot: clear and repopulate.
+                last_sent.clear();
+                for name in current {
+                    last_sent.insert(name);
+                }
             }
         }
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,13 +10,13 @@
       "license": "BUSL-1.1",
       "dependencies": {
         "@tailwindcss/typography": "^0.5.19",
+        "@xyflow/react": "^12.10.2",
         "axios": "^1.12.2",
         "elkjs": "^0.11.0",
         "lucide-react": "^0.577.0",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
         "react-markdown": "^10.1.0",
-        "reactflow": "^11.11.4",
         "remark-gfm": "^4.0.1"
       },
       "devDependencies": {
@@ -1034,108 +1034,6 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
-    "node_modules/@reactflow/background": {
-      "version": "11.3.14",
-      "resolved": "https://registry.npmjs.org/@reactflow/background/-/background-11.3.14.tgz",
-      "integrity": "sha512-Gewd7blEVT5Lh6jqrvOgd4G6Qk17eGKQfsDXgyRSqM+CTwDqRldG2LsWN4sNeno6sbqVIC2fZ+rAUBFA9ZEUDA==",
-      "license": "MIT",
-      "dependencies": {
-        "@reactflow/core": "11.11.4",
-        "classcat": "^5.0.3",
-        "zustand": "^4.4.1"
-      },
-      "peerDependencies": {
-        "react": ">=17",
-        "react-dom": ">=17"
-      }
-    },
-    "node_modules/@reactflow/controls": {
-      "version": "11.2.14",
-      "resolved": "https://registry.npmjs.org/@reactflow/controls/-/controls-11.2.14.tgz",
-      "integrity": "sha512-MiJp5VldFD7FrqaBNIrQ85dxChrG6ivuZ+dcFhPQUwOK3HfYgX2RHdBua+gx+40p5Vw5It3dVNp/my4Z3jF0dw==",
-      "license": "MIT",
-      "dependencies": {
-        "@reactflow/core": "11.11.4",
-        "classcat": "^5.0.3",
-        "zustand": "^4.4.1"
-      },
-      "peerDependencies": {
-        "react": ">=17",
-        "react-dom": ">=17"
-      }
-    },
-    "node_modules/@reactflow/core": {
-      "version": "11.11.4",
-      "resolved": "https://registry.npmjs.org/@reactflow/core/-/core-11.11.4.tgz",
-      "integrity": "sha512-H4vODklsjAq3AMq6Np4LE12i1I4Ta9PrDHuBR9GmL8uzTt2l2jh4CiQbEMpvMDcp7xi4be0hgXj+Ysodde/i7Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/d3": "^7.4.0",
-        "@types/d3-drag": "^3.0.1",
-        "@types/d3-selection": "^3.0.3",
-        "@types/d3-zoom": "^3.0.1",
-        "classcat": "^5.0.3",
-        "d3-drag": "^3.0.0",
-        "d3-selection": "^3.0.0",
-        "d3-zoom": "^3.0.0",
-        "zustand": "^4.4.1"
-      },
-      "peerDependencies": {
-        "react": ">=17",
-        "react-dom": ">=17"
-      }
-    },
-    "node_modules/@reactflow/minimap": {
-      "version": "11.7.14",
-      "resolved": "https://registry.npmjs.org/@reactflow/minimap/-/minimap-11.7.14.tgz",
-      "integrity": "sha512-mpwLKKrEAofgFJdkhwR5UQ1JYWlcAAL/ZU/bctBkuNTT1yqV+y0buoNVImsRehVYhJwffSWeSHaBR5/GJjlCSQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@reactflow/core": "11.11.4",
-        "@types/d3-selection": "^3.0.3",
-        "@types/d3-zoom": "^3.0.1",
-        "classcat": "^5.0.3",
-        "d3-selection": "^3.0.0",
-        "d3-zoom": "^3.0.0",
-        "zustand": "^4.4.1"
-      },
-      "peerDependencies": {
-        "react": ">=17",
-        "react-dom": ">=17"
-      }
-    },
-    "node_modules/@reactflow/node-resizer": {
-      "version": "2.2.14",
-      "resolved": "https://registry.npmjs.org/@reactflow/node-resizer/-/node-resizer-2.2.14.tgz",
-      "integrity": "sha512-fwqnks83jUlYr6OHcdFEedumWKChTHRGw/kbCxj0oqBd+ekfs+SIp4ddyNU0pdx96JIm5iNFS0oNrmEiJbbSaA==",
-      "license": "MIT",
-      "dependencies": {
-        "@reactflow/core": "11.11.4",
-        "classcat": "^5.0.4",
-        "d3-drag": "^3.0.0",
-        "d3-selection": "^3.0.0",
-        "zustand": "^4.4.1"
-      },
-      "peerDependencies": {
-        "react": ">=17",
-        "react-dom": ">=17"
-      }
-    },
-    "node_modules/@reactflow/node-toolbar": {
-      "version": "1.3.14",
-      "resolved": "https://registry.npmjs.org/@reactflow/node-toolbar/-/node-toolbar-1.3.14.tgz",
-      "integrity": "sha512-rbynXQnH/xFNu4P9H+hVqlEUafDCkEoCy0Dg9mG22Sg+rY/0ck6KkrAQrYrTgXusd+cEJOMK0uOOFCK2/5rSGQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@reactflow/core": "11.11.4",
-        "classcat": "^5.0.3",
-        "zustand": "^4.4.1"
-      },
-      "peerDependencies": {
-        "react": ">=17",
-        "react-dom": ">=17"
-      }
-    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-rc.3",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.3.tgz",
@@ -1144,9 +1042,9 @@
       "license": "MIT"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.52.5",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.52.5.tgz",
-      "integrity": "sha512-8c1vW4ocv3UOMp9K+gToY5zL2XiiVw3k7f1ksf4yO1FlDFQ1C2u72iACFnSOceJFsWskc2WZNqeRhFRPzv+wtQ==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.1.tgz",
+      "integrity": "sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA==",
       "cpu": [
         "arm"
       ],
@@ -1158,9 +1056,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.52.5",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.52.5.tgz",
-      "integrity": "sha512-mQGfsIEFcu21mvqkEKKu2dYmtuSZOBMmAl5CFlPGLY94Vlcm+zWApK7F/eocsNzp8tKmbeBP8yXyAbx0XHsFNA==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.1.tgz",
+      "integrity": "sha512-YjG/EwIDvvYI1YvYbHvDz/BYHtkY4ygUIXHnTdLhG+hKIQFBiosfWiACWortsKPKU/+dUwQQCKQM3qrDe8c9BA==",
       "cpu": [
         "arm64"
       ],
@@ -1172,9 +1070,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.52.5",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.52.5.tgz",
-      "integrity": "sha512-takF3CR71mCAGA+v794QUZ0b6ZSrgJkArC+gUiG6LB6TQty9T0Mqh3m2ImRBOxS2IeYBo4lKWIieSvnEk2OQWA==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.1.tgz",
+      "integrity": "sha512-mjCpF7GmkRtSJwon+Rq1N8+pI+8l7w5g9Z3vWj4T7abguC4Czwi3Yu/pFaLvA3TTeMVjnu3ctigusqWUfjZzvw==",
       "cpu": [
         "arm64"
       ],
@@ -1186,9 +1084,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.52.5",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.52.5.tgz",
-      "integrity": "sha512-W901Pla8Ya95WpxDn//VF9K9u2JbocwV/v75TE0YIHNTbhqUTv9w4VuQ9MaWlNOkkEfFwkdNhXgcLqPSmHy0fA==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.1.tgz",
+      "integrity": "sha512-haZ7hJ1JT4e9hqkoT9R/19XW2QKqjfJVv+i5AGg57S+nLk9lQnJ1F/eZloRO3o9Scy9CM3wQ9l+dkXtcBgN5Ew==",
       "cpu": [
         "x64"
       ],
@@ -1200,9 +1098,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.52.5",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.52.5.tgz",
-      "integrity": "sha512-QofO7i7JycsYOWxe0GFqhLmF6l1TqBswJMvICnRUjqCx8b47MTo46W8AoeQwiokAx3zVryVnxtBMcGcnX12LvA==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.1.tgz",
+      "integrity": "sha512-czw90wpQq3ZsAVBlinZjAYTKduOjTywlG7fEeWKUA7oCmpA8xdTkxZZlwNJKWqILlq0wehoZcJYfBvOyhPTQ6w==",
       "cpu": [
         "arm64"
       ],
@@ -1214,9 +1112,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.52.5",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.52.5.tgz",
-      "integrity": "sha512-jr21b/99ew8ujZubPo9skbrItHEIE50WdV86cdSoRkKtmWa+DDr6fu2c/xyRT0F/WazZpam6kk7IHBerSL7LDQ==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.1.tgz",
+      "integrity": "sha512-KVB2rqsxTHuBtfOeySEyzEOB7ltlB/ux38iu2rBQzkjbwRVlkhAGIEDiiYnO2kFOkJp+Z7pUXKyrRRFuFUKt+g==",
       "cpu": [
         "x64"
       ],
@@ -1228,9 +1126,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.52.5",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.52.5.tgz",
-      "integrity": "sha512-PsNAbcyv9CcecAUagQefwX8fQn9LQ4nZkpDboBOttmyffnInRy8R8dSg6hxxl2Re5QhHBf6FYIDhIj5v982ATQ==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.1.tgz",
+      "integrity": "sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==",
       "cpu": [
         "arm"
       ],
@@ -1242,9 +1140,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.52.5",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.52.5.tgz",
-      "integrity": "sha512-Fw4tysRutyQc/wwkmcyoqFtJhh0u31K+Q6jYjeicsGJJ7bbEq8LwPWV/w0cnzOqR2m694/Af6hpFayLJZkG2VQ==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.1.tgz",
+      "integrity": "sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==",
       "cpu": [
         "arm"
       ],
@@ -1256,9 +1154,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.52.5",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.52.5.tgz",
-      "integrity": "sha512-a+3wVnAYdQClOTlyapKmyI6BLPAFYs0JM8HRpgYZQO02rMR09ZcV9LbQB+NL6sljzG38869YqThrRnfPMCDtZg==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.1.tgz",
+      "integrity": "sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==",
       "cpu": [
         "arm64"
       ],
@@ -1270,9 +1168,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.52.5",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.52.5.tgz",
-      "integrity": "sha512-AvttBOMwO9Pcuuf7m9PkC1PUIKsfaAJ4AYhy944qeTJgQOqJYJ9oVl2nYgY7Rk0mkbsuOpCAYSs6wLYB2Xiw0Q==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.1.tgz",
+      "integrity": "sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==",
       "cpu": [
         "arm64"
       ],
@@ -1284,9 +1182,23 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.52.5",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.52.5.tgz",
-      "integrity": "sha512-DkDk8pmXQV2wVrF6oq5tONK6UHLz/XcEVow4JTTerdeV1uqPeHxwcg7aFsfnSm9L+OO8WJsWotKM2JJPMWrQtA==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.1.tgz",
+      "integrity": "sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.1.tgz",
+      "integrity": "sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==",
       "cpu": [
         "loong64"
       ],
@@ -1298,9 +1210,23 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.52.5",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.52.5.tgz",
-      "integrity": "sha512-W/b9ZN/U9+hPQVvlGwjzi+Wy4xdoH2I8EjaCkMvzpI7wJUs8sWJ03Rq96jRnHkSrcHTpQe8h5Tg3ZzUPGauvAw==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.1.tgz",
+      "integrity": "sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.1.tgz",
+      "integrity": "sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==",
       "cpu": [
         "ppc64"
       ],
@@ -1312,9 +1238,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.52.5",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.52.5.tgz",
-      "integrity": "sha512-sjQLr9BW7R/ZiXnQiWPkErNfLMkkWIoCz7YMn27HldKsADEKa5WYdobaa1hmN6slu9oWQbB6/jFpJ+P2IkVrmw==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.1.tgz",
+      "integrity": "sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==",
       "cpu": [
         "riscv64"
       ],
@@ -1326,9 +1252,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.52.5",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.52.5.tgz",
-      "integrity": "sha512-hq3jU/kGyjXWTvAh2awn8oHroCbrPm8JqM7RUpKjalIRWWXE01CQOf/tUNWNHjmbMHg/hmNCwc/Pz3k1T/j/Lg==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.1.tgz",
+      "integrity": "sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==",
       "cpu": [
         "riscv64"
       ],
@@ -1340,9 +1266,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.52.5",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.52.5.tgz",
-      "integrity": "sha512-gn8kHOrku8D4NGHMK1Y7NA7INQTRdVOntt1OCYypZPRt6skGbddska44K8iocdpxHTMMNui5oH4elPH4QOLrFQ==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.1.tgz",
+      "integrity": "sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==",
       "cpu": [
         "s390x"
       ],
@@ -1354,9 +1280,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.52.5",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.52.5.tgz",
-      "integrity": "sha512-hXGLYpdhiNElzN770+H2nlx+jRog8TyynpTVzdlc6bndktjKWyZyiCsuDAlpd+j+W+WNqfcyAWz9HxxIGfZm1Q==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.1.tgz",
+      "integrity": "sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==",
       "cpu": [
         "x64"
       ],
@@ -1368,9 +1294,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.52.5",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.52.5.tgz",
-      "integrity": "sha512-arCGIcuNKjBoKAXD+y7XomR9gY6Mw7HnFBv5Rw7wQRvwYLR7gBAgV7Mb2QTyjXfTveBNFAtPt46/36vV9STLNg==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.1.tgz",
+      "integrity": "sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==",
       "cpu": [
         "x64"
       ],
@@ -1381,10 +1307,24 @@
         "linux"
       ]
     },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.1.tgz",
+      "integrity": "sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
     "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.52.5",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.52.5.tgz",
-      "integrity": "sha512-QoFqB6+/9Rly/RiPjaomPLmR/13cgkIGfA40LHly9zcH1S0bN2HVFYk3a1eAyHQyjs3ZJYlXvIGtcCs5tko9Cw==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.1.tgz",
+      "integrity": "sha512-4Cv23ZrONRbNtbZa37mLSueXUCtN7MXccChtKpUnQNgF010rjrjfHx3QxkS2PI7LqGT5xXyYs1a7LbzAwT0iCA==",
       "cpu": [
         "arm64"
       ],
@@ -1396,9 +1336,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.52.5",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.52.5.tgz",
-      "integrity": "sha512-w0cDWVR6MlTstla1cIfOGyl8+qb93FlAVutcor14Gf5Md5ap5ySfQ7R9S/NjNaMLSFdUnKGEasmVnu3lCMqB7w==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.1.tgz",
+      "integrity": "sha512-i1okWYkA4FJICtr7KpYzFpRTHgy5jdDbZiWfvny21iIKky5YExiDXP+zbXzm3dUcFpkEeYNHgQ5fuG236JPq0g==",
       "cpu": [
         "arm64"
       ],
@@ -1410,9 +1350,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.52.5",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.52.5.tgz",
-      "integrity": "sha512-Aufdpzp7DpOTULJCuvzqcItSGDH73pF3ko/f+ckJhxQyHtp67rHw3HMNxoIdDMUITJESNE6a8uh4Lo4SLouOUg==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.1.tgz",
+      "integrity": "sha512-u09m3CuwLzShA0EYKMNiFgcjjzwqtUMLmuCJLeZWjjOYA3IT2Di09KaxGBTP9xVztWyIWjVdsB2E9goMjZvTQg==",
       "cpu": [
         "ia32"
       ],
@@ -1424,9 +1364,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.52.5",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.52.5.tgz",
-      "integrity": "sha512-UGBUGPFp1vkj6p8wCRraqNhqwX/4kNQPS57BCFc8wYh0g94iVIW33wJtQAx3G7vrjjNtRaxiMUylM0ktp/TRSQ==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.1.tgz",
+      "integrity": "sha512-k+600V9Zl1CM7eZxJgMyTUzmrmhB/0XZnF4pRypKAlAgxmedUA+1v9R+XOFv56W4SlHEzfeMtzujLJD22Uz5zg==",
       "cpu": [
         "x64"
       ],
@@ -1438,9 +1378,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.52.5",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.52.5.tgz",
-      "integrity": "sha512-TAcgQh2sSkykPRWLrdyy2AiceMckNf5loITqXxFI5VuQjS5tSuw3WlwdN8qv8vzjLAUTvYaH/mVjSFpbkFbpTg==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.1.tgz",
+      "integrity": "sha512-lWMnixq/QzxyhTV6NjQJ4SFo1J6PvOX8vUx5Wb4bBPsEb+8xZ89Bz6kOXpfXj9ak9AHTQVQzlgzBEc1SyM27xQ==",
       "cpu": [
         "x64"
       ],
@@ -1843,100 +1783,10 @@
         "@babel/types": "^7.28.2"
       }
     },
-    "node_modules/@types/d3": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@types/d3/-/d3-7.4.3.tgz",
-      "integrity": "sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/d3-array": "*",
-        "@types/d3-axis": "*",
-        "@types/d3-brush": "*",
-        "@types/d3-chord": "*",
-        "@types/d3-color": "*",
-        "@types/d3-contour": "*",
-        "@types/d3-delaunay": "*",
-        "@types/d3-dispatch": "*",
-        "@types/d3-drag": "*",
-        "@types/d3-dsv": "*",
-        "@types/d3-ease": "*",
-        "@types/d3-fetch": "*",
-        "@types/d3-force": "*",
-        "@types/d3-format": "*",
-        "@types/d3-geo": "*",
-        "@types/d3-hierarchy": "*",
-        "@types/d3-interpolate": "*",
-        "@types/d3-path": "*",
-        "@types/d3-polygon": "*",
-        "@types/d3-quadtree": "*",
-        "@types/d3-random": "*",
-        "@types/d3-scale": "*",
-        "@types/d3-scale-chromatic": "*",
-        "@types/d3-selection": "*",
-        "@types/d3-shape": "*",
-        "@types/d3-time": "*",
-        "@types/d3-time-format": "*",
-        "@types/d3-timer": "*",
-        "@types/d3-transition": "*",
-        "@types/d3-zoom": "*"
-      }
-    },
-    "node_modules/@types/d3-array": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
-      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-axis": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@types/d3-axis/-/d3-axis-3.0.6.tgz",
-      "integrity": "sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/d3-selection": "*"
-      }
-    },
-    "node_modules/@types/d3-brush": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@types/d3-brush/-/d3-brush-3.0.6.tgz",
-      "integrity": "sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/d3-selection": "*"
-      }
-    },
-    "node_modules/@types/d3-chord": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@types/d3-chord/-/d3-chord-3.0.6.tgz",
-      "integrity": "sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==",
-      "license": "MIT"
-    },
     "node_modules/@types/d3-color": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
       "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-contour": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@types/d3-contour/-/d3-contour-3.0.6.tgz",
-      "integrity": "sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/d3-array": "*",
-        "@types/geojson": "*"
-      }
-    },
-    "node_modules/@types/d3-delaunay": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/@types/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
-      "integrity": "sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==",
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-dispatch": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/@types/d3-dispatch/-/d3-dispatch-3.0.7.tgz",
-      "integrity": "sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==",
       "license": "MIT"
     },
     "node_modules/@types/d3-drag": {
@@ -1948,54 +1798,6 @@
         "@types/d3-selection": "*"
       }
     },
-    "node_modules/@types/d3-dsv": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/@types/d3-dsv/-/d3-dsv-3.0.7.tgz",
-      "integrity": "sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==",
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-ease": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
-      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-fetch": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/@types/d3-fetch/-/d3-fetch-3.0.7.tgz",
-      "integrity": "sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/d3-dsv": "*"
-      }
-    },
-    "node_modules/@types/d3-force": {
-      "version": "3.0.10",
-      "resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-3.0.10.tgz",
-      "integrity": "sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==",
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-format": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-3.0.4.tgz",
-      "integrity": "sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==",
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-geo": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-3.1.0.tgz",
-      "integrity": "sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/geojson": "*"
-      }
-    },
-    "node_modules/@types/d3-hierarchy": {
-      "version": "3.1.7",
-      "resolved": "https://registry.npmjs.org/@types/d3-hierarchy/-/d3-hierarchy-3.1.7.tgz",
-      "integrity": "sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==",
-      "license": "MIT"
-    },
     "node_modules/@types/d3-interpolate": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
@@ -2005,76 +1807,10 @@
         "@types/d3-color": "*"
       }
     },
-    "node_modules/@types/d3-path": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
-      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-polygon": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@types/d3-polygon/-/d3-polygon-3.0.2.tgz",
-      "integrity": "sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==",
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-quadtree": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@types/d3-quadtree/-/d3-quadtree-3.0.6.tgz",
-      "integrity": "sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==",
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-random": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@types/d3-random/-/d3-random-3.0.3.tgz",
-      "integrity": "sha512-Imagg1vJ3y76Y2ea0871wpabqp613+8/r0mCLEBfdtqC7xMSfj9idOnmBYyMoULfHePJyxMAw3nWhJxzc+LFwQ==",
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-scale": {
-      "version": "4.0.9",
-      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
-      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/d3-time": "*"
-      }
-    },
-    "node_modules/@types/d3-scale-chromatic": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
-      "integrity": "sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==",
-      "license": "MIT"
-    },
     "node_modules/@types/d3-selection": {
       "version": "3.0.11",
       "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
       "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-shape": {
-      "version": "3.1.7",
-      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.7.tgz",
-      "integrity": "sha512-VLvUQ33C+3J+8p+Daf+nYSOsjB4GXp19/S/aGo60m9h1v6XaxjiT82lKVWJCfzhtuZ3yD7i/TPeC/fuKLLOSmg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/d3-path": "*"
-      }
-    },
-    "node_modules/@types/d3-time": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
-      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-time-format": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-4.0.3.tgz",
-      "integrity": "sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==",
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-timer": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
-      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
       "license": "MIT"
     },
     "node_modules/@types/d3-transition": {
@@ -2119,12 +1855,6 @@
       "dependencies": {
         "@types/estree": "*"
       }
-    },
-    "node_modules/@types/geojson": {
-      "version": "7946.0.16",
-      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
-      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
-      "license": "MIT"
     },
     "node_modules/@types/hast": {
       "version": "3.0.4",
@@ -2391,9 +2121,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2514,6 +2244,38 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@xyflow/react": {
+      "version": "12.10.2",
+      "resolved": "https://registry.npmjs.org/@xyflow/react/-/react-12.10.2.tgz",
+      "integrity": "sha512-CgIi6HwlcHXwlkTpr0fxLv/0sRVNZ8IdwKLzzeCscaYBwpvfcH1QFOCeaTCuEn1FQEs/B8CjnTSjhs8udgmBgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@xyflow/system": "0.0.76",
+        "classcat": "^5.0.3",
+        "zustand": "^4.4.0"
+      },
+      "peerDependencies": {
+        "react": ">=17",
+        "react-dom": ">=17"
+      }
+    },
+    "node_modules/@xyflow/system": {
+      "version": "0.0.76",
+      "resolved": "https://registry.npmjs.org/@xyflow/system/-/system-0.0.76.tgz",
+      "integrity": "sha512-hvwvnRS1B3REwVDlWexsq7YQaPZeG3/mKo1jv38UmnpWmxihp14bW6VtEOuHEwJX2FvzFw8k77LyKSk/wiZVNA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-drag": "^3.0.7",
+        "@types/d3-interpolate": "^3.0.4",
+        "@types/d3-selection": "^3.0.10",
+        "@types/d3-transition": "^3.0.8",
+        "@types/d3-zoom": "^3.0.8",
+        "d3-drag": "^3.0.0",
+        "d3-interpolate": "^3.0.1",
+        "d3-selection": "^3.0.0",
+        "d3-zoom": "^3.0.0"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -2621,14 +2383,14 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.13.6",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
-      "integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/bail": {
@@ -2659,9 +2421,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3527,9 +3289,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },
@@ -5421,9 +5183,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5503,10 +5265,13 @@
       }
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -5574,24 +5339,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/reactflow": {
-      "version": "11.11.4",
-      "resolved": "https://registry.npmjs.org/reactflow/-/reactflow-11.11.4.tgz",
-      "integrity": "sha512-70FOtJkUWH3BAOsN+LU9lCrKoKbtOPnz2uq0CV2PLdNSwxTXOhCbsZr50GmZ+Rtw3jx8Uv7/vBFtCGixLfd4Og==",
-      "license": "MIT",
-      "dependencies": {
-        "@reactflow/background": "11.3.14",
-        "@reactflow/controls": "11.2.14",
-        "@reactflow/core": "11.11.4",
-        "@reactflow/minimap": "11.7.14",
-        "@reactflow/node-resizer": "2.2.14",
-        "@reactflow/node-toolbar": "1.3.14"
-      },
-      "peerDependencies": {
-        "react": ">=17",
-        "react-dom": ">=17"
       }
     },
     "node_modules/remark-gfm": {
@@ -5671,9 +5418,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.52.5",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.52.5.tgz",
-      "integrity": "sha512-3GuObel8h7Kqdjt0gxkEzaifHTqLVW56Y/bjN7PSQtkKr0w3V/QYSdt6QWYtd7A1xUtYQigtdUfgj1RvWVtorw==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.1.tgz",
+      "integrity": "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5687,28 +5434,31 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.52.5",
-        "@rollup/rollup-android-arm64": "4.52.5",
-        "@rollup/rollup-darwin-arm64": "4.52.5",
-        "@rollup/rollup-darwin-x64": "4.52.5",
-        "@rollup/rollup-freebsd-arm64": "4.52.5",
-        "@rollup/rollup-freebsd-x64": "4.52.5",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.52.5",
-        "@rollup/rollup-linux-arm-musleabihf": "4.52.5",
-        "@rollup/rollup-linux-arm64-gnu": "4.52.5",
-        "@rollup/rollup-linux-arm64-musl": "4.52.5",
-        "@rollup/rollup-linux-loong64-gnu": "4.52.5",
-        "@rollup/rollup-linux-ppc64-gnu": "4.52.5",
-        "@rollup/rollup-linux-riscv64-gnu": "4.52.5",
-        "@rollup/rollup-linux-riscv64-musl": "4.52.5",
-        "@rollup/rollup-linux-s390x-gnu": "4.52.5",
-        "@rollup/rollup-linux-x64-gnu": "4.52.5",
-        "@rollup/rollup-linux-x64-musl": "4.52.5",
-        "@rollup/rollup-openharmony-arm64": "4.52.5",
-        "@rollup/rollup-win32-arm64-msvc": "4.52.5",
-        "@rollup/rollup-win32-ia32-msvc": "4.52.5",
-        "@rollup/rollup-win32-x64-gnu": "4.52.5",
-        "@rollup/rollup-win32-x64-msvc": "4.52.5",
+        "@rollup/rollup-android-arm-eabi": "4.60.1",
+        "@rollup/rollup-android-arm64": "4.60.1",
+        "@rollup/rollup-darwin-arm64": "4.60.1",
+        "@rollup/rollup-darwin-x64": "4.60.1",
+        "@rollup/rollup-freebsd-arm64": "4.60.1",
+        "@rollup/rollup-freebsd-x64": "4.60.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.1",
+        "@rollup/rollup-linux-arm64-musl": "4.60.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.1",
+        "@rollup/rollup-linux-loong64-musl": "4.60.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.1",
+        "@rollup/rollup-linux-x64-gnu": "4.60.1",
+        "@rollup/rollup-linux-x64-musl": "4.60.1",
+        "@rollup/rollup-openbsd-x64": "4.60.1",
+        "@rollup/rollup-openharmony-arm64": "4.60.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.1",
+        "@rollup/rollup-win32-x64-gnu": "4.60.1",
+        "@rollup/rollup-win32-x64-msvc": "4.60.1",
         "fsevents": "~2.3.2"
       }
     },
@@ -6129,9 +5879,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,13 +12,13 @@
   },
   "dependencies": {
     "@tailwindcss/typography": "^0.5.19",
+    "@xyflow/react": "^12.10.2",
     "axios": "^1.12.2",
     "elkjs": "^0.11.0",
     "lucide-react": "^0.577.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "react-markdown": "^10.1.0",
-    "reactflow": "^11.11.4",
     "remark-gfm": "^4.0.1"
   },
   "devDependencies": {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,5 @@
 import { useState, useCallback, useEffect } from 'react';
-import { RefreshCw, Shield, Sparkles } from 'lucide-react';
+import { RefreshCw, Shield, Sparkles, AlertTriangle, ChevronDown, ChevronUp } from 'lucide-react';
 import NetworkGraph from './components/NetworkGraph';
 import NamespaceSelector from './components/NamespaceSelector';
 import DataTable from './components/DataTable';
@@ -33,6 +33,7 @@ function App() {
   const [layoutDirection, setLayoutDirection] = useState<'LR' | 'TB'>('LR');
 
   const { namespaces } = useNamespaces();
+  const [showErrorDetails, setShowErrorDetails] = useState(false);
   const { pods, allPodsLookup, services, loading, error, togglePodExpansion, refreshData } = usePodData(namespace);
 
   // Calculate the right padding for content when AI panel is docked (in pixels)
@@ -170,8 +171,37 @@ function App() {
       {/* Main Content */}
       <div className="flex-1 flex flex-col overflow-hidden">
         {error && (
-          <div className="bg-hubble-error/20 border border-hubble-error text-hubble-error px-6 py-3">
-            <p className="text-sm">Error: {error}</p>
+          <div className="border border-red-500/50 bg-red-950/30 px-6 py-4 mx-4 mt-4 rounded-lg">
+            <div className="flex items-start gap-3">
+              <AlertTriangle className="w-5 h-5 text-red-400 shrink-0 mt-0.5" />
+              <div className="flex-1 min-w-0">
+                <p className="text-sm font-medium text-red-300">
+                  Unable to connect to kguardian broker. Ensure it&apos;s running in the kguardian namespace.
+                </p>
+                {showErrorDetails && (
+                  <p className="text-xs text-red-500/70 mt-2 font-mono bg-red-950/50 rounded px-2 py-1 break-all">
+                    {error}
+                  </p>
+                )}
+              </div>
+              <div className="flex items-center gap-2 shrink-0">
+                <button
+                  onClick={() => setShowErrorDetails(prev => !prev)}
+                  className="flex items-center gap-1 text-xs text-red-400/70 hover:text-red-300 transition-colors"
+                >
+                  {showErrorDetails ? <ChevronUp className="w-3 h-3" /> : <ChevronDown className="w-3 h-3" />}
+                  {showErrorDetails ? 'Hide' : 'Show'} details
+                </button>
+                <button
+                  onClick={() => { setShowErrorDetails(false); refreshData(); }}
+                  className="flex items-center gap-1 px-3 py-1 text-xs bg-red-500/20 border border-red-500/40
+                             text-red-300 rounded hover:bg-red-500/30 hover:border-red-400 transition-all"
+                >
+                  <RefreshCw className="w-3 h-3" />
+                  Retry
+                </button>
+              </div>
+            </div>
           </div>
         )}
 

--- a/frontend/src/components/AIAssistant.tsx
+++ b/frontend/src/components/AIAssistant.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useRef, useEffect, useCallback } from 'react';
-import ReactMarkdown from 'react-markdown';
+import ReactMarkdown, { type Components } from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { X, Send, Sparkles, Bot, User, Minimize2, Maximize2, ChevronRight, ChevronLeft } from 'lucide-react';
 import { sendChatMessage, type HistoryMessage } from '../services/aiApi';
@@ -21,6 +21,19 @@ interface AIAssistantProps {
 }
 
 type ViewMode = 'modal' | 'side-panel';
+
+const ALLOWED_MARKDOWN_ELEMENTS: string[] = [
+  'p', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
+  'ul', 'ol', 'li', 'a', 'code', 'pre', 'blockquote',
+  'em', 'strong', 'table', 'thead', 'tbody', 'tr', 'th', 'td',
+  'br', 'hr', 'img', 'span', 'div', 'sup', 'sub', 'del', 'input',
+];
+
+const markdownComponents: Components = {
+  a({ node: _node, ...props }) {
+    return <a {...props} rel="noopener noreferrer" target="_blank" />;
+  },
+};
 
 const AIAssistant: React.FC<AIAssistantProps> = ({ isOpen, onClose, onLayoutChange, namespace, podNames }) => {
   const [messages, setMessages] = useState<Message[]>([]);
@@ -284,7 +297,12 @@ const AIAssistant: React.FC<AIAssistantProps> = ({ isOpen, onClose, onLayoutChan
                     >
                       {message.role === 'assistant' ? (
                         <div className="text-sm prose prose-sm dark:prose-invert max-w-none prose-p:my-1 prose-headings:my-2 prose-ul:my-1 prose-ol:my-1 prose-li:my-0.5 prose-pre:my-2 prose-table:my-2 prose-th:px-2 prose-th:py-1 prose-td:px-2 prose-td:py-1 prose-code:text-hubble-accent prose-a:text-hubble-accent">
-                          <ReactMarkdown remarkPlugins={[remarkGfm]}>{message.content}</ReactMarkdown>
+                          <ReactMarkdown
+                            remarkPlugins={[remarkGfm]}
+                            allowedElements={ALLOWED_MARKDOWN_ELEMENTS}
+                            unwrapDisallowed={true}
+                            components={markdownComponents}
+                          >{message.content}</ReactMarkdown>
                         </div>
                       ) : (
                         <p className="text-sm whitespace-pre-wrap">{message.content}</p>

--- a/frontend/src/components/DataTable.tsx
+++ b/frontend/src/components/DataTable.tsx
@@ -281,7 +281,7 @@ const DataTable: React.FC<DataTableProps> = ({ selectedPod, allPodsLookup, servi
   if (!selectedPod) {
     return (
       <div className="h-full flex items-center justify-center text-tertiary">
-        <p>Select a pod to view details</p>
+        <p>Click a pod in the network graph above to view its traffic and syscall details.</p>
       </div>
     );
   }
@@ -366,7 +366,7 @@ const DataTable: React.FC<DataTableProps> = ({ selectedPod, allPodsLookup, servi
         {isTrafficExpanded && hasTraffic && (
           <>
             {/* Filter Controls */}
-            <div className="mb-3 flex items-center gap-4 flex-wrap">
+            <div id="traffic-filters" className="mb-3 flex items-center gap-4 flex-wrap">
               <div className="flex items-center gap-2">
                 <Filter className="w-4 h-4 text-secondary" />
                 <span className="text-sm text-secondary">Filters:</span>
@@ -376,6 +376,7 @@ const DataTable: React.FC<DataTableProps> = ({ selectedPod, allPodsLookup, servi
               <div className="flex items-center gap-2">
                 <span className="text-xs text-tertiary">Decision:</span>
                 <select
+                  aria-label="Filter by decision"
                   value={decisionFilter}
                   onChange={(e) => {
                     setDecisionFilter(e.target.value as 'all' | 'ALLOW' | 'DROP');
@@ -393,6 +394,7 @@ const DataTable: React.FC<DataTableProps> = ({ selectedPod, allPodsLookup, servi
               <div className="flex items-center gap-2">
                 <span className="text-xs text-tertiary">Type:</span>
                 <select
+                  aria-label="Filter by traffic type"
                   value={trafficTypeFilter}
                   onChange={(e) => {
                     setTrafficTypeFilter(e.target.value as 'all' | 'ingress' | 'egress');
@@ -410,6 +412,7 @@ const DataTable: React.FC<DataTableProps> = ({ selectedPod, allPodsLookup, servi
               <div className="flex items-center gap-2">
                 <span className="text-xs text-tertiary">Protocol:</span>
                 <select
+                  aria-label="Filter by protocol"
                   value={protocolFilter}
                   onChange={(e) => {
                     setProtocolFilter(e.target.value);
@@ -429,6 +432,7 @@ const DataTable: React.FC<DataTableProps> = ({ selectedPod, allPodsLookup, servi
                 <div className="flex items-center gap-2">
                   <span className="text-xs text-tertiary">Port:</span>
                   <select
+                    aria-label="Filter by port"
                     value={portFilter}
                     onChange={(e) => {
                       setPortFilter(e.target.value);
@@ -461,17 +465,17 @@ const DataTable: React.FC<DataTableProps> = ({ selectedPod, allPodsLookup, servi
               )}
             </div>
 
-            <div className="bg-hubble-card rounded-lg border border-hubble-border overflow-hidden">
+            <div role="region" aria-label="Network traffic data" className="bg-hubble-card rounded-lg border border-hubble-border overflow-hidden">
             <div className="overflow-x-auto">
-              <table className="w-full text-sm">
+              <table className="w-full text-sm" aria-label="Pod traffic and syscall data" aria-describedby="traffic-filters">
                 <thead className="bg-hubble-dark border-b border-hubble-border">
                   <tr>
-                    <th className="px-4 py-2 text-left text-secondary font-medium">Direction</th>
-                    <th className="px-4 py-2 text-left text-secondary font-medium">Source</th>
-                    <th className="px-4 py-2 text-left text-secondary font-medium">Destination</th>
-                    <th className="px-4 py-2 text-left text-secondary font-medium">Protocol</th>
-                    <th className="px-4 py-2 text-left text-secondary font-medium">Decision</th>
-                    <th className="px-4 py-2 text-left text-secondary font-medium">Timestamp</th>
+                    <th scope="col" className="px-4 py-2 text-left text-secondary font-medium">Direction</th>
+                    <th scope="col" className="px-4 py-2 text-left text-secondary font-medium">Source</th>
+                    <th scope="col" className="px-4 py-2 text-left text-secondary font-medium">Destination</th>
+                    <th scope="col" className="px-4 py-2 text-left text-secondary font-medium">Protocol</th>
+                    <th scope="col" className="px-4 py-2 text-left text-secondary font-medium">Decision</th>
+                    <th scope="col" className="px-4 py-2 text-left text-secondary font-medium">Timestamp</th>
                   </tr>
                 </thead>
                 <tbody>
@@ -670,14 +674,14 @@ const DataTable: React.FC<DataTableProps> = ({ selectedPod, allPodsLookup, servi
           </button>
 
           {isSyscallsExpanded && (
-            <div className="bg-hubble-card rounded-lg border border-hubble-border overflow-hidden">
+            <div role="region" aria-label="System call data" className="bg-hubble-card rounded-lg border border-hubble-border overflow-hidden">
             <div className="overflow-x-auto">
-              <table className="w-full text-sm">
+              <table className="w-full text-sm" aria-label="System call data">
                 <thead className="bg-hubble-dark border-b border-hubble-border">
                   <tr>
-                    <th className="px-4 py-2 text-left text-secondary font-medium">Architecture</th>
-                    <th className="px-4 py-2 text-left text-secondary font-medium">Syscalls</th>
-                    <th className="px-4 py-2 text-left text-secondary font-medium">Timestamp</th>
+                    <th scope="col" className="px-4 py-2 text-left text-secondary font-medium">Architecture</th>
+                    <th scope="col" className="px-4 py-2 text-left text-secondary font-medium">System Calls</th>
+                    <th scope="col" className="px-4 py-2 text-left text-secondary font-medium">Timestamp</th>
                   </tr>
                 </thead>
                 <tbody>

--- a/frontend/src/components/NetworkGraph.tsx
+++ b/frontend/src/components/NetworkGraph.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useMemo, useEffect, useState } from 'react';
-import ReactFlow, {
+import {
+  ReactFlow,
   Controls,
   Background,
   BackgroundVariant,
@@ -9,9 +10,9 @@ import ReactFlow, {
   useReactFlow,
   ReactFlowProvider,
   Panel,
-} from 'reactflow';
-import type { Node, Edge } from 'reactflow';
-import 'reactflow/dist/style.css';
+} from '@xyflow/react';
+import type { Node, Edge } from '@xyflow/react';
+import '@xyflow/react/dist/style.css';
 import ELK from 'elkjs/lib/elk.bundled.js';
 import { Eye, EyeOff, Activity, ShieldAlert, Server } from 'lucide-react';
 import PodNode from './PodNode';
@@ -408,6 +409,9 @@ const NetworkGraphInner: React.FC<NetworkGraphProps> = ({
   // Track ELK-computed node positions
   const [elkPositions, setElkPositions] = useState<Map<string, { x: number; y: number }>>(new Map());
 
+  // Track whether ELK layout is being computed
+  const [isLayoutLoading, setIsLayoutLoading] = useState(false);
+
   // Well-known port to service name mapping
   const wellKnownPorts: Record<string, string> = useMemo(() => ({
     '53': 'DNS',
@@ -593,6 +597,8 @@ const NetworkGraphInner: React.FC<NetworkGraphProps> = ({
       return;
     }
 
+    setIsLayoutLoading(true);
+
     // Only include edges whose source and target exist in the current node set
     const nodeIds = new Set(baseNodes.map((n) => n.id));
     const validEdges = initialEdges.filter(
@@ -669,6 +675,7 @@ const NetworkGraphInner: React.FC<NetworkGraphProps> = ({
       }
 
       setElkPositions(positions);
+      setIsLayoutLoading(false);
     }).catch((err) => {
       // Fallback: simple grid layout if ELK fails
       console.error('ELK layout error, using fallback grid:', err);
@@ -683,6 +690,7 @@ const NetworkGraphInner: React.FC<NetworkGraphProps> = ({
         });
       });
       setElkPositions(positions);
+      setIsLayoutLoading(false);
     });
   }, [baseNodes, initialEdges, layoutDirection]);
 
@@ -751,7 +759,18 @@ const NetworkGraphInner: React.FC<NetworkGraphProps> = ({
   }, [pods]);
 
   return (
-    <div className="w-full h-full">
+    <div className="w-full h-full relative">
+      {isLayoutLoading && (
+        <div className="absolute inset-0 z-10 flex items-center justify-center pointer-events-none">
+          <div className="flex items-center gap-2 px-4 py-2 rounded-lg bg-hubble-card/90 border border-hubble-border backdrop-blur-sm text-xs text-secondary">
+            <span
+              className="inline-block w-3 h-3 rounded-full border-2 border-hubble-accent border-t-transparent animate-spin"
+              aria-hidden="true"
+            />
+            Computing layout...
+          </div>
+        </div>
+      )}
       <ReactFlow
         nodes={nodes}
         edges={edges}

--- a/frontend/src/components/NetworkPolicyEditor.tsx
+++ b/frontend/src/components/NetworkPolicyEditor.tsx
@@ -147,7 +147,7 @@ const NetworkPolicyEditor: React.FC<NetworkPolicyEditorProps> = ({ isOpen, onClo
       {/* Modal */}
       <div className="fixed inset-0 z-50 flex items-center justify-center p-4 pointer-events-none">
         <div
-          className="bg-hubble-card border border-hubble-border rounded-lg shadow-2xl w-full max-w-7xl h-[90vh] flex flex-col pointer-events-auto"
+          className="bg-hubble-card border border-hubble-border rounded-lg shadow-2xl w-full max-w-full sm:max-w-full md:max-w-4xl lg:max-w-6xl xl:max-w-7xl h-[75vh] sm:h-[80vh] md:h-[90vh] flex flex-col pointer-events-auto"
           onClick={(e) => e.stopPropagation()}
         >
           {/* Header */}
@@ -313,6 +313,13 @@ const NetworkPolicyEditor: React.FC<NetworkPolicyEditorProps> = ({ isOpen, onClo
                                           <option value="inNamespace">In Namespace (Same Namespace)</option>
                                           <option value="inCluster">In Cluster (Any Namespace)</option>
                                         </select>
+                                        <p className="text-xs text-tertiary italic mt-1">
+                                          {peer.ipBlock
+                                            ? 'Matches external IPs via CIDR blocks'
+                                            : peer.podSelector && !peer.namespaceSelector
+                                            ? 'Matches pods in the same namespace'
+                                            : 'Matches pods in any namespace'}
+                                        </p>
                                       </div>
 
                                       {/* IP Block Editor */}
@@ -766,6 +773,13 @@ const NetworkPolicyEditor: React.FC<NetworkPolicyEditorProps> = ({ isOpen, onClo
                                           <option value="inNamespace">In Namespace (Same Namespace)</option>
                                           <option value="inCluster">In Cluster (Any Namespace)</option>
                                         </select>
+                                        <p className="text-xs text-tertiary italic mt-1">
+                                          {peer.ipBlock
+                                            ? 'Matches external IPs via CIDR blocks'
+                                            : peer.podSelector && !peer.namespaceSelector
+                                            ? 'Matches pods in the same namespace'
+                                            : 'Matches pods in any namespace'}
+                                        </p>
                                       </div>
 
                                       {/* External: IP Block Editor */}

--- a/frontend/src/components/PodNode.tsx
+++ b/frontend/src/components/PodNode.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Handle, Position } from 'reactflow';
+import { Handle, Position } from '@xyflow/react';
 import { ChevronDown, ChevronRight, Network, Server, Globe, FileCode } from 'lucide-react';
 import type { PodNodeData } from '../types';
 

--- a/frontend/src/components/ThemeToggle.tsx
+++ b/frontend/src/components/ThemeToggle.tsx
@@ -11,8 +11,8 @@ const ThemeToggle: React.FC = () => {
       className="flex items-center gap-2 px-3 py-2 bg-hubble-card border border-hubble-border
                  rounded-lg text-secondary hover:bg-hubble-dark hover:border-hubble-accent
                  transition-all"
-      title={`Switch to ${theme === 'dark' ? 'light' : 'dark'} theme`}
-      aria-label={`Switch to ${theme === 'dark' ? 'light' : 'dark'} theme`}
+      title={`Switch to ${theme === 'dark' ? 'light' : 'dark'} mode`}
+      aria-label={`Switch to ${theme === 'dark' ? 'light' : 'dark'} mode`}
     >
       {theme === 'dark' ? (
         <>

--- a/frontend/src/hooks/useNamespaces.ts
+++ b/frontend/src/hooks/useNamespaces.ts
@@ -1,28 +1,38 @@
 import { useState, useEffect } from 'react';
+import axios from 'axios';
 import { apiClient } from '../services/api';
 
 export const useNamespaces = () => {
   const [namespaces, setNamespaces] = useState<string[]>(['default']);
   const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
+    const controller = new AbortController();
+
     const fetchNamespaces = async () => {
       setLoading(true);
+      setError(null);
       try {
-        const ns = await apiClient.getNamespaces();
+        const ns = await apiClient.getNamespaces(controller.signal);
         if (ns.length > 0) {
           setNamespaces(ns);
         }
-      } catch (error) {
-        console.error('Error fetching namespaces:', error);
-        // Keep default namespace on error
+      } catch (err) {
+        if (axios.isCancel(err) || (err instanceof Error && err.name === 'CanceledError')) {
+          return;
+        }
+        console.error('Error fetching namespaces:', err);
+        setError(err instanceof Error ? err.message : 'Unknown error occurred');
       } finally {
         setLoading(false);
       }
     };
 
     fetchNamespaces();
+
+    return () => controller.abort();
   }, []);
 
-  return { namespaces, loading };
+  return { namespaces, loading, isError: error !== null, error };
 };

--- a/frontend/src/hooks/usePodData.ts
+++ b/frontend/src/hooks/usePodData.ts
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback } from 'react';
+import axios from 'axios';
 import type { PodInfo, PodNodeData, ServiceInfo } from '../types';
 import { apiClient } from '../services/api';
 
@@ -25,15 +26,15 @@ export const usePodData = (namespace: string) => {
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
 
-  const fetchPodData = useCallback(async () => {
+  const fetchPodData = useCallback(async (signal?: AbortSignal) => {
     setLoading(true);
     setError(null);
 
     try {
       // Fetch all pods and services from broker
       const [allPods, allServices] = await Promise.all([
-        apiClient.getAllPods(),
-        apiClient.getAllServices(),
+        apiClient.getAllPods(signal),
+        apiClient.getAllServices(signal),
       ]);
 
       setServices(allServices);
@@ -67,12 +68,13 @@ export const usePodData = (namespace: string) => {
         const identity = primaryPod.pod_identity || primaryPod.pod_name;
 
         // Fetch traffic and syscalls for all pods in the group with concurrency limit
-        const trafficTasks = podsInGroup.map(pod => () => apiClient.getPodTrafficByName(pod.pod_name));
-        const syscallTasks = podsInGroup.map(pod => () => apiClient.getPodSyscalls(pod.pod_name));
+        // TODO: Replace with broker batch endpoint for better performance
+        const trafficTasks = podsInGroup.map(pod => () => apiClient.getPodTrafficByName(pod.pod_name, signal));
+        const syscallTasks = podsInGroup.map(pod => () => apiClient.getPodSyscalls(pod.pod_name, signal));
 
         return Promise.all([
-          withConcurrencyLimit(trafficTasks, 10),
-          withConcurrencyLimit(syscallTasks, 10),
+          withConcurrencyLimit(trafficTasks, 50),
+          withConcurrencyLimit(syscallTasks, 50),
         ]).then(([allTraffic, allSyscalls]) => {
           // Merge all traffic and syscalls
           const mergedTraffic = allTraffic.flat();
@@ -90,9 +92,14 @@ export const usePodData = (namespace: string) => {
         });
       });
 
-      const podData = await withConcurrencyLimit(podDataTasks, 10);
+      // TODO: Replace with broker batch endpoint for better performance
+      const podData = await withConcurrencyLimit(podDataTasks, 50);
       setPods(podData);
     } catch (err) {
+      if (axios.isCancel(err) || (err instanceof Error && err.name === 'CanceledError')) {
+        return;
+      }
+      console.error('Error fetching pod data:', err);
       setError(err instanceof Error ? err.message : 'Unknown error occurred');
     } finally {
       setLoading(false);
@@ -100,7 +107,9 @@ export const usePodData = (namespace: string) => {
   }, [namespace]);
 
   useEffect(() => {
-    fetchPodData();
+    const controller = new AbortController();
+    fetchPodData(controller.signal);
+    return () => controller.abort();
   }, [fetchPodData]);
 
   const togglePodExpansion = useCallback((podId: string) => {
@@ -120,6 +129,7 @@ export const usePodData = (namespace: string) => {
     allPodsLookup,
     services,
     loading,
+    isError: error !== null,
     error,
     togglePodExpansion,
     refreshData,

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -22,92 +22,57 @@ class BrokerAPIClient {
   /**
    * Get all pod traffic
    */
-  async getAllPodTraffic(): Promise<NetworkTraffic[]> {
-    try {
-      const response = await this.client.get('/pod/traffic');
-      return response.data || [];
-    } catch (error) {
-      console.error('Error fetching all pod traffic:', error);
-      return [];
-    }
+  async getAllPodTraffic(signal?: AbortSignal): Promise<NetworkTraffic[]> {
+    const response = await this.client.get('/pod/traffic', { signal });
+    return response.data || [];
   }
 
   /**
    * Get pod traffic by pod name
    */
-  async getPodTrafficByName(podName: string): Promise<NetworkTraffic[]> {
-    try {
-      const response = await this.client.get(`/pod/traffic/${podName}`);
-      return response.data || [];
-    } catch (error) {
-      console.error('Error fetching pod traffic by name:', error);
-      return [];
-    }
+  async getPodTrafficByName(podName: string, signal?: AbortSignal): Promise<NetworkTraffic[]> {
+    const response = await this.client.get(`/pod/traffic/${podName}`, { signal });
+    return response.data || [];
   }
 
   /**
    * Get pod details by pod name
    */
-  async getPodDetailsByName(podName: string): Promise<PodInfo | null> {
-    try {
-      const response = await this.client.get(`/pod/name/${podName}`);
-      return response.data;
-    } catch (error) {
-      console.error('Error fetching pod details by name:', error);
-      return null;
-    }
+  async getPodDetailsByName(podName: string, signal?: AbortSignal): Promise<PodInfo | null> {
+    const response = await this.client.get(`/pod/name/${podName}`, { signal });
+    return response.data;
   }
 
   /**
    * Get pod details by IP address
    */
-  async getPodDetailsByIP(podIP: string): Promise<PodInfo | null> {
-    try {
-      const response = await this.client.get(`/pod/ip/${podIP}`);
-      return response.data;
-    } catch (error) {
-      console.error('Error fetching pod details by IP:', error);
-      return null;
-    }
+  async getPodDetailsByIP(podIP: string, signal?: AbortSignal): Promise<PodInfo | null> {
+    const response = await this.client.get(`/pod/ip/${podIP}`, { signal });
+    return response.data;
   }
 
   /**
    * Get syscalls for a pod by pod name
    */
-  async getPodSyscalls(podName: string): Promise<SyscallInfo[]> {
-    try {
-      const response = await this.client.get(`/pod/syscalls/${podName}`);
-      return response.data || [];
-    } catch (error) {
-      console.error('Error fetching pod syscalls:', error);
-      return [];
-    }
+  async getPodSyscalls(podName: string, signal?: AbortSignal): Promise<SyscallInfo[]> {
+    const response = await this.client.get(`/pod/syscalls/${podName}`, { signal });
+    return response.data || [];
   }
 
   /**
    * Get all service details
    */
-  async getAllServices(): Promise<ServiceInfo[]> {
-    try {
-      const response = await this.client.get('/svc/info');
-      return response.data || [];
-    } catch (error) {
-      console.error('Error fetching all services:', error);
-      return [];
-    }
+  async getAllServices(signal?: AbortSignal): Promise<ServiceInfo[]> {
+    const response = await this.client.get('/svc/info', { signal });
+    return response.data || [];
   }
 
   /**
    * Get service details by IP address
    */
-  async getServiceByIP(serviceIP: string): Promise<ServiceInfo | null> {
-    try {
-      const response = await this.client.get(`/svc/ip/${serviceIP}`);
-      return response.data;
-    } catch (error) {
-      console.error('Error fetching service by IP:', error);
-      return null;
-    }
+  async getServiceByIP(serviceIP: string, signal?: AbortSignal): Promise<ServiceInfo | null> {
+    const response = await this.client.get(`/svc/ip/${serviceIP}`, { signal });
+    return response.data;
   }
 
   /**
@@ -126,60 +91,44 @@ class BrokerAPIClient {
   /**
    * Get all pod details
    */
-  async getAllPods(): Promise<PodInfo[]> {
-    try {
-      const response = await this.client.get('/pod/info');
-      // Ensure we always return an array
-      if (Array.isArray(response.data)) {
-        return response.data;
-      }
-      console.warn('API returned non-array data for /pod/info:', response.data);
-      return [];
-    } catch (error) {
-      console.error('Error fetching all pods:', error);
-      return [];
+  async getAllPods(signal?: AbortSignal): Promise<PodInfo[]> {
+    const response = await this.client.get('/pod/info', { signal });
+    // Ensure we always return an array
+    if (Array.isArray(response.data)) {
+      return response.data;
     }
+    console.warn('API returned non-array data for /pod/info:', response.data);
+    return [];
   }
 
   /**
    * Get all unique namespaces from pods
    */
-  async getNamespaces(): Promise<string[]> {
-    try {
-      const pods = await this.getAllPods();
+  async getNamespaces(signal?: AbortSignal): Promise<string[]> {
+    const pods = await this.getAllPods(signal);
 
-      // Ensure pods is an array
-      if (!Array.isArray(pods)) {
-        console.error('getAllPods() did not return an array:', pods);
-        return ['default'];
+    const namespaces = new Set<string>();
+
+    pods.forEach(pod => {
+      if (pod.pod_namespace) {
+        namespaces.add(pod.pod_namespace);
       }
+    });
 
-      const namespaces = new Set<string>();
+    // Convert to array and sort, with "default" always first
+    const namespaceArray = Array.from(namespaces).sort();
+    const defaultIndex = namespaceArray.indexOf('default');
 
-      pods.forEach(pod => {
-        if (pod.pod_namespace) {
-          namespaces.add(pod.pod_namespace);
-        }
-      });
-
-      // Convert to array and sort, with "default" always first
-      const namespaceArray = Array.from(namespaces).sort();
-      const defaultIndex = namespaceArray.indexOf('default');
-
-      if (defaultIndex > 0) {
-        // Move "default" to the front
-        namespaceArray.splice(defaultIndex, 1);
-        namespaceArray.unshift('default');
-      } else if (defaultIndex === -1 && namespaceArray.length > 0) {
-        // If no "default" namespace exists, still sort alphabetically
-        return namespaceArray;
-      }
-
+    if (defaultIndex > 0) {
+      // Move "default" to the front
+      namespaceArray.splice(defaultIndex, 1);
+      namespaceArray.unshift('default');
+    } else if (defaultIndex === -1 && namespaceArray.length > 0) {
+      // If no "default" namespace exists, still sort alphabetically
       return namespaceArray;
-    } catch (error) {
-      console.error('Error fetching namespaces:', error);
-      return ['default'];
     }
+
+    return namespaceArray;
   }
 
   /**

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -47,7 +47,7 @@ export default defineConfig({
         manualChunks: {
           // Vendor chunks
           'react-vendor': ['react', 'react-dom'],
-          'react-flow-vendor': ['reactflow'],
+          'react-flow-vendor': ['@xyflow/react'],
         },
       },
     },

--- a/llm-bridge/package-lock.json
+++ b/llm-bridge/package-lock.json
@@ -9,11 +9,11 @@
       "version": "1.2.3",
       "license": "BUSL-1.1",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.23.0",
-        "axios": "^1.7.9",
+        "@modelcontextprotocol/sdk": "^1.29.0",
+        "axios": "^1.15.0",
         "cors": "^2.8.5",
         "dotenv": "^17.0.0",
-        "express": "^5.0.0",
+        "express": "^5.2.1",
         "express-rate-limit": "^8.2.1",
         "zod": "^4.0.0"
       },
@@ -515,9 +515,9 @@
       }
     },
     "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -589,9 +589,9 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -660,9 +660,9 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.9",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.9.tgz",
-      "integrity": "sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw==",
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
       "license": "MIT",
       "engines": {
         "node": ">=18.14.1"
@@ -724,9 +724,9 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.27.1",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.27.1.tgz",
-      "integrity": "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==",
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
       "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^1.19.9",
@@ -1232,9 +1232,9 @@
       }
     },
     "node_modules/ajv-formats/node_modules/ajv": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -1283,14 +1283,14 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.13.6",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
-      "integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/balanced-match": {
@@ -1325,9 +1325,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1801,9 +1801,9 @@
       }
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2156,9 +2156,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },
@@ -2378,9 +2378,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.11.9",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.9.tgz",
-      "integrity": "sha512-Eaw2YTGM6WOxA6CXbckaEvslr2Ne4NFsKrvc0v97JD5awbmeBLO5w9Ho9L9kmKonrwF9RJlW6BxT1PVv/agBHQ==",
+      "version": "4.12.12",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
+      "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -2833,9 +2833,9 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
-      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -2843,9 +2843,9 @@
       }
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2888,10 +2888,13 @@
       }
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -2904,9 +2907,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
-      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"

--- a/llm-bridge/package.json
+++ b/llm-bridge/package.json
@@ -21,11 +21,11 @@
   "author": "kguardian-dev",
   "license": "BUSL-1.1",
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.23.0",
-    "axios": "^1.7.9",
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "axios": "^1.15.0",
     "cors": "^2.8.5",
     "dotenv": "^17.0.0",
-    "express": "^5.0.0",
+    "express": "^5.2.1",
     "express-rate-limit": "^8.2.1",
     "zod": "^4.0.0"
   },

--- a/llm-bridge/src/brokerClient.ts
+++ b/llm-bridge/src/brokerClient.ts
@@ -1,6 +1,18 @@
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
-import type { ToolCall, ToolResult } from "./types/index.js";
+import type { ToolCall, ToolResult, ToolDefinition, JsonSchemaObject } from "./types/index.js";
+
+/** Shape of a tool as returned by the MCP SDK listTools() response */
+interface McpRawTool {
+  name: string;
+  description?: string;
+  inputSchema?: {
+    type?: string;
+    properties?: Record<string, { type: string; description?: string }>;
+    required?: string[];
+    [key: string]: unknown;
+  };
+}
 
 export interface ParsedContext {
   namespace?: string;
@@ -12,7 +24,7 @@ export class BrokerClient {
   private mcpUrl: string;
   private mcpInitialized: boolean = false;
   private initPromise: Promise<void> | null = null;
-  private static toolDefsCache: any[] | null = null;
+  private static toolDefsCache: ToolDefinition[] | null = null;
 
   constructor(brokerUrl: string, mcpUrl?: string) {
     this.mcpUrl = mcpUrl || process.env.MCP_SERVER_URL || "http://kguardian-mcp-server.kguardian.svc.cluster.local:8081";
@@ -157,7 +169,7 @@ export class BrokerClient {
   /**
    * Get available tools from MCP server
    */
-  async getAvailableTools(): Promise<any[]> {
+  async getAvailableTools(): Promise<McpRawTool[]> {
     try {
       await this.initializeMCPClient();
 
@@ -166,7 +178,7 @@ export class BrokerClient {
       }
 
       const response = await this.mcpClient.listTools();
-      return response.tools || [];
+      return (response.tools || []) as McpRawTool[];
     } catch (error) {
       console.error("Error fetching tools from MCP server:", error);
       return [];
@@ -177,16 +189,16 @@ export class BrokerClient {
    * Get tool definitions for LLMs
    * This fetches the actual tools from the MCP server dynamically
    */
-  static async getToolDefinitionsFromMCP(mcpUrl?: string): Promise<any[]> {
+  static async getToolDefinitionsFromMCP(mcpUrl?: string): Promise<ToolDefinition[]> {
     const client = new BrokerClient("", mcpUrl);
     try {
       const tools = await client.getAvailableTools();
 
       // Convert MCP tool format to LLM provider format
-      return tools.map((tool: any) => ({
+      return tools.map((tool: McpRawTool): ToolDefinition => ({
         name: tool.name,
         description: tool.description || "",
-        parameters: tool.inputSchema || {
+        parameters: (tool.inputSchema as JsonSchemaObject | undefined) || {
           type: "object",
           properties: {},
           required: [],
@@ -204,7 +216,7 @@ export class BrokerClient {
   /**
    * Get tool definitions with caching — tries MCP server first, falls back to static
    */
-  static async getToolsCached(): Promise<any[]> {
+  static async getToolsCached(): Promise<ToolDefinition[]> {
     if (BrokerClient.toolDefsCache) return BrokerClient.toolDefsCache;
     try {
       BrokerClient.toolDefsCache = await BrokerClient.getToolDefinitionsFromMCP();
@@ -217,7 +229,7 @@ export class BrokerClient {
   /**
    * Get available tools definition for LLMs (static fallback)
    */
-  static getToolDefinitions() {
+  static getToolDefinitions(): ToolDefinition[] {
     return [
       {
         name: "get_pod_network_traffic",

--- a/llm-bridge/src/index.ts
+++ b/llm-bridge/src/index.ts
@@ -2,8 +2,8 @@ import express, { Request, Response } from "express";
 import cors from "cors";
 import rateLimit from "express-rate-limit";
 import dotenv from "dotenv";
-import { ZodError } from "zod";
-import { ChatRequestSchema, LLMProvider, type ErrorResponse } from "./types/index.js";
+import { ZodError, ZodIssue } from "zod";
+import { ChatRequestSchema, LLMProvider, type ChatResponse, type ErrorResponse } from "./types/index.js";
 import { BrokerClient } from "./brokerClient.js";
 import { callOpenAI } from "./providers/openai.js";
 import { callAnthropic } from "./providers/anthropic.js";
@@ -19,7 +19,12 @@ const brokerUrl =
   process.env.BROKER_URL || "http://broker.kguardian.svc.cluster.local:9090";
 
 // Middleware
-app.use(cors({ origin: process.env.ALLOWED_ORIGIN || '*' }));
+// P1-1: Default to localhost instead of wildcard to avoid open CORS
+const allowedOrigin = process.env.ALLOWED_ORIGIN;
+if (!allowedOrigin) {
+  console.warn('WARNING: ALLOWED_ORIGIN not set, defaulting to http://localhost:3000');
+}
+app.use(cors({ origin: allowedOrigin || 'http://localhost:3000' }));
 app.use(express.json({ limit: '100kb' }));
 
 // Initialize broker client
@@ -45,14 +50,17 @@ app.get("/health", (req: Request, res: Response) => {
 });
 
 // Rate limiting for chat endpoint
+const rateLimitMax = parseInt(process.env.RATE_LIMIT_MAX || '60', 10);
 const chatLimiter = rateLimit({
   windowMs: 60 * 1000,
-  max: 20,
+  max: rateLimitMax,
+  standardHeaders: true,
+  legacyHeaders: false,
   message: { error: 'Too many requests' },
 });
 
 // Chat endpoint
-app.post("/api/chat", chatLimiter, async (req: Request, res: Response<any>) => {
+app.post("/api/chat", chatLimiter, async (req: Request, res: Response<ChatResponse | ErrorResponse>) => {
   try {
     // Validate request
     const chatRequest = ChatRequestSchema.parse(req.body);
@@ -60,24 +68,25 @@ app.post("/api/chat", chatLimiter, async (req: Request, res: Response<any>) => {
     // Determine provider to use
     const availableProviders = getAvailableProviders();
 
+    // P1-2: Return generic error — do not reveal which providers are configured
     if (availableProviders.length === 0) {
       return res.status(503).json({
-        error: "No LLM provider configured",
-        details: "Please configure at least one API key: OPENAI_API_KEY, ANTHROPIC_API_KEY, GOOGLE_API_KEY, or GITHUB_TOKEN",
+        error: "No LLM provider available",
       } as ErrorResponse);
     }
 
     const provider = chatRequest.provider || availableProviders[0];
 
-    // Verify the requested provider is available
+    // P1-2: Return generic error — do not reveal which providers are available
     if (!availableProviders.includes(provider)) {
-      return res.status(400).json({
-        error: `Provider ${provider} not configured`,
-        details: `Available providers: ${availableProviders.join(", ")}`,
+      return res.status(503).json({
+        error: "No LLM provider available",
       } as ErrorResponse);
     }
 
-    console.log(`Processing chat request with provider: ${provider}`);
+    if (process.env.DEBUG) {
+      console.log(`Processing chat request with provider: ${provider}`);
+    }
 
     // Route to appropriate provider
     let response;
@@ -95,8 +104,8 @@ app.post("/api/chat", chatLimiter, async (req: Request, res: Response<any>) => {
         response = await callCopilot(chatRequest, brokerClient);
         break;
       default:
-        return res.status(400).json({
-          error: `Unknown provider: ${provider}`,
+        return res.status(503).json({
+          error: "No LLM provider available",
         } as ErrorResponse);
     }
 
@@ -107,7 +116,7 @@ app.post("/api/chat", chatLimiter, async (req: Request, res: Response<any>) => {
     if (error instanceof ZodError) {
       return res.status(400).json({
         error: "Invalid request format",
-        details: error.issues.map((e: any) => e.message).join(", "),
+        details: error.issues.map((e: ZodIssue) => e.message).join(", "),
       } as ErrorResponse);
     }
 
@@ -126,14 +135,17 @@ app.post("/api/chat", chatLimiter, async (req: Request, res: Response<any>) => {
 
 // Start server
 const server = app.listen(port, () => {
-  const availableProviders = getAvailableProviders();
   console.log(`LLM Bridge listening on port ${port}`);
   console.log(`Broker URL: ${brokerUrl}`);
-  console.log(`Available providers: ${availableProviders.join(", ") || "NONE"}`);
 
-  if (availableProviders.length === 0) {
+  // P1-2: Guard provider availability details behind DEBUG flag
+  if (process.env.DEBUG) {
+    const availableProviders = getAvailableProviders();
+    console.log(`Available providers: ${availableProviders.join(", ") || "NONE"}`);
+  }
+
+  if (getAvailableProviders().length === 0) {
     console.warn("WARNING: No LLM provider API keys configured!");
-    console.warn("Set at least one: OPENAI_API_KEY, ANTHROPIC_API_KEY, GOOGLE_API_KEY, or GITHUB_TOKEN");
   }
 });
 

--- a/llm-bridge/src/providers/anthropic.ts
+++ b/llm-bridge/src/providers/anthropic.ts
@@ -7,8 +7,40 @@ import { serializeToolResult } from "./truncate.js";
 interface AnthropicTool {
   name: string;
   description: string;
-  input_schema: any;
+  input_schema: object;
 }
+
+interface AnthropicTextBlock {
+  type: "text";
+  text: string;
+}
+
+interface AnthropicToolUseBlock {
+  type: "tool_use";
+  id: string;
+  name: string;
+  input: Record<string, unknown>;
+}
+
+type AnthropicContentBlock = AnthropicTextBlock | AnthropicToolUseBlock;
+
+interface AnthropicUserMessage {
+  role: "user";
+  content: string | AnthropicToolResultBlock[];
+}
+
+interface AnthropicAssistantMessage {
+  role: "assistant";
+  content: AnthropicContentBlock[];
+}
+
+interface AnthropicToolResultBlock {
+  type: "tool_result";
+  tool_use_id: string;
+  content: string;
+}
+
+type AnthropicMessage = AnthropicUserMessage | AnthropicAssistantMessage;
 
 const MAX_TOOL_ROUNDS = 10;
 
@@ -34,14 +66,24 @@ export async function callAnthropic(
   }));
 
   // Build messages with history
-  const messages: any[] = [];
+  const messages: AnthropicMessage[] = [];
 
   // Add conversation history if provided
   if (request.history && request.history.length > 0) {
-    messages.push(...request.history.filter(msg => msg.role !== 'system').map(msg => ({
-      role: msg.role,
-      content: msg.content,
-    })));
+    for (const msg of request.history) {
+      if (msg.role === 'system') continue;
+      if (msg.role === 'assistant') {
+        messages.push({
+          role: 'assistant',
+          content: [{ type: 'text', text: msg.content }],
+        });
+      } else {
+        messages.push({
+          role: 'user',
+          content: msg.content,
+        });
+      }
+    }
   }
 
   // Add current user message
@@ -65,19 +107,24 @@ export async function callAnthropic(
         { model, max_tokens: 4096, system: systemPrompt, messages, tools },
         { headers, timeout: 120000 }
       );
-    } catch (error: any) {
-      console.error("Anthropic API Error:", error.response?.data?.error?.message || error.message);
-      throw new Error(`Anthropic API error: ${error.response?.data?.error?.message || error.message}`);
+    } catch (error: unknown) {
+      const axiosErr = error as { response?: { data?: { error?: { message?: string } } }; message?: string };
+      console.error("Anthropic API Error:", axiosErr.response?.data?.error?.message || axiosErr.message);
+      throw new Error(`Anthropic API error: ${axiosErr.response?.data?.error?.message || axiosErr.message}`);
     }
 
-    const content = response.data.content;
+    const content = response.data.content as AnthropicContentBlock[];
 
     // Check if there are tool uses
-    const toolUses = content.filter((block: any) => block.type === "tool_use");
+    const toolUses = content.filter(
+      (block): block is AnthropicToolUseBlock => block.type === "tool_use"
+    );
 
     if (toolUses.length === 0) {
       // No tool calls — return text response
-      const textContent = content.find((block: any) => block.type === "text");
+      const textContent = content.find(
+        (block): block is AnthropicTextBlock => block.type === "text"
+      );
       return {
         message: textContent?.text || "No response from Claude",
         provider: LLMProvider.ANTHROPIC,
@@ -93,14 +140,14 @@ export async function callAnthropic(
     });
 
     // Execute tool calls and build tool results
-    const toolResults = await Promise.all(
-      toolUses.map(async (toolUse: any) => {
+    const toolResults: AnthropicToolResultBlock[] = await Promise.all(
+      toolUses.map(async (toolUse: AnthropicToolUseBlock) => {
         const result = await brokerClient.executeTool({
           name: toolUse.name,
-          arguments: toolUse.input,
+          arguments: toolUse.input as Record<string, import("../types/index.js").JsonValue>,
         });
         return {
-          type: "tool_result",
+          type: "tool_result" as const,
           tool_use_id: toolUse.id,
           content: serializeToolResult(result),
         };
@@ -121,8 +168,8 @@ export async function callAnthropic(
     { headers, timeout: 120000 }
   );
 
-  const finalContent = finalResponse.data.content.find(
-    (block: any) => block.type === "text"
+  const finalContent = (finalResponse.data.content as AnthropicContentBlock[]).find(
+    (block): block is AnthropicTextBlock => block.type === "text"
   );
 
   return {

--- a/llm-bridge/src/providers/copilot.ts
+++ b/llm-bridge/src/providers/copilot.ts
@@ -4,10 +4,19 @@ import { LLMProvider } from "../types/index.js";
 import { BrokerClient } from "../brokerClient.js";
 import { serializeToolResult } from "./truncate.js";
 
+interface CopilotToolCall {
+  id: string;
+  type: string;
+  function: {
+    name: string;
+    arguments: string;
+  };
+}
+
 interface CopilotMessage {
   role: string;
   content: string | null;
-  tool_calls?: any[];
+  tool_calls?: CopilotToolCall[];
   tool_call_id?: string;
   name?: string;
 }
@@ -69,9 +78,10 @@ export async function callCopilot(
         { model, messages, tools, tool_choice: "auto" },
         { headers, timeout: 120000 }
       );
-    } catch (error: any) {
-      console.error("Copilot API Error:", error.response?.data?.error?.message || error.message);
-      throw new Error(`Copilot API error: ${error.response?.data?.error?.message || error.message}`);
+    } catch (error: unknown) {
+      const axiosErr = error as { response?: { data?: { error?: { message?: string } } }; message?: string };
+      console.error("Copilot API Error:", axiosErr.response?.data?.error?.message || axiosErr.message);
+      throw new Error(`Copilot API error: ${axiosErr.response?.data?.error?.message || axiosErr.message}`);
     }
 
     const choice = response.data.choices[0];
@@ -96,10 +106,10 @@ export async function callCopilot(
 
     // Execute tool calls and append results
     const toolResults = await Promise.all(
-      message.tool_calls.map(async (toolCall: any) => {
-        let parsedArgs: Record<string, any>;
+      (message.tool_calls as CopilotToolCall[]).map(async (toolCall: CopilotToolCall) => {
+        let parsedArgs: Record<string, unknown>;
         try {
-          parsedArgs = JSON.parse(toolCall.function.arguments);
+          parsedArgs = JSON.parse(toolCall.function.arguments) as Record<string, unknown>;
         } catch {
           return {
             tool_call_id: toolCall.id,
@@ -111,7 +121,7 @@ export async function callCopilot(
 
         const result = await brokerClient.executeTool({
           name: toolCall.function.name,
-          arguments: parsedArgs,
+          arguments: parsedArgs as Record<string, import("../types/index.js").JsonValue>,
         });
 
         return {

--- a/llm-bridge/src/providers/gemini.ts
+++ b/llm-bridge/src/providers/gemini.ts
@@ -4,6 +4,33 @@ import { LLMProvider } from "../types/index.js";
 import { BrokerClient } from "../brokerClient.js";
 import { serializeToolResult } from "./truncate.js";
 
+interface GeminiFunctionCall {
+  name: string;
+  args: Record<string, unknown>;
+}
+
+interface GeminiTextPart {
+  text: string;
+}
+
+interface GeminiFunctionCallPart {
+  functionCall: GeminiFunctionCall;
+}
+
+interface GeminiFunctionResponsePart {
+  functionResponse: {
+    name: string;
+    response: unknown;
+  };
+}
+
+type GeminiPart = GeminiTextPart | GeminiFunctionCallPart | GeminiFunctionResponsePart;
+
+interface GeminiContent {
+  role: string;
+  parts: GeminiPart[];
+}
+
 const MAX_TOOL_ROUNDS = 10;
 
 export async function callGemini(
@@ -28,7 +55,7 @@ export async function callGemini(
   }));
 
   // Build contents with history
-  const contents: any[] = [];
+  const contents: GeminiContent[] = [];
 
   // Add conversation history if provided
   if (request.history && request.history.length > 0) {
@@ -66,22 +93,25 @@ export async function callGemini(
         },
         { headers, timeout: 120000 }
       );
-    } catch (error: any) {
-      console.error("Gemini API Error:", error.response?.data?.error?.message || error.message);
-      throw new Error(`Gemini API error: ${error.response?.data?.error?.message || error.message}`);
+    } catch (error: unknown) {
+      const axiosErr = error as { response?: { data?: { error?: { message?: string } } }; message?: string };
+      console.error("Gemini API Error:", axiosErr.response?.data?.error?.message || axiosErr.message);
+      throw new Error(`Gemini API error: ${axiosErr.response?.data?.error?.message || axiosErr.message}`);
     }
 
     const candidate = response.data.candidates[0];
-    const content = candidate.content;
+    const content = candidate.content as GeminiContent;
 
     // Check for function calls
     const functionCalls = content.parts.filter(
-      (part: any) => part.functionCall
+      (part): part is GeminiFunctionCallPart => "functionCall" in part
     );
 
     if (functionCalls.length === 0) {
       // No function calls — return text response
-      const textPart = content.parts.find((part: any) => part.text);
+      const textPart = content.parts.find(
+        (part): part is GeminiTextPart => "text" in part
+      );
       return {
         message: textPart?.text || "No response from Gemini",
         provider: LLMProvider.GEMINI,
@@ -97,11 +127,11 @@ export async function callGemini(
     });
 
     // Execute function calls and build responses
-    const functionResponses = await Promise.all(
-      functionCalls.map(async (part: any) => {
+    const functionResponses: GeminiFunctionResponsePart[] = await Promise.all(
+      functionCalls.map(async (part: GeminiFunctionCallPart) => {
         const result = await brokerClient.executeTool({
           name: part.functionCall.name,
-          arguments: part.functionCall.args,
+          arguments: part.functionCall.args as Record<string, import("../types/index.js").JsonValue>,
         });
         return {
           functionResponse: {
@@ -133,8 +163,8 @@ export async function callGemini(
   );
 
   const finalCandidate = finalResponse.data.candidates[0];
-  const textPart = finalCandidate.content.parts.find(
-    (part: any) => part.text
+  const textPart = (finalCandidate.content as GeminiContent).parts.find(
+    (part): part is GeminiTextPart => "text" in part
   );
 
   return {

--- a/llm-bridge/src/providers/openai.ts
+++ b/llm-bridge/src/providers/openai.ts
@@ -4,10 +4,19 @@ import { LLMProvider } from "../types/index.js";
 import { BrokerClient } from "../brokerClient.js";
 import { serializeToolResult } from "./truncate.js";
 
+interface OpenAIToolCall {
+  id: string;
+  type: string;
+  function: {
+    name: string;
+    arguments: string;
+  };
+}
+
 interface OpenAIMessage {
   role: string;
   content: string | null;
-  tool_calls?: any[];
+  tool_calls?: OpenAIToolCall[];
   tool_call_id?: string;
   name?: string;
 }
@@ -17,7 +26,7 @@ interface OpenAITool {
   function: {
     name: string;
     description: string;
-    parameters: any;
+    parameters: object;
   };
 }
 
@@ -77,9 +86,10 @@ export async function callOpenAI(
         { model, messages, tools, tool_choice: "auto" },
         { headers, timeout: 120000 }
       );
-    } catch (error: any) {
-      console.error("OpenAI API Error:", error.response?.data || error.message);
-      throw new Error(`OpenAI API error: ${error.response?.data?.error?.message || error.message}`);
+    } catch (error: unknown) {
+      const axiosErr = error as { response?: { data?: { error?: { message?: string } } }; message?: string };
+      console.error("OpenAI API Error:", axiosErr.response?.data || axiosErr.message);
+      throw new Error(`OpenAI API error: ${axiosErr.response?.data?.error?.message || axiosErr.message}`);
     }
 
     const choice = response.data.choices[0];
@@ -104,10 +114,10 @@ export async function callOpenAI(
 
     // Execute tool calls and append results
     const toolResults = await Promise.all(
-      message.tool_calls.map(async (toolCall: any) => {
-        let parsedArgs: Record<string, any>;
+      (message.tool_calls as OpenAIToolCall[]).map(async (toolCall: OpenAIToolCall) => {
+        let parsedArgs: Record<string, unknown>;
         try {
-          parsedArgs = JSON.parse(toolCall.function.arguments);
+          parsedArgs = JSON.parse(toolCall.function.arguments) as Record<string, unknown>;
         } catch {
           return {
             tool_call_id: toolCall.id,
@@ -119,7 +129,7 @@ export async function callOpenAI(
 
         const result = await brokerClient.executeTool({
           name: toolCall.function.name,
-          arguments: parsedArgs,
+          arguments: parsedArgs as Record<string, import("../types/index.js").JsonValue>,
         });
 
         return {

--- a/llm-bridge/src/types/index.ts
+++ b/llm-bridge/src/types/index.ts
@@ -41,12 +41,36 @@ export interface ErrorResponse {
 }
 
 // Broker API tool definitions
+
+/** JSON-serialisable scalar values */
+export type JsonScalar = string | number | boolean | null;
+
+/** Recursive JSON value type */
+export type JsonValue =
+  | JsonScalar
+  | JsonValue[]
+  | { [key: string]: JsonValue };
+
 export interface ToolCall {
   name: string;
-  arguments: Record<string, any>;
+  arguments: Record<string, JsonValue>;
 }
 
 export interface ToolResult {
-  data: any;
+  data: JsonValue | object;
   error?: string;
+}
+
+/** JSON Schema object describing tool parameters */
+export interface JsonSchemaObject {
+  type: "object";
+  properties: Record<string, { type: string; description?: string }>;
+  required: string[];
+}
+
+/** Tool definition used when building provider request payloads */
+export interface ToolDefinition {
+  name: string;
+  description: string;
+  parameters: JsonSchemaObject;
 }

--- a/mcp-server/main.go
+++ b/mcp-server/main.go
@@ -3,8 +3,10 @@ package main
 import (
 	"context"
 	"net/http"
+	"net/url"
 	"os"
 	"os/signal"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -25,7 +27,12 @@ func main() {
 	// Get configuration from environment
 	brokerURL := os.Getenv("BROKER_URL")
 	if brokerURL == "" {
-		brokerURL = "http://kguardian-broker.kguardian.svc.cluster.local:9090"
+		logger.Log.Error("BROKER_URL environment variable is required but not set")
+		os.Exit(1)
+	}
+	if _, err := url.Parse(brokerURL); err != nil {
+		logger.Log.WithField("broker_url", brokerURL).WithError(err).Error("BROKER_URL is not a valid URL")
+		os.Exit(1)
 	}
 
 	port := os.Getenv("PORT")
@@ -38,6 +45,14 @@ func main() {
 		"broker_url": brokerURL,
 		"log_level":  logLevel,
 	}).Info("Initializing kguardian MCP server")
+
+	// shuttingDown is set to 1 when a shutdown signal is received so that the
+	// health endpoint can start returning 503 before the server drains.
+	var shuttingDown atomic.Bool
+
+	// Server lifecycle context — cancelled when shutdown begins.
+	_, serverCancel := context.WithCancel(context.Background())
+	defer serverCancel()
 
 	// Create MCP server
 	server := mcp.NewServer(
@@ -59,6 +74,13 @@ func main() {
 	// Wrap in ServeMux to add health endpoint for Kubernetes probes
 	mux := http.NewServeMux()
 	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
+		if shuttingDown.Load() {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			if _, err := w.Write([]byte("shutting down")); err != nil {
+				logger.Log.Errorf("health write: %v", err)
+			}
+			return
+		}
 		w.WriteHeader(http.StatusOK)
 		if _, err := w.Write([]byte("ok")); err != nil {
 			logger.Log.Errorf("health write: %v", err)
@@ -95,11 +117,15 @@ func main() {
 
 	logger.Log.WithField("signal", sig.String()).Info("Received shutdown signal")
 
-	// Graceful shutdown
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
+	// Signal health endpoint to return 503 and cancel the server lifecycle context.
+	shuttingDown.Store(true)
+	serverCancel()
 
-	if err := httpServer.Shutdown(ctx); err != nil {
+	// Graceful shutdown with a 10-second timeout.
+	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer shutdownCancel()
+
+	if err := httpServer.Shutdown(shutdownCtx); err != nil {
 		logger.Log.WithField("error", err.Error()).Error("Server forced to shutdown")
 	}
 

--- a/mcp-server/tools/broker_client.go
+++ b/mcp-server/tools/broker_client.go
@@ -27,7 +27,12 @@ func NewBrokerClient(baseURL string) *BrokerClient {
 	return &BrokerClient{
 		baseURL: baseURL,
 		httpClient: &http.Client{
-			Timeout: 90 * time.Second, // Allow enough time for cluster-wide queries
+			Transport: &http.Transport{
+				MaxIdleConns:        50,
+				MaxIdleConnsPerHost: 50,
+				IdleConnTimeout:     90 * time.Second,
+			},
+			Timeout: 30 * time.Second,
 		},
 	}
 }

--- a/mcp-server/tools/cluster_pods.go
+++ b/mcp-server/tools/cluster_pods.go
@@ -35,6 +35,16 @@ func (h ClusterPodsHandler) Call(
 	startTime := time.Now()
 	logger.Log.WithField("namespace", input.Namespace).Info("Received get_cluster_pods request")
 
+	if input.Namespace != "" {
+		if err := ValidateNamespace(input.Namespace); err != nil {
+			logger.Log.WithField("namespace", input.Namespace).Error("Invalid namespace parameter")
+			return &mcp.CallToolResult{
+				Content: []mcp.Content{&mcp.TextContent{Text: fmt.Sprintf("invalid namespace: %v", err)}},
+				IsError: true,
+			}, ClusterPodsOutput{}, nil
+		}
+	}
+
 	data, err := h.client.GetAllPods(ctx)
 	if err != nil {
 		logger.Log.WithFields(logrus.Fields{

--- a/mcp-server/tools/cluster_traffic.go
+++ b/mcp-server/tools/cluster_traffic.go
@@ -35,6 +35,16 @@ func (h ClusterTrafficHandler) Call(
 	startTime := time.Now()
 	logger.Log.WithField("namespace", input.Namespace).Info("Received get_cluster_traffic request")
 
+	if input.Namespace != "" {
+		if err := ValidateNamespace(input.Namespace); err != nil {
+			logger.Log.WithField("namespace", input.Namespace).Error("Invalid namespace parameter")
+			return &mcp.CallToolResult{
+				Content: []mcp.Content{&mcp.TextContent{Text: fmt.Sprintf("invalid namespace: %v", err)}},
+				IsError: true,
+			}, ClusterTrafficOutput{}, nil
+		}
+	}
+
 	fetchStart := time.Now()
 	data, err := h.client.GetAllPodTraffic(ctx)
 	fetchDuration := time.Since(fetchStart)

--- a/mcp-server/tools/network_traffic.go
+++ b/mcp-server/tools/network_traffic.go
@@ -13,7 +13,8 @@ import (
 
 // NetworkTrafficInput defines the input parameters for the network traffic tool
 type NetworkTrafficInput struct {
-	PodName string `json:"pod_name" jsonschema:"The name of the pod to query traffic for"`
+	PodName   string `json:"pod_name" jsonschema:"The name of the pod to query traffic for"`
+	Namespace string `json:"namespace,omitempty" jsonschema:"Optional Kubernetes namespace the pod belongs to"`
 }
 
 // NetworkTrafficOutput defines the output for the network traffic tool
@@ -41,6 +42,24 @@ func (h NetworkTrafficHandler) Call(
 			Content: []mcp.Content{&mcp.TextContent{Text: "pod_name is required"}},
 			IsError: true,
 		}, NetworkTrafficOutput{}, nil
+	}
+
+	if err := ValidatePodName(input.PodName); err != nil {
+		logger.Log.WithField("pod_name", input.PodName).Error("Invalid pod_name parameter")
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{&mcp.TextContent{Text: fmt.Sprintf("invalid pod_name: %v", err)}},
+			IsError: true,
+		}, NetworkTrafficOutput{}, nil
+	}
+
+	if input.Namespace != "" {
+		if err := ValidateNamespace(input.Namespace); err != nil {
+			logger.Log.WithField("namespace", input.Namespace).Error("Invalid namespace parameter")
+			return &mcp.CallToolResult{
+				Content: []mcp.Content{&mcp.TextContent{Text: fmt.Sprintf("invalid namespace: %v", err)}},
+				IsError: true,
+			}, NetworkTrafficOutput{}, nil
+		}
 	}
 
 	// Fetch data from broker

--- a/mcp-server/tools/pod_details.go
+++ b/mcp-server/tools/pod_details.go
@@ -43,6 +43,14 @@ func (h PodDetailsHandler) Call(
 		}, PodDetailsOutput{}, nil
 	}
 
+	if err := ValidateIP(input.IP); err != nil {
+		logger.Log.WithField("ip", input.IP).Error("Invalid IP address parameter")
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{&mcp.TextContent{Text: fmt.Sprintf("invalid ip: %v", err)}},
+			IsError: true,
+		}, PodDetailsOutput{}, nil
+	}
+
 	data, err := h.client.GetPodByIP(ctx, input.IP)
 	if err != nil {
 		logger.Log.WithFields(logrus.Fields{

--- a/mcp-server/tools/service_details.go
+++ b/mcp-server/tools/service_details.go
@@ -43,6 +43,14 @@ func (h ServiceDetailsHandler) Call(
 		}, ServiceDetailsOutput{}, nil
 	}
 
+	if err := ValidateIP(input.IP); err != nil {
+		logger.Log.WithField("ip", input.IP).Error("Invalid IP address parameter")
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{&mcp.TextContent{Text: fmt.Sprintf("invalid ip: %v", err)}},
+			IsError: true,
+		}, ServiceDetailsOutput{}, nil
+	}
+
 	data, err := h.client.GetServiceByIP(ctx, input.IP)
 	if err != nil {
 		logger.Log.WithFields(logrus.Fields{

--- a/mcp-server/tools/syscalls.go
+++ b/mcp-server/tools/syscalls.go
@@ -13,7 +13,8 @@ import (
 
 // SyscallsInput defines the input parameters for the syscalls tool
 type SyscallsInput struct {
-	PodName string `json:"pod_name" jsonschema:"The name of the pod to query syscalls for"`
+	PodName   string `json:"pod_name" jsonschema:"The name of the pod to query syscalls for"`
+	Namespace string `json:"namespace,omitempty" jsonschema:"Optional Kubernetes namespace the pod belongs to"`
 }
 
 // SyscallsOutput defines the output for the syscalls tool
@@ -41,6 +42,24 @@ func (h SyscallsHandler) Call(
 			Content: []mcp.Content{&mcp.TextContent{Text: "pod_name is required"}},
 			IsError: true,
 		}, SyscallsOutput{}, nil
+	}
+
+	if err := ValidatePodName(input.PodName); err != nil {
+		logger.Log.WithField("pod_name", input.PodName).Error("Invalid pod_name parameter")
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{&mcp.TextContent{Text: fmt.Sprintf("invalid pod_name: %v", err)}},
+			IsError: true,
+		}, SyscallsOutput{}, nil
+	}
+
+	if input.Namespace != "" {
+		if err := ValidateNamespace(input.Namespace); err != nil {
+			logger.Log.WithField("namespace", input.Namespace).Error("Invalid namespace parameter")
+			return &mcp.CallToolResult{
+				Content: []mcp.Content{&mcp.TextContent{Text: fmt.Sprintf("invalid namespace: %v", err)}},
+				IsError: true,
+			}, SyscallsOutput{}, nil
+		}
 	}
 
 	// Fetch data from broker

--- a/mcp-server/tools/validate.go
+++ b/mcp-server/tools/validate.go
@@ -1,0 +1,58 @@
+package tools
+
+import (
+	"fmt"
+	"net"
+	"regexp"
+)
+
+// podNameRegexp matches RFC 1123 DNS subdomain names used for pod names.
+// Allows lowercase alphanumeric characters, '-', and '.', must start and end
+// with an alphanumeric character.
+var podNameRegexp = regexp.MustCompile(`^[a-z0-9]([a-z0-9.\-]*[a-z0-9])?$`)
+
+// namespaceRegexp matches RFC 1123 DNS label names used for namespaces.
+// Allows lowercase alphanumeric characters and '-', must start and end with
+// an alphanumeric character.
+var namespaceRegexp = regexp.MustCompile(`^[a-z0-9]([a-z0-9\-]*[a-z0-9])?$`)
+
+// ValidatePodName validates a Kubernetes pod name against RFC 1123 DNS subdomain
+// rules: lowercase alphanumeric, '-', and '.'; max 253 characters.
+func ValidatePodName(name string) error {
+	if len(name) == 0 {
+		return fmt.Errorf("pod name must not be empty")
+	}
+	if len(name) > 253 {
+		return fmt.Errorf("pod name %q exceeds maximum length of 253 characters", name)
+	}
+	if !podNameRegexp.MatchString(name) {
+		return fmt.Errorf("pod name %q is invalid: must match %s", name, podNameRegexp.String())
+	}
+	return nil
+}
+
+// ValidateNamespace validates a Kubernetes namespace name against RFC 1123 DNS
+// label rules: lowercase alphanumeric and '-'; max 63 characters.
+func ValidateNamespace(ns string) error {
+	if len(ns) == 0 {
+		return fmt.Errorf("namespace must not be empty")
+	}
+	if len(ns) > 63 {
+		return fmt.Errorf("namespace %q exceeds maximum length of 63 characters", ns)
+	}
+	if !namespaceRegexp.MatchString(ns) {
+		return fmt.Errorf("namespace %q is invalid: must match %s", ns, namespaceRegexp.String())
+	}
+	return nil
+}
+
+// ValidateIP validates that the given string is a valid IP address (v4 or v6).
+func ValidateIP(ip string) error {
+	if len(ip) == 0 {
+		return fmt.Errorf("IP address must not be empty")
+	}
+	if net.ParseIP(ip) == nil {
+		return fmt.Errorf("IP address %q is invalid", ip)
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary

Implements all P0 (critical), P1 (this sprint), and P2 (next release) findings from the multi-component codebase audit covering all 7 kguardian components. **68 files changed, 1710 insertions, 958 deletions.**

### Security Fixes (P0)
- **Broker**: API key authentication middleware (`X-API-Key`), CORS restriction to configured origins
- **Broker**: Data model validation — reject requests with missing required fields (400)
- **Frontend**: Updated axios (CVE-2025-62718 SSRF, CVSS 9.3) and vite (path traversal)
- **LLM Bridge**: Updated deps to fix 10+ high-severity hono, path-to-regexp, qs, axios CVEs

### Bug & Stability Fixes (P1)
- **Broker**: Replace `.expect()` panics with structured error handling; add input validation (RFC 1123), 1MB body limits, performance indexes
- **Controller**: Fix unsafe `.unwrap()` on K8s API data; replace `Mutex<HashSet>` with `DashSet`; migrate to `LazyLock`
- **Advisor**: Context cancellation for goroutines; handle `fmt.Sscanf` errors; sentinel error types with shared HTTP client
- **LLM Bridge**: CORS defaults to `localhost:3000`; error responses don't leak provider config
- **MCP Server**: Input validation on all tool handlers; graceful shutdown with signal handling
- **Helm**: Controller health probes, pinned images (no `latest` tags), broker NetworkPolicy, documented RBAC

### Performance & UX Improvements (P2)
- **Broker**: Proper HTTP status codes (409/400/503), JSON health check, connection pool config, transactional batch inserts
- **Controller**: 5-min cache TTL, configurable channel buffers, reduced ring buffer poll latency (100ms → 20ms)
- **Advisor**: Actionable CLI error messages with kubectl remediation, improved flag help text
- **LLM Bridge**: Zero `any` types (full type safety), configurable rate limits (default 60/min)
- **MCP Server**: Required `BROKER_URL` with validation, HTTP connection pooling
- **Helm**: DB persistence warnings, frontend `readOnlyRootFilesystem`, `existingSecret` support, pinned CI tools
- **Frontend**: ARIA accessibility on DataTable, loading skeleton for graph layout, user-friendly error messages

## Validation
- [x] Frontend: `tsc --noEmit` + `npm run build` pass
- [x] Broker: `cargo check` passes
- [x] Controller: Rust code compiles (eBPF link is env-dependent)
- [x] Advisor: `go build` + `go vet` + `go test` (30/30 tests pass)
- [x] LLM Bridge: `npm run build` passes
- [x] MCP Server: `go build` + `go vet` pass
- [x] Helm: YAML validated

## Test plan
- [ ] Verify broker starts with `API_KEY` set and rejects unauthenticated requests
- [ ] Verify broker returns 400 for invalid pod names/IPs
- [ ] Verify frontend shows error state when broker is unreachable
- [ ] Verify MCP server refuses to start without `BROKER_URL`
- [ ] Verify controller DaemonSet picks up health probes when enabled
- [ ] Verify LLM bridge CORS blocks non-localhost origins by default
- [ ] Run full CI pipeline