### PR TITLE
docs: tier 2 — dedupe README ↔ docs, add docs map, adopt Falco intro pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,27 @@
 
 kguardian watches pod traffic and syscalls with eBPF, then writes Kubernetes NetworkPolicies, CiliumNetworkPolicies, and seccomp profiles from what it sees — no hand-authored rules.
 
+## What is kguardian?
+
+A Kubernetes runtime-observability tool that turns the network and syscall behavior of your pods into the policy YAML you would otherwise have to write by hand.
+
+## What does it do?
+
+The Controller (eBPF DaemonSet) captures every TCP/UDP connection and syscall on each node. The Broker stores the per-pod baseline in PostgreSQL. The `kubectl kguardian` plugin queries that baseline and synthesizes a least-privilege policy for the pod, namespace, or whole cluster you ask about.
+
+## What does it generate?
+
+For each target you select, kguardian emits:
+
+- a Kubernetes [`NetworkPolicy`](docs/policy-gallery/) YAML,
+- a Cilium [`CiliumNetworkPolicy`](docs/policy-gallery/) YAML (for Cilium CNI users),
+- a [seccomp](docs/policy-gallery/) JSON profile.
+
+Worked examples for nginx, Postgres, kube-dns, Prometheus, an Istio sidecar, and a Go microservice are in the [Generated Policy Gallery](docs/policy-gallery/).
+
 ## Distro Compatibility
 
-kguardian's eBPF controller requires Linux kernel **6.2 or newer** on every node that runs the DaemonSet. Verify with `uname -r` per node before installing.
+kguardian's eBPF Controller requires Linux kernel **6.2 or newer** on every node that runs the DaemonSet. Verify with `uname -r` per node before installing.
 
 | Distro | Default kernel | Compatible? |
 |---|---|---|
@@ -35,30 +53,7 @@ Kernel versions reflect the GA/server defaults shipped by each distro as of May 
 
 ## Comparison with Other Tools
 
