### PR TITLE
fix(chart): provision DB PVC by default, fix PGDATA mount path

### DIFF
--- a/charts/kguardian/README.md
+++ b/charts/kguardian/README.md
@@ -155,7 +155,9 @@ The following table lists the configurable parameters of the kguardian chart and
 | database.nameOverride | string | `""` | Override the name of the database resources |
 | database.nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Node labels for the kguardian database pod assignment |
 | database.persistence.enabled | bool | `true` | Enable persistent storage for database. Defaults to true; set to false only for ephemeral testing. |
-| database.persistence.existingClaim | string | `""` | Use an existing PersistentVolumeClaim instead of creating a new one |
+| database.persistence.existingClaim | string | `""` | Use an existing PersistentVolumeClaim instead of creating a new one. When unset, the chart provisions a PVC named "{{ database.name }}-data". |
+| database.persistence.size | string | `"10Gi"` | Size of the auto-provisioned PVC (only used when existingClaim is unset) |
+| database.persistence.storageClassName | string | `""` | StorageClass for the auto-provisioned PVC (only used when existingClaim is unset). Empty string uses the cluster's default StorageClass. |
 | database.podAnnotations | object | `{}` | Annotations to add to database pods |
 | database.podSecurityContext | object | `{"fsGroup":999,"fsGroupChangePolicy":"OnRootMismatch","runAsGroup":999,"runAsUser":999,"seccompProfile":{"type":"RuntimeDefault"},"supplementalGroups":[999]}` | Database pod security context. Runs as postgres user (999) |
 | database.priorityClassName | string | `""` | Priority class to be used for the kguardian database pods |

--- a/charts/kguardian/templates/database/deployment.yaml
+++ b/charts/kguardian/templates/database/deployment.yaml
@@ -72,13 +72,17 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           volumeMounts:
-            - mountPath: /var/lib/postgres/data
+            # postgres:18+ images use major-version-specific subdirectories
+            # under /var/lib/postgresql (e.g. /var/lib/postgresql/18/docker/),
+            # so the PVC must mount the parent directory. See
+            # https://github.com/docker-library/postgres/pull/1259
+            - mountPath: /var/lib/postgresql
               name: db-data
       volumes:
         - name: db-data
           {{- if .Values.database.persistence.enabled }}
           persistentVolumeClaim:
-            claimName: {{ .Values.database.persistence.existingClaim }}
+            claimName: {{ .Values.database.persistence.existingClaim | default (printf "%s-data" .Values.database.name) }}
           {{- else }}
           emptyDir: {}
           {{- end -}}

--- a/charts/kguardian/templates/database/pvc.yaml
+++ b/charts/kguardian/templates/database/pvc.yaml
@@ -1,0 +1,18 @@
+{{- if and .Values.database.persistence.enabled (not .Values.database.persistence.existingClaim) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ .Values.database.name }}-data
+  labels:
+    {{- include "kguardian.labels" . | nindent 4 }}
+    app.kubernetes.io/name: {{ .Values.database.service.name }}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  {{- with .Values.database.persistence.storageClassName }}
+  storageClassName: {{ . | quote }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.database.persistence.size | default "10Gi" }}
+{{- end }}

--- a/charts/kguardian/values.yaml
+++ b/charts/kguardian/values.yaml
@@ -281,8 +281,12 @@ database:
   persistence:
     # -- Enable persistent storage for database. Defaults to true; set to false only for ephemeral testing.
     enabled: true
-    # -- Use an existing PersistentVolumeClaim instead of creating a new one
+    # -- Use an existing PersistentVolumeClaim instead of creating a new one. When unset, the chart provisions a PVC named "{{ database.name }}-data".
     existingClaim: ""
+    # -- Size of the auto-provisioned PVC (only used when existingClaim is unset)
+    size: "10Gi"
+    # -- StorageClass for the auto-provisioned PVC (only used when existingClaim is unset). Empty string uses the cluster's default StorageClass.
+    storageClassName: ""
 
   container:
     # -- PostgreSQL container port


### PR DESCRIPTION
## Summary

Two pre-existing bugs in \`charts/kguardian/templates/database/deployment.yaml\` that have been blocking chart-testing's \`ct install\` job on every chart-touching PR for the past 1+ days. Surfaced while investigating #844; both predate that PR. **Updated 2026-05-07 with the corrected PG18 mount path discovered from the failing CI logs.**

### Bug 1 — invalid \`claimName: \"\"\` on default install

With \`database.persistence.enabled=true\` (default) and \`database.persistence.existingClaim=\"\"\` (default), the deployment renders \`claimName: \"\"\`, which Kubernetes rejects.

**Fix:** new \`templates/database/pvc.yaml\` provisions a PVC named \`{{ database.name }}-data\` whenever persistence is enabled and no existingClaim is provided. Adds \`database.persistence.size\` (10Gi default) and \`database.persistence.storageClassName\` (\"\" = cluster default).

### Bug 2 — wrong PVC mount path for postgres:18+

The official \`postgres:18-alpine\` image changed its on-disk layout per [docker-library/postgres#1259](https://github.com/docker-library/postgres/pull/1259): data is now written under major-version-specific subdirectories (e.g. \`/var/lib/postgresql/18/docker/\`), and the recommended container configuration is to mount the **parent** directory \`/var/lib/postgresql\` so \`pg_upgrade --link\` can work without crossing mount boundaries.

The chart was previously mounting at \`/var/lib/postgres/data\` (a typo — postgres image has never used that path) so persistence was silently broken across every PG version. My first attempt at this fix moved it to \`/var/lib/postgresql/data\`, which works for PG≤17 but causes PG18 to refuse to start with:

> Error: in 18+, these Docker images are configured to store database data in a format which is compatible with \"pg_ctlcluster\". The suggested container configuration for 18+ is to place a single mount at /var/lib/postgresql.

**Fix:** mount at \`/var/lib/postgresql\` (the parent). This works for both PG18 and earlier versions.

## Validation

- \`helm lint\`: clean
- \`helm template\` for all three persistence modes:
  - default → provisions \`kguardian-db-data\` PVC, mountPath \`/var/lib/postgresql\`
  - existingClaim set → uses the supplied PVC
  - persistence.enabled=false → \`emptyDir\`
- \`README.md\` regenerated via helm-docs

## Note on UPGRADING.md from #844

The PG15 → PG18 upgrade warning still describes a real risk for users with a real PG15 PVC, but because of bug #2 nobody actually had one — postgres was writing to its container-internal \`/var/lib/postgresql/data\` regardless of the chart's bogus volumeMount. So practical upgrade impact is zero for existing users.

## Test plan

- [ ] \`charts-lint\` workflow's \`lint-test\` job passes (broken on every chart PR for >1 day)
- [ ] Manual: \`helm install\` against a fresh cluster with default values comes up healthy