### PR TITLE
chore(deps): update postgres docker tag to v18 (major)

### DIFF
--- a/charts/kguardian/README.md
+++ b/charts/kguardian/README.md
@@ -149,7 +149,7 @@ The following table lists the configurable parameters of the kguardian chart and
 | database.image.pullPolicy | string | `"IfNotPresent"` | PostgreSQL image pull policy |
 | database.image.repository | string | `"postgres"` | PostgreSQL container image repository |
 | database.image.sha | string | `""` | Overrides the image tag using SHA digest |
-| database.image.tag | string | `"15-alpine"` | PostgreSQL image tag (pinned; bump deliberately) |
+| database.image.tag | string | `"18-alpine"` | PostgreSQL image tag (pinned; bump deliberately). @breaking 18-alpine: PostgreSQL major-version data dirs are not forward-compatible. Existing PG15 PersistentVolumeClaims must be migrated with pg_upgrade or dropped before upgrading. See charts/kguardian/UPGRADING.md. |
 | database.imagePullSecrets | list | `[]` | List of image pull secrets for private registries |
 | database.name | string | `"kguardian-db"` | Database name for PostgreSQL |
 | database.nameOverride | string | `""` | Override the name of the database resources |
@@ -277,6 +277,11 @@ The following table lists the configurable parameters of the kguardian chart and
 | namespace.annotations | object | `{}` | Annotations to add to the namespace |
 | namespace.labels | object | `{}` | Labels to add to the namespace |
 | namespace.name | string | `""` | Namespace name. If empty, uses the release namespace |
+
+## Upgrading
+
+For breaking-change migrations between chart versions (e.g. PostgreSQL major-version
+bumps), see [UPGRADING.md](./UPGRADING.md).
 
 ## Uninstalling the Chart
 

--- a/charts/kguardian/README.md.gotmpl
+++ b/charts/kguardian/README.md.gotmpl
@@ -73,6 +73,11 @@ The following table lists the configurable parameters of the kguardian chart and
 
 {{ template "chart.valuesTable" . }}
 
+## Upgrading
+
+For breaking-change migrations between chart versions (e.g. PostgreSQL major-version
+bumps), see [UPGRADING.md](./UPGRADING.md).
+
 ## Uninstalling the Chart
 
 To uninstall/delete the my-release deployment:

--- a/charts/kguardian/UPGRADING.md
+++ b/charts/kguardian/UPGRADING.md
@@ -1,0 +1,76 @@
+# Upgrading the kguardian Helm chart
+
+## chart 1.10.0: PostgreSQL 15 → 18
+
+The `database.image.tag` default moved from `15-alpine` to `18-alpine`.
+PostgreSQL major-version data directories are not forward-compatible, so
+existing installations with `database.persistence.enabled=true` will not
+start under PostgreSQL 18 against a PG15 PVC. The database pod will fail
+its readiness probe with:
+
+```
+database files are incompatible with server
+The data directory was initialized by PostgreSQL version 15, which is
+not compatible with this version 18.x.
+```
+
+Pick one of the two paths below before running `helm upgrade`.
+
+### Option 1 — drop the data and repopulate (recommended)
+
+The kguardian database stores only ephemeral observability state:
+captured pod traffic, syscall samples, and pod/service spec snapshots.
+The controller and broker repopulate it from the live cluster state
+once they reconnect, so dropping the PVC is non-destructive in practice.
+
+```sh
+# 1. Scale broker + controller down so nothing is writing.
+kubectl -n <ns> scale deploy/kguardian-broker --replicas=0
+kubectl -n <ns> rollout pause daemonset/kguardian-controller
+
+# 2. Delete the database deployment + PVC.
+kubectl -n <ns> delete deploy/kguardian-db
+kubectl -n <ns> delete pvc <existing-claim-name>
+
+# 3. Apply the new chart (creates a fresh PG18 data dir).
+helm upgrade --install kguardian kguardian/kguardian \
+  --namespace <ns> \
+  --set database.persistence.existingClaim=<new-claim-name>
+
+# 4. Resume the controller; broker will be re-created by the chart.
+kubectl -n <ns> rollout resume daemonset/kguardian-controller
+```
+
+### Option 2 — pg_upgrade in place (preserves data)
+
+Use this if you have downstream tooling that depends on continuity of
+the database contents.
+
+```sh
+# 1. Take a logical backup as a safety net.
+kubectl -n <ns> exec deploy/kguardian-db -- pg_dumpall -U rust > backup.sql
+
+# 2. Stop the broker (drops live writers).
+kubectl -n <ns> scale deploy/kguardian-broker --replicas=0
+
+# 3. Run pg_upgrade against the existing PVC. Easiest is to mount it in
+#    a one-shot Job that runs both PG15 and PG18 binaries, e.g.
+#    tianon/postgres-upgrade:15-to-18, with both /var/lib/postgres/15 and
+#    /var/lib/postgres/18 PVCs mounted. After it completes, repoint the
+#    chart at the new (PG18) PVC via database.persistence.existingClaim.
+
+# 4. Apply the new chart.
+helm upgrade --install kguardian kguardian/kguardian \
+  --namespace <ns> \
+  --set database.persistence.existingClaim=<pg18-claim-name>
+```
+
+If neither path is acceptable, pin the previous tag and stay on PG15:
+
+```yaml
+database:
+  image:
+    tag: "15-alpine"
+```
+
+PG15 is still receiving security fixes through 2027-11-11.