-This table is a high-level comparison of kguardian with other open-source Kubernetes security tools. The landscape moves quickly; features may change.
-
-| Feature                       | kguardian                         | Inspektor Gadget                   | Security Profiles Operator (SPO) |
-| :---------------------------- | :-------------------------------- | :--------------------------------- | :------------------------------- |
-| **Network Policy (K8s)**      | ✅                                | ✅ (Network Policy Advisor)        | ❌                               |
-| **Network Policy (Cilium)**   | ✅                                | ❌                                 | ❌                               |
-| **Seccomp Profile Generation**| ✅                                | 📝 (Provides syscall trace data)   | ✅ (Via Log Enricher/Recorder)   |
-| **AppArmor Profile Mgmt**     | ❌                                | ❌                                 | ✅                               |
-| **SELinux Profile Mgmt**      | ❌                                | ❌                                 | ✅                               |
-| **Data Source**               | kguardian Controller (eBPF)       | eBPF                               | Seccomp Logs / BPF Recorder      |
-| **Operational Model**         | Client CLI + Server Controller    | Client CLI + Server Gadgets        | Server Operator + CRDs           |
-| **Dry Run / Preview**         | ✅ (NetPol)                       | ✅ (YAML output for advisor)       | N/A                              |
-| **Save to File**              | ✅ (NetPol, Seccomp)              | ✅ (YAML output for advisor)       | N/A (Uses CRDs)                  |
-| **Direct Apply (NetPol)**     | ✅                                | ❌                                 | N/A                              |
-| **Direct Apply (Seccomp)**    | ❌                                | ❌                                 | ✅                               |
-
-*Legend: ✅ = Supported, ❌ = Not Supported, 📝 = Partial/Requires Manual Steps, N/A = Not Applicable*
-
-**Note on Operational Models:** kguardian and Inspektor Gadget use client CLIs that interact with dedicated server-side components (Controller/Gadgets) primarily for data retrieval. SPO operates as a full Kubernetes operator managing security profiles via Custom Resource Definitions (CRDs).
-
-**Where kguardian fits:**
-- One data source produces both Kubernetes-native and Cilium NetworkPolicies plus seccomp profiles.
-- Apply directly (NetworkPolicy) or save YAML for GitOps review.
-- Optional LLM bridge for natural-language queries against the observed traffic/syscall data.
+How kguardian compares to Inspektor Gadget and Security Profiles Operator (NetworkPolicy support, seccomp generation, operational model, …): see the [feature comparison table](https://docs.kguardian.dev/#comparison-with-other-tools) on the docs site.
 
 ## Performance
 
@@ -72,68 +67,27 @@ _Numbers are TODO — pending benchmark on a reference cluster._
 
 ## Prerequisites
 
-- Linux Kernel 6.2+ on every node running the controller DaemonSet
+- Linux Kernel 6.2+ on every node running the Controller DaemonSet
 - Kubernetes cluster v1.19+
 - `kubectl` v1.19+
-- kguardian Controller **MUST** be installed and running in the cluster to collect the necessary data
+- The Controller **MUST** be installed and running in the cluster to collect the necessary data
 - (For Seccomp) Linux Kernel supporting seccomp (most modern kernels)
 
 ## Installation
 
-### Install the Controller Components
-
-Before using the CLI, install the kguardian controller, broker, and UI in your cluster:
+Install the Controller, Broker, and UI into your cluster, then install the `kubectl` plugin:
 
 ```bash
-# Install from OCI registry (recommended)
 helm install kguardian oci://ghcr.io/kguardian-dev/charts/kguardian \
-  --version 1.9.1 \
-  --namespace kguardian \
-  --create-namespace
-```
-
-For detailed installation options and configuration, see the [Installation Guide](https://docs.kguardian.dev/installation).
-
-### Install the CLI Plugin
-
-Choose one of the following methods:
-
-#### Quick Install Script (Recommended)
-
-This script downloads the latest release binary and attempts to install it.
-
-```bash
+  --version 1.9.1 --namespace kguardian --create-namespace
 sh -c "$(curl -fsSL https://raw.githubusercontent.com/kguardian-dev/kguardian/main/scripts/quick-install.sh)"
 ```
 
-#### Krew
-
-Use [Krew](https://krew.sigs.k8s.io/), the plugin manager for `kubectl`:
-
-```bash
-# Ensure Krew is installed: https://krew.sigs.k8s.io/docs/user-guide/setup/install/
-kubectl krew install kguardian
-```
-
-#### Manual Download
-
-Download the appropriate binary for your system from the [Releases page](https://github.com/kguardian-dev/kguardian/releases) and place it in your `PATH` named `kubectl-kguardian`.
-
-Example (Linux AMD64, replace version/binary name as needed):
-
-```bash
-# Replace with the correct release URL
-wget -O kguardian https://github.com/kguardian-dev/kguardian/releases/download/vX.Y.Z/kguardian-linux-amd64
-chmod +x kguardian
-sudo mv kguardian /usr/local/bin/kubectl-kguardian
-
-# Verify installation
-kubectl kguardian --help
-```
+Krew, manual download, custom Helm values, Kind setup, verification, upgrades, and uninstall are all covered in the [Installation Guide](https://docs.kguardian.dev/installation).
 
 ## Quick Start
 
-Once the kguardian controller is running and collecting data, you can generate policies. For curated examples of what the generator produces against representative workloads (nginx, Postgres, kube-dns, Prometheus, Istio sidecar, Go microservice), see the [Generated Policy Gallery](docs/policy-gallery/).
+Once the Controller is running and collecting data, you can generate policies. For curated examples of what the generator produces against representative workloads (nginx, Postgres, kube-dns, Prometheus, Istio sidecar, Go microservice), see the [Generated Policy Gallery](docs/policy-gallery/).
 
 1.  **Generate a Network Policy (Dry Run, Save to File):**
 

--- a/STYLE.md
+++ b/STYLE.md
@@ -1,0 +1,68 @@
+# kguardian Style Guide
+
+This document defines naming, terminology, and tone conventions used in kguardian's documentation, READMEs, and any user-facing copy. Apply it when adding or revising content. Tier-2 docs cleanup (PR `tier2-structure`) introduced this file; future tiers reference it instead of relitigating these rules.
+
+## Naming
+
+### Product name
+
+The product name is `kguardian` — lowercase, always. That includes the start of a sentence ("kguardian watches pod traffic …"), titles, frontmatter, and headings. Never `KGuardian`, `Kguardian`, `KGUARDIAN`, or `K-Guardian`.
+
+Use `kguardian` (the package/system) when speaking about the project as a whole. Use a component noun (below) when you mean a specific binary or service.
+
+### Component nouns
+
+The system has three named components. When referring to the specific kguardian component, capitalize as proper nouns:
+
+- **Controller** — the eBPF DaemonSet that captures pod traffic and syscalls.
+- **Broker** — the Rust + Actix-web service that stores observed behavior in PostgreSQL and serves it back over an HTTP API.
+- **UI** — the React + TypeScript frontend that visualises pod-to-pod traffic.
+
+When the same words appear generically (a controller in another tool, the broker pattern, a ui), keep them lowercase.
+
+Avoid the awkward "kguardian Controller" form — within kguardian's own README and docs, "the Controller" is unambiguous. Reach for the qualified form ("kguardian's Controller") only when the surrounding text is comparing kguardian to other projects, where the bare proper noun could be mistaken for someone else's component.
+
+### Binary and CLI
+
+- The binary on disk is `kubectl-kguardian`. Use this exact spelling **only** when literally referring to the file (install instructions, `mv` targets, `which` output).
+- The CLI is invoked as `kubectl kguardian <subcommand>` — no hyphen, space-separated, written in `code` font.
+- Do not write `kguardian-cli`. It is not a binary, command, or package name and never has been.
+
+### Generated artefact names
+
+- Capitalise Kubernetes API kinds when referring to the resource: `NetworkPolicy`, `CiliumNetworkPolicy`, `CiliumClusterwideNetworkPolicy`, `SeccompProfile`.
+- Use lowercase plain-English when speaking about the concept: "a network policy", "the seccomp profile JSON", "a Cilium policy".
+
+## Tone
+
+- **Specific over fluff.** Prefer concrete numbers, kernel versions, and command examples. A docs sentence with a kernel version, a Helm version, and a kubectl flag in it is almost always stronger than one without.
+- **No emoji in headings.** Emoji is fine in feature-comparison tables, badges, and inline status markers (`✅`, `❌`, `🔜`). Headings stay text-only.
+- **Banned marketing words.** The following do not appear in user-facing copy:
+  - "made simple"
+  - "tailored"
+  - "zero-trust" (we mean default-deny — say that)
+  - "powerful"
+  - "next-generation", "cutting-edge", "world-class"
+  - "say goodbye to …"
+  - "hello to …"
+- **No unqualified "real-time".** kguardian's UI polls the Broker (~5 second cadence). When describing this, write "live view (polled, ~5s)" or simply "polled". Reserve "real-time" for sub-second push paths kguardian does not currently have.
+
+## Versioning and links
+
+- Pin Helm chart versions in copy-paste install snippets so they do not drift behind newer releases. The Tier-1 baseline is `1.9.1`; bump in lockstep with chart releases.
+- Internal docs links are repo-relative (`/installation`, `/quickstart`, `/architecture`). External links use full URLs.
+- Cross-link rather than duplicate. If the same install snippet, comparison table, or "what is kguardian?" pitch already lives somewhere canonical, link to it instead of copy-pasting.
+
+## Canonical sources for repeated content
+
+When the same content would otherwise appear in multiple places, this is the canonical home and everything else links to it:
+
+| Topic | Canonical source |
+|---|---|
+| "What is kguardian?" pitch | `README.md` lede (line 10) — used verbatim in `docs/index.mdx` and `docs/concepts/overview.mdx` |
+| Feature comparison table | `docs/index.mdx` `## Comparison with Other Tools` |
+| Install snippets (Helm, Krew, manual, Kind, custom values) | `docs/installation.mdx` |
+| Quickstart-flow install (one Helm command + link) | `docs/quickstart.mdx` Step 1 |
+| Generated policy examples | `docs/policy-gallery/` |
+
+If a future change makes one of those locations no longer canonical, update this table in the same PR.

--- a/docs/architecture.mdx
+++ b/docs/architecture.mdx
@@ -151,7 +151,7 @@ graph TB
 
     - An interactive graph of pod-to-pod communication (React Flow)
     - Tables of traffic details with filtering
-    - Real-time updates as new data arrives
+    - Live view (polled, ~5s) — the UI re-fetches from the Broker on a short interval
   </Step>
 </Steps>
 
@@ -260,7 +260,7 @@ graph TB
   <Accordion icon="table" title="Data Display">
     - Traffic table with sorting and pagination
     - Pod details panel with labels and metadata
-    - Real-time updates via polling the Broker API
+    - Live view (polled, ~5s) via the Broker API
     - Dark mode support (matches Cilium Hubble aesthetic)
   </Accordion>
 </AccordionGroup>

--- a/docs/concepts/overview.mdx
+++ b/docs/concepts/overview.mdx
@@ -6,7 +6,9 @@ icon: "book-open"
 
 ## What is kguardian?
 
-kguardian implements **observed-based security** - it watches what your applications actually do at runtime and generates security policies that match that behavior. This is fundamentally different from traditional approaches where you manually write policies and hope they're correct.
+kguardian watches pod traffic and syscalls with eBPF, then writes Kubernetes NetworkPolicies, CiliumNetworkPolicies, and seccomp profiles from what it sees — no hand-authored rules.
+
+This is fundamentally different from traditional approaches where you write policies manually and hope they cover what your workloads actually do.
 
 ## Key Concepts
 

--- a/docs/guides/generating-network-policies.mdx
+++ b/docs/guides/generating-network-policies.mdx
@@ -413,7 +413,7 @@ kubectl apply -f ./production-policies/
 ```
 
 <Check>
-Now your namespace has zero-trust networking - only explicitly observed communication is allowed.
+Now your namespace runs default-deny — only explicitly observed communication is allowed.
 </Check>
 
 ---
@@ -467,7 +467,7 @@ Now your namespace has zero-trust networking - only explicitly observed communic
   <Card title="CLI Reference" icon="terminal" href="/cli/gen-networkpolicy">
     Complete flag documentation
   </Card>
-  <Card title="GitOps Integration" icon="code-branch" href="/guides/gitops-integration">
-    Automate policy generation in CI/CD
+  <Card title="Policy Gallery" icon="images" href="/policy-gallery">
+    Worked examples for nginx, Postgres, Prometheus, Istio, and more
   </Card>
 </CardGroup>

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -1,15 +1,25 @@
 ---
-title: "kguardian: Kubernetes Security Made Simple"
-description: "Automatically generate least-privilege Network Policies and Seccomp Profiles using eBPF-powered runtime behavior analysis"
+title: "kguardian"
+description: "kguardian watches pod traffic and syscalls with eBPF, then writes Kubernetes NetworkPolicies, CiliumNetworkPolicies, and seccomp profiles from what it sees — no hand-authored rules."
 ---
 
 # kguardian
 
-**Kubernetes Security Made Simple** - Automatically generate least-privilege Network Policies and Seccomp Profiles using eBPF-powered runtime behavior analysis.
+kguardian watches pod traffic and syscalls with eBPF, then writes Kubernetes NetworkPolicies, CiliumNetworkPolicies, and seccomp profiles from what it sees — no hand-authored rules.
+
+## Docs map
+
+- [**Getting Started**](/quickstart) — install, configure, run your first capture.
+- [**Generating Policies**](/guides/generating-network-policies) — NetworkPolicies and CiliumNetworkPolicies from observed traffic.
+- [**Generating Seccomp Profiles**](/concepts/seccomp-profiles) — least-privilege syscall profiles from runtime data.
+- [**Architecture**](/architecture) — Controller, Broker, storage; how data flows.
+- [**Operations**](/advanced/troubleshooting) — production deployment, retention, performance tuning.
+- [**AI Assistant**](https://github.com/kguardian-dev/kguardian/tree/main/llm-bridge) — optional LLM bridge for natural-language queries.
+- [**Reference**](/cli/overview) — CLI, [API](/api-reference/introduction), [helm values](/installation).
 
 ## What is kguardian?
 
-kguardian is a **Kubernetes security toolkit** that observes your applications at runtime using eBPF technology and automatically generates tailored security resources. Say goodbye to manual policy crafting and hello to zero-trust security that adapts to your workloads.
+A Kubernetes runtime-observability tool that turns the network and syscall behavior of your pods into the policy YAML you would otherwise have to write by hand.
 
 <CardGroup cols={2}>
   <Card
@@ -34,11 +44,11 @@ kguardian is a **Kubernetes security toolkit** that observes your applications a
     Low-overhead kernel-level visibility without code changes
   </Card>
   <Card
-    title="Real-time Visualization"
+    title="Live view (polled, ~5s)"
     icon="chart-network"
     iconType="duotone"
   >
-    Interactive UI to explore pod communication and traffic flows
+    Interactive UI that polls the Broker every few seconds to render pod-to-pod traffic
   </Card>
 </CardGroup>
 
@@ -49,12 +59,12 @@ kguardian is a **Kubernetes security toolkit** that observes your applications a
     Writing Network Policies and Seccomp profiles by hand is tedious and error-prone. kguardian observes your running applications and generates policies automatically in seconds.
   </Accordion>
 
-  <Accordion icon="lock" title="Implement Zero-Trust Security">
+  <Accordion icon="lock" title="Default-Deny by Default">
     Start with a default-deny posture and allow only the exact network paths and syscalls your applications actually use. No guesswork, no over-permissioning.
   </Accordion>
 
   <Accordion icon="eye" title="Gain Runtime Visibility">
-    See exactly how your pods communicate and what system calls they make. The built-in UI provides real-time insights into your cluster's behavior.
+    See exactly how your pods communicate and what system calls they make. The UI polls the Broker every few seconds and renders the latest observed traffic and syscall data.
   </Accordion>
 
   <Accordion icon="rocket" title="Integrate with GitOps">
@@ -172,7 +182,7 @@ kubectl apply -f ./policies/production-my-app-networkpolicy.yaml
 | **Network Policy (Cilium)**   | ✅        | ❌               | ❌                         |
 | **Seccomp Profile Generation**| ✅        | 📝               | ✅                         |
 | **AppArmor Profile Mgmt**     | 🔜        | ❌               | ✅                         |
-| **Real-time UI**              | ✅        | ❌               | ❌                         |
+| **Live view (polled, ~5s)**   | ✅        | ❌               | ❌                         |
 | **GitOps-friendly**           | ✅        | ✅               | Partial                    |
 | **eBPF-based**                | ✅        | ✅               | ✅                         |
 
@@ -200,7 +210,7 @@ kubectl apply -f ./policies/production-my-app-networkpolicy.yaml
   <Card
     title="Contributing"
     icon="code-pull-request"
-    href="/development/overview"
+    href="https://github.com/kguardian-dev/kguardian#contributing"
   >
     Learn how to contribute to kguardian
   </Card>

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -45,63 +45,17 @@ Before you begin, ensure you have:
 
 ## Step 1: Install the Controller
 
-The kguardian controller runs as a DaemonSet and uses eBPF to observe your workloads.
+The Controller runs as a DaemonSet and uses eBPF to observe your workloads.
 
-<Tabs>
-  <Tab title="Helm (Recommended)">
-    ```bash
-    # Install directly from OCI registry
-    helm install kguardian oci://ghcr.io/kguardian-dev/charts/kguardian \
-      --version 1.9.1 \
-      --namespace kguardian \
-      --create-namespace \
-      --wait
-    ```
+```bash
+helm install kguardian oci://ghcr.io/kguardian-dev/charts/kguardian \
+  --version 1.9.1 \
+  --namespace kguardian \
+  --create-namespace \
+  --wait
+```
 
-    <Tip>
-    The controller will automatically start monitoring pods across your cluster (excluding kube-system and kguardian namespaces by default).
-    </Tip>
-  </Tab>
-
-  <Tab title="Specific Version">
-    ```bash
-    # Install a specific version from OCI registry
-    helm install kguardian oci://ghcr.io/kguardian-dev/charts/kguardian \
-      --version 1.9.1 \
-      --namespace kguardian \
-      --create-namespace \
-      --wait
-    ```
-  </Tab>
-
-  <Tab title="Custom Values">
-    ```bash
-    # Create a custom values file
-    cat > values.yaml <<EOF
-    controller:
-      resources:
-        limits:
-          memory: "512Mi"
-          cpu: "500m"
-      excludedNamespaces: "kube-system,kguardian,monitoring"
-
-    broker:
-      replicas: 2
-      persistence:
-        enabled: true
-        size: 10Gi
-    EOF
-
-    # Install with custom values
-    helm install kguardian oci://ghcr.io/kguardian-dev/charts/kguardian \
-      --version 1.9.1 \
-      --namespace kguardian \
-      --create-namespace \
-      --values values.yaml \
-      --wait
-    ```
-  </Tab>
-</Tabs>
+For specific versions, custom Helm values, Kind-based local development, and external PostgreSQL setups, see the [Installation Guide](/installation) — that page is the canonical install reference.
 
 ### Verify Installation
 
@@ -353,8 +307,8 @@ Automated seccomp profile distribution from kguardian is on the roadmap. Until t
 ## Next Steps
 
 <CardGroup cols={2}>
-  <Card title="Explore the UI" icon="chart-network" href="/guides/using-the-ui">
-    Visualize pod communication in real-time
+  <Card title="Architecture" icon="sitemap" href="/architecture">
+    See how the Controller, Broker, and UI fit together
   </Card>
   <Card title="Generate Cilium Policies" icon="network-wired" href="/guides/generating-network-policies">
     Create enhanced L7-aware policies
@@ -362,8 +316,8 @@ Automated seccomp profile distribution from kguardian is on the roadmap. Until t
   <Card title="Batch Generation" icon="layer-group" href="/cli/gen-networkpolicy">
     Generate policies for all pods at once
   </Card>
-  <Card title="GitOps Integration" icon="code-branch" href="/guides/gitops-integration">
-    Integrate with your CI/CD pipeline
+  <Card title="Policy Gallery" icon="images" href="/policy-gallery">
+    Worked examples for nginx, Postgres, kube-dns, Prometheus, Istio, Go
   </Card>
 </CardGroup>
 

--- a/docs/roadmap/future-resources.mdx
+++ b/docs/roadmap/future-resources.mdx
@@ -9,7 +9,7 @@ icon: "map"
 kguardian is continuously evolving to support more Kubernetes security resources. This page outlines our plans for future capabilities.
 
 <Note>
-**Want to contribute?** Check out our [GitHub Discussions](https://github.com/kguardian-dev/kguardian/discussions) to participate in roadmap planning or our [Contributing Guide](/development/overview) to help build these features!
+**Want to contribute?** Check out our [GitHub Discussions](https://github.com/kguardian-dev/kguardian/discussions) to participate in roadmap planning or the [Contributing](https://github.com/kguardian-dev/kguardian#contributing) section of the README to help build these features!
 </Note>
 
 ## Planned Resources

--- a/docs/roadmap/planned-features.mdx
+++ b/docs/roadmap/planned-features.mdx
@@ -216,7 +216,7 @@ All releases follow [Semantic Versioning](https://semver.org/) and include:
   <Card title="Future Resources" icon="map" href="/roadmap/future-resources">
     See detailed plans for AppArmor, SELinux, and more
   </Card>
-  <Card title="Contributing Guide" icon="code-pull-request" href="/development/overview">
+  <Card title="Contributing Guide" icon="code-pull-request" href="https://github.com/kguardian-dev/kguardian#contributing">
     Help build the future of kguardian
   </Card>
   <Card title="GitHub Roadmap" icon="github" href="https://github.com/kguardian-dev/kguardian/milestones">


### PR DESCRIPTION
## Summary

Tier 2 of the docs overhaul. Structural cleanup, dedupe, peer-pattern adoption, and a new `STYLE.md`. Builds on the Tier-1 lede.

### Dedupe — pick a canonical home for each repeated block

- **"What is kguardian?" pitch** — Tier-1 README lede now used verbatim in `README.md`, `docs/index.mdx`, and `docs/concepts/overview.mdx`. No more drift.
- **Comparison table** — `docs/index.mdx` is canonical. `README.md`'s 25-line table → one-line pitch + link to the docs anchor. The "Real-time UI" row reconciled to "Live view (polled, ~5s)".
- **Install snippets** — `docs/installation.mdx` is canonical. `README.md` install shrinks to 2 commands + link. `docs/quickstart.mdx` Step 1 is one Helm command + link.

### Falco's three-question intro in README

After the lede, three short subsections replace the jump-to-feature-list:

- **What is kguardian?** (1 sentence)
- **What does it do?** (eBPF capture → behavioral baseline → policy synthesis)
- **What does it generate?** (concrete artefacts linking to the policy gallery from Tier 1)

### Cilium's docs-map pattern in `docs/index.mdx`

Top-of-page "Docs map" with seven labelled entries: Getting Started, Generating Policies, Generating Seccomp Profiles, Architecture, Operations, AI Assistant, Reference. Each links to its section.

### Normalised "real-time" claims

The UI polls the Broker (~5s). Every doc occurrence now agrees:

- `docs/index.mdx` hero card + accordion + comparison-table row.
- `docs/architecture.mdx` two occurrences (lines 154, 263).
- `docs/quickstart.mdx` Next Steps card (route was 404 anyway).

`frontend/*` and `RELEASES.md` deliberately untouched (build internals, commit-message example).

### Naming consistency + new `STYLE.md`

- "kguardian Controller" mixed-case removed from `README.md`.
- New `STYLE.md` at repo root: product name lowercase always, component nouns (`Controller`, `Broker`, `UI`) capitalised when specific, `kubectl-kguardian` only on disk, banned marketing words (`made simple`, `tailored`, `zero-trust`, `powerful`, …), no unqualified "real-time", canonical-source table for repeated content.

### Validator pickups absorbed

- **I2** — `docs/index.mdx:203` Contributing card → broken `/development/overview`. Cleared. Two more instances in `roadmap/future-resources.mdx` and `roadmap/planned-features.mdx` swept too.
- **I3, I4** — `docs/quickstart.mdx:356/365` cards pointing at removed `/guides/using-the-ui` and `/guides/gitops-integration` → replaced with `/architecture` and `/policy-gallery`. One more `/guides/gitops-integration` in `docs/guides/generating-network-policies.mdx` swept while in the file.
- **A1** — `docs/index.mdx` "Made Simple" ×2, "tailored", "zero-trust" ×2 cleared.
- **A2** — `README.md` "kguardian Controller" mixed-case cleared per `STYLE.md`.
- Incidental: stray "zero-trust" in `docs/guides/generating-network-policies.mdx:416` swept.

## Test plan

- [ ] `grep -rn -i "made simple\|tailored\|zero-trust" docs/ README.md` returns nothing.
- [ ] `grep -rn -i "real-time\|real time" docs/` returns nothing.
- [ ] `grep -rn "/development/overview\|/guides/using-the-ui\|/guides/gitops-integration" docs/ README.md` returns nothing.
- [ ] `grep -rn "kguardian Controller" --include="*.md" --include="*.mdx"` returns only the `STYLE.md` entry that documents the form is bad.
- [ ] Mintlify build of `docs/` succeeds (no broken-link warnings).
- [ ] `README.md` and `docs/index.mdx` "What is kguardian?" sentence is byte-identical to the Tier-1 lede.