### PR TITLE
chore(deps): update typescript to v6 (major)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -34,7 +34,7 @@
         "globals": "^17.0.0",
         "postcss": "^8.5.6",
         "tailwindcss": "^4.1.16",
-        "typescript": "~5.9.3",
+        "typescript": "~6.0.0",
         "typescript-eslint": "^8.45.0",
         "vite": "^8.0.0"
       }
@@ -5567,9 +5567,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -36,7 +36,7 @@
     "globals": "^17.0.0",
     "postcss": "^8.5.6",
     "tailwindcss": "^4.1.16",
-    "typescript": "~5.9.3",
+    "typescript": "~6.0.0",
     "typescript-eslint": "^8.45.0",
     "vite": "^8.0.0"
   }

--- a/llm-bridge/package-lock.json
+++ b/llm-bridge/package-lock.json
@@ -24,7 +24,7 @@
         "@types/node": "^24.0.0",
         "eslint": "^10.0.0",
         "tsx": "^4.19.2",
-        "typescript": "^5.7.2",
+        "typescript": "^6.0.0",
         "typescript-eslint": "^8.59.0"
       }
     },
@@ -3059,9 +3059,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/llm-bridge/package.json
+++ b/llm-bridge/package.json
@@ -36,7 +36,7 @@
     "@types/node": "^24.0.0",
     "eslint": "^10.0.0",
     "tsx": "^4.19.2",
-    "typescript": "^5.7.2",
+    "typescript": "^6.0.0",
     "typescript-eslint": "^8.59.0"
   }
 }


### PR DESCRIPTION
## Summary

Supersedes #780. Bumps `typescript` to ~6.0.0 in `frontend/` and ^6.0.0 in `llm-bridge/`.

- `typescript-eslint` 8's peer constraint is `>=4.8.4 <6.1.0`, so 6.0.3 is in range — no other config changes needed.
- TS 6 resolves cleanly against existing `vite` 8, `@vitejs/plugin-react` 6, `tsx` 4, `@types/*`.

## Validation (local)

| Check | Frontend | llm-bridge |
|---|---|---|
| `npm install` (typescript@6.0.3) | clean | clean |
| `tsc --noEmit` / `tsc -b` | clean | clean |
| `npm run build` | green (vite emits dist) | green |
| `npm run lint` (eslint 9 + ts-eslint 8 against TS 6) | output unchanged from main | clean |

No new compiler errors surfaced under `strict: true` + the existing `noUnusedLocals/Parameters/erasableSyntaxOnly/noUncheckedSideEffectImports` flags.

## Test plan

- [ ] CI build-frontend job passes
- [ ] CI build-llm-bridge job passes