--- a/charts/kguardian/templates/NOTES.txt
+++ b/charts/kguardian/templates/NOTES.txt
@@ -1,0 +1,32 @@
+kguardian {{ .Chart.AppVersion }} installed in namespace "{{ .Release.Namespace }}".
+
+Database: PostgreSQL {{ .Values.database.image.tag }}
+{{- if .Values.database.persistence.enabled }}
+Persistence: enabled (claim {{ .Values.database.persistence.existingClaim | default "<unset>" | quote }})
+{{- else }}
+Persistence: disabled (emptyDir; data is lost when the pod restarts)
+{{- end }}
+
+{{- if and .Values.database.persistence.enabled (hasPrefix "18" .Values.database.image.tag) }}
+
+UPGRADING FROM POSTGRESQL 15 -> 18
+==================================
+PostgreSQL major-version data directories are not forward-compatible.
+If your existing PVC was initialised by a previous chart release running
+PostgreSQL 15, the database pod will crashloop with:
+
+  "database files are incompatible with server"
+
+To resolve, choose one:
+
+  1. Run pg_upgrade against the data directory before reinstalling
+     (preserves data). Steps in: charts/kguardian/UPGRADING.md
+
+  2. Drop the existing PVC and let kguardian repopulate from cluster
+     state (acceptable when the database holds only observability data).
+
+For fresh installs this notice does not apply.
+{{- end }}
+
+To check status:
+  kubectl -n {{ .Release.Namespace }} get pods -l app.kubernetes.io/instance={{ .Release.Name }}

--- a/charts/kguardian/values.yaml
+++ b/charts/kguardian/values.yaml
@@ -269,8 +269,12 @@ database:
     repository: postgres
     # -- PostgreSQL image pull policy
     pullPolicy: IfNotPresent
-    # -- PostgreSQL image tag (pinned; bump deliberately)
-    tag: "15-alpine"
+    # -- PostgreSQL image tag (pinned; bump deliberately).
+    # @breaking 18-alpine: PostgreSQL major-version data dirs are not
+    # forward-compatible. Existing PG15 PersistentVolumeClaims must be
+    # migrated with pg_upgrade or dropped before upgrading. See
+    # charts/kguardian/UPGRADING.md.
+    tag: "18-alpine"
     # -- Overrides the image tag using SHA digest
     sha: ""
 


### PR DESCRIPTION
## Summary

Supersedes #838. Bumps `database.image.tag` from `15-alpine` to `18-alpine`.

PostgreSQL major-version data directories are not forward-compatible. Existing installations with \`database.persistence.enabled=true\` and a PG15 PVC would normally fail to start under PG18 with \`database files are incompatible with server\`. This PR adds the tooling/docs to walk operators through the migration.

### Changes

- \`values.yaml\`: tag \`15-alpine\` → \`18-alpine\`; expanded comment with \`@breaking\` annotation
- \`templates/NOTES.txt\` (new): post-install warning rendered **only** when tag starts with \`"18"\` and persistence is enabled
- \`UPGRADING.md\` (new): two documented migration paths
  1. Drop the PVC and let kguardian repopulate from cluster state (recommended — DB holds only observability data)
  2. \`pg_upgrade\` in place (preserves data)
- \`README.md.gotmpl\` + \`README.md\`: link UPGRADING.md from the chart README

## Validation (local)

- \`helm lint charts/kguardian/\` — clean
- \`helm install --dry-run\` for all three combinations:
  - PG18 + persistence on → warning shown
  - PG18 + persistence off → warning suppressed
  - PG15 + persistence on → warning suppressed
- Diesel migrations (\`broker/db/migrations/\`) reviewed against PG18: every SQL construct (VARCHAR, JSON, TIMESTAMP, BOOLEAN, plpgsql triggers with \`regclass\` + \`format()\` + \`IS DISTINCT FROM\`) has been stable since PG12
- Broker source: no version-sensitive Postgres calls

### Not validated locally

No docker available in this WSL distro, so I could **not** runtime-validate by booting \`postgres:18-alpine\` and running diesel migrations against it. CI also doesn't runtime-test postgres (only builds Docker images), so this gap won't be caught by CI either. Recommend either runtime-testing on a non-prod cluster before merge, or a follow-up integration test.

### Tangential finding (out of scope)

The chart's deployment mounts the database PVC at \`/var/lib/postgres/data\`, but the official postgres image's default \`PGDATA\` is \`/var/lib/postgresql/data\` (note the \`ql\`). Persistence has therefore been silently broken regardless of PG version — Postgres has been writing to its default container-internal path and ignoring the PVC. This actually de-risks the PG15→PG18 transition (no real PG15 data on the volume to be incompatible) but is its own bug worth filing separately.

## Test plan

- [ ] CI helm lint passes
- [ ] CI charts-docs auto-commit no-ops (README already regenerated)
- [ ] Manual: deploy to non-prod cluster, confirm broker connects to PG18 and runs diesel migrations