### PR TITLE
feat(chart,docs): support external Postgres + configurable DB user/db, fix doc lies

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ helm install kguardian oci://ghcr.io/kguardian-dev/charts/kguardian \
 sh -c "$(curl -fsSL https://raw.githubusercontent.com/kguardian-dev/kguardian/main/scripts/quick-install.sh)"
 ```
 
-Krew, manual download, custom Helm values, Kind setup, verification, upgrades, and uninstall are all covered in the [Installation Guide](https://docs.kguardian.dev/installation).
+Manual download, custom Helm values, Kind setup, verification, upgrades, and uninstall are all covered in the [Installation Guide](https://docs.kguardian.dev/installation).
 
 ## Quick Start
 

--- a/charts/kguardian/README.md
+++ b/charts/kguardian/README.md
@@ -145,15 +145,22 @@ The following table lists the configurable parameters of the kguardian chart and
 | database.autoscaling.minReplicas | int | `1` | Minimum number of database replicas |
 | database.autoscaling.targetCPUUtilizationPercentage | int | `80` | Target CPU utilization percentage for autoscaling |
 | database.container.port | int | `5432` | PostgreSQL container port |
+| database.databaseName | string | `"kube"` | Database name used by the broker. Must exist on external Postgres. |
+| database.enabled | bool | `true` | Deploy the bundled in-cluster PostgreSQL. Set false to use an external PostgreSQL — populate `database.external.host` and provide credentials via `database.existingSecret`. |
+| database.existingSecret | string | `""` | Existing Secret containing the DB password under the key configured by `database.passwordSecretKey`. When empty AND `database.enabled=true`, the chart provisions a Secret named "kguardian-db-credentials" with a random password (regenerated only on first install). |
+| database.external.host | string | `""` | Hostname or FQDN of the external PostgreSQL instance, e.g. "postgres.databases.svc.cluster.local" or "db.example.com". Required when `database.enabled=false`. |
+| database.external.port | int | `5432` | Port of the external PostgreSQL instance. |
+| database.external.sslMode | string | `"prefer"` | libpq sslmode for the external connection (disable | allow | prefer | require | verify-ca | verify-full). Cloud-managed Postgres typically requires "require" or stricter. |
 | database.fullnameOverride | string | `""` | Override the full name of the database resources |
 | database.image.pullPolicy | string | `"IfNotPresent"` | PostgreSQL image pull policy |
 | database.image.repository | string | `"postgres"` | PostgreSQL container image repository |
 | database.image.sha | string | `""` | Overrides the image tag using SHA digest |
 | database.image.tag | string | `"18-alpine"` | PostgreSQL image tag (pinned; bump deliberately). @breaking 18-alpine: PostgreSQL major-version data dirs are not forward-compatible. Existing PG15 PersistentVolumeClaims must be migrated with pg_upgrade or dropped before upgrading. See charts/kguardian/UPGRADING.md. |
 | database.imagePullSecrets | list | `[]` | List of image pull secrets for private registries |
-| database.name | string | `"kguardian-db"` | Database name for PostgreSQL |
+| database.name | string | `"kguardian-db"` | Object name for the in-cluster Database deployment / PVC / SA. Only used when `database.enabled=true`. |
 | database.nameOverride | string | `""` | Override the name of the database resources |
 | database.nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Node labels for the kguardian database pod assignment |
+| database.passwordSecretKey | string | `"password"` | Secret data key holding the DB password. |
 | database.persistence.enabled | bool | `true` | Enable persistent storage for database. Defaults to true; set to false only for ephemeral testing. |
 | database.persistence.existingClaim | string | `""` | Use an existing PersistentVolumeClaim instead of creating a new one. When unset, the chart provisions a PVC named "{{ database.name }}-data". |
 | database.persistence.size | string | `"10Gi"` | Size of the auto-provisioned PVC (only used when existingClaim is unset) |
@@ -171,6 +178,7 @@ The following table lists the configurable parameters of the kguardian chart and
 | database.serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
 | database.serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template |
 | database.tolerations | list | `[]` | Tolerations for the kguardian database pod assignment |
+| database.user | string | `"rust"` | PostgreSQL role used by the broker. Must exist on external Postgres. |
 | frontend.affinity | object | `{}` | Affinity rules for frontend pod assignment |
 | frontend.autoscaling.enabled | bool | `false` | Enable horizontal pod autoscaling for frontend |
 | frontend.autoscaling.maxReplicas | int | `100` | Maximum number of frontend replicas |

--- a/charts/kguardian/templates/NOTES.txt
+++ b/charts/kguardian/templates/NOTES.txt
@@ -1,13 +1,19 @@
 kguardian {{ .Chart.AppVersion }} installed in namespace "{{ .Release.Namespace }}".
 
-Database: PostgreSQL {{ .Values.database.image.tag }}
+{{- if .Values.database.enabled }}
+Database: in-cluster PostgreSQL {{ .Values.database.image.tag }}
 {{- if .Values.database.persistence.enabled }}
-Persistence: enabled (claim {{ .Values.database.persistence.existingClaim | default "<unset>" | quote }})
+Persistence: enabled (claim {{ .Values.database.persistence.existingClaim | default (printf "%s-data (auto-provisioned)" .Values.database.name) | quote }})
 {{- else }}
 Persistence: disabled (emptyDir; data is lost when the pod restarts)
 {{- end }}
+{{- else }}
+Database: external PostgreSQL at {{ .Values.database.external.host }}:{{ .Values.database.external.port }}
+                  user="{{ .Values.database.user }}" db="{{ .Values.database.databaseName }}" sslmode="{{ .Values.database.external.sslMode }}"
+                  password from Secret "{{ include "kguardian.dbSecretName" . }}" (key="{{ .Values.database.passwordSecretKey }}")
+{{- end }}
 
-{{- if and .Values.database.persistence.enabled (hasPrefix "18" .Values.database.image.tag) }}
+{{- if and .Values.database.enabled .Values.database.persistence.enabled (hasPrefix "18" .Values.database.image.tag) }}
 
 UPGRADING FROM POSTGRESQL 15 -> 18
 ==================================

--- a/charts/kguardian/templates/_helpers.tpl
+++ b/charts/kguardian/templates/_helpers.tpl
@@ -74,3 +74,51 @@ Usage: include "kguardian.imageTag" .Values.<component>.image.tag
 {{- define "kguardian.imageTag" -}}
 {{- if regexMatch "^[0-9]+\\.[0-9]+\\.[0-9]+" . -}}v{{ . }}{{- else -}}{{ . }}{{- end -}}
 {{- end -}}
+
+{{/*
+Name of the Secret holding the database password.
+Returns `database.existingSecret` if set, otherwise the chart-managed default.
+Usage: include "kguardian.dbSecretName" .
+*/}}
+{{- define "kguardian.dbSecretName" -}}
+{{- .Values.database.existingSecret | default "kguardian-db-credentials" -}}
+{{- end -}}
+
+{{/*
+Hostname for the broker's DATABASE_URL.
+- database.enabled=true  -> in-cluster service FQDN
+- database.enabled=false -> database.external.host (required)
+Usage: include "kguardian.dbHost" .
+*/}}
+{{- define "kguardian.dbHost" -}}
+{{- if .Values.database.enabled -}}
+{{- printf "%s.%s.svc.cluster.local" .Values.database.service.name (include "kguardian.namespace" . | trim) -}}
+{{- else -}}
+{{- required "database.external.host is required when database.enabled=false" .Values.database.external.host -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Port for the broker's DATABASE_URL.
+*/}}
+{{- define "kguardian.dbPort" -}}
+{{- if .Values.database.enabled -}}
+{{- .Values.database.container.port -}}
+{{- else -}}
+{{- .Values.database.external.port -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Full broker DATABASE_URL value, with $(DB_PASSWORD) interpolated by the
+container at runtime via secretKeyRef. sslmode is appended only for the
+external case so the in-cluster URL stays identical to prior releases.
+*/}}
+{{- define "kguardian.dbUrl" -}}
+{{- $base := printf "postgres://%s:$(DB_PASSWORD)@%s:%v/%s" .Values.database.user (include "kguardian.dbHost" .) (include "kguardian.dbPort" .) .Values.database.databaseName -}}
+{{- if and (not .Values.database.enabled) .Values.database.external.sslMode -}}
+{{- printf "%s?sslmode=%s" $base .Values.database.external.sslMode -}}
+{{- else -}}
+{{- $base -}}
+{{- end -}}
+{{- end -}}

--- a/charts/kguardian/templates/broker/deployment.yaml
+++ b/charts/kguardian/templates/broker/deployment.yaml
@@ -38,7 +38,7 @@ spec:
           image: "{{ .Values.broker.initContainer.image.repository }}:{{ .Values.broker.initContainer.image.tag }}"
           {{- end }}
           imagePullPolicy: {{ .Values.broker.initContainer.image.pullPolicy }}
-          command: ["sh", "-c", "until nc -z {{ .Values.database.service.name }}.{{ include "kguardian.namespace" . }}.svc.cluster.local {{ .Values.database.container.port }}; do echo 'waiting for db'; sleep 2; done"]
+          command: ["sh", "-c", "until nc -z {{ include "kguardian.dbHost" . }} {{ include "kguardian.dbPort" . }}; do echo 'waiting for db'; sleep 2; done"]
           securityContext:
             {{- toYaml .Values.broker.initContainer.securityContext | nindent 12 }}
       containers:
@@ -59,10 +59,10 @@ spec:
             - name: DB_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: kguardian-db-credentials
-                  key: password
+                  name: {{ include "kguardian.dbSecretName" . }}
+                  key: {{ .Values.database.passwordSecretKey }}
             - name: DATABASE_URL
-              value: "postgres://rust:$(DB_PASSWORD)@{{ .Values.database.service.name }}.{{ include "kguardian.namespace" . }}.svc.cluster.local:{{ .Values.database.container.port }}/kube"
+              value: {{ include "kguardian.dbUrl" . | quote }}
           livenessProbe:
             httpGet:
               path: /health

--- a/charts/kguardian/templates/database/deployment.yaml
+++ b/charts/kguardian/templates/database/deployment.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.database.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -35,22 +36,22 @@ spec:
             {{- toYaml .Values.database.securityContext | nindent 12 }}
           env:
             - name: POSTGRES_USER
-              value: rust
+              value: {{ .Values.database.user | quote }}
             - name: POSTGRES_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: kguardian-db-credentials
-                  key: password
+                  name: {{ include "kguardian.dbSecretName" . }}
+                  key: {{ .Values.database.passwordSecretKey }}
             - name: POSTGRES_DB
-              value: kube
+              value: {{ .Values.database.databaseName | quote }}
           livenessProbe:
             exec:
               command:
                 - pg_isready
                 - -U
-                - rust
+                - {{ .Values.database.user | quote }}
                 - -d
-                - kube
+                - {{ .Values.database.databaseName | quote }}
             initialDelaySeconds: 30
             periodSeconds: 15
             timeoutSeconds: 5
@@ -60,9 +61,9 @@ spec:
               command:
                 - pg_isready
                 - -U
-                - rust
+                - {{ .Values.database.user | quote }}
                 - -d
-                - kube
+                - {{ .Values.database.databaseName | quote }}
             initialDelaySeconds: 5
             periodSeconds: 10
             timeoutSeconds: 5
@@ -98,3 +99,4 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+{{- end }}

--- a/charts/kguardian/templates/database/pvc.yaml
+++ b/charts/kguardian/templates/database/pvc.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.database.persistence.enabled (not .Values.database.persistence.existingClaim) }}
+{{- if and .Values.database.enabled .Values.database.persistence.enabled (not .Values.database.persistence.existingClaim) }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/charts/kguardian/templates/database/secret.yaml
+++ b/charts/kguardian/templates/database/secret.yaml
@@ -1,4 +1,5 @@
-{{- $existingSecret := (lookup "v1" "Secret" .Release.Namespace "kguardian-db-credentials") }}
+{{- if and .Values.database.enabled (not .Values.database.existingSecret) -}}
+{{- $existingSecret := (lookup "v1" "Secret" .Release.Namespace "kguardian-db-credentials") -}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -7,8 +8,9 @@ metadata:
     {{- include "kguardian.labels" . | nindent 4 }}
 type: Opaque
 data:
-  {{- if and $existingSecret $existingSecret.data (index $existingSecret.data "password") }}
-  password: {{ index $existingSecret.data "password" }}
+  {{- if and $existingSecret $existingSecret.data (index $existingSecret.data .Values.database.passwordSecretKey) }}
+  {{ .Values.database.passwordSecretKey }}: {{ index $existingSecret.data .Values.database.passwordSecretKey }}
   {{- else }}
-  password: {{ default (randAlphaNum 24) .Values.database.password | b64enc | quote }}
+  {{ .Values.database.passwordSecretKey }}: {{ default (randAlphaNum 24) .Values.database.password | b64enc | quote }}
   {{- end }}
+{{- end }}

--- a/charts/kguardian/templates/database/service.yaml
+++ b/charts/kguardian/templates/database/service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.database.enabled }}
 ---
 apiVersion: v1
 kind: Service
@@ -14,3 +15,4 @@ spec:
       name: http
   selector:
     app.kubernetes.io/name: {{ .Values.database.service.name }}
+{{- end }}

--- a/charts/kguardian/templates/database/serviceaccount.yaml
+++ b/charts/kguardian/templates/database/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.database.serviceAccount.create -}}
+{{- if and .Values.database.enabled .Values.database.serviceAccount.create -}}
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/charts/kguardian/values.yaml
+++ b/charts/kguardian/values.yaml
@@ -262,7 +262,39 @@ broker:
   priorityClassName: ""
 
 database:
-  # -- Database name for PostgreSQL
+  # -- Deploy the bundled in-cluster PostgreSQL. Set false to use an external
+  # PostgreSQL — populate `database.external.host` and provide credentials via
+  # `database.existingSecret`.
+  enabled: true
+
+  # -- PostgreSQL role used by the broker. Must exist on external Postgres.
+  user: rust
+  # -- Database name used by the broker. Must exist on external Postgres.
+  databaseName: kube
+
+  # -- Existing Secret containing the DB password under the key configured by
+  # `database.passwordSecretKey`. When empty AND `database.enabled=true`, the
+  # chart provisions a Secret named "kguardian-db-credentials" with a random
+  # password (regenerated only on first install).
+  existingSecret: ""
+  # -- Secret data key holding the DB password.
+  passwordSecretKey: password
+
+  # External PostgreSQL connection. Used only when `database.enabled=false`.
+  external:
+    # -- Hostname or FQDN of the external PostgreSQL instance, e.g.
+    # "postgres.databases.svc.cluster.local" or "db.example.com". Required
+    # when `database.enabled=false`.
+    host: ""
+    # -- Port of the external PostgreSQL instance.
+    port: 5432
+    # -- libpq sslmode for the external connection (disable | allow | prefer
+    # | require | verify-ca | verify-full). Cloud-managed Postgres typically
+    # requires "require" or stricter.
+    sslMode: prefer
+
+  # -- Object name for the in-cluster Database deployment / PVC / SA. Only
+  # used when `database.enabled=true`.
   name: kguardian-db
   image:
     # -- PostgreSQL container image repository

--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -168,105 +168,91 @@ controller:
 
 # Broker configuration
 broker:
-  # Number of replicas for HA
-  replicas: 2
-
-  # PostgreSQL connection
-  postgresql:
-    host: "kguardian-postgresql"
-    port: 5432
-    database: "kguardian"
-    username: "kguardian"
-    # Password from secret (created automatically)
-
-  # Persistence
-  persistence:
-    enabled: true
-    size: "10Gi"
-    storageClass: "standard"
-
-  # Resource limits
+  replicaCount: 1
   resources:
     requests:
       cpu: "100m"
       memory: "256Mi"
     limits:
-      cpu: "1000m"
       memory: "1Gi"
 
-# UI configuration
-ui:
-  # Number of replicas
-  replicas: 2
-
-  # Ingress (optional)
-  ingress:
-    enabled: true
-    className: "nginx"
-    hosts:
-      - host: kguardian.example.com
-        paths:
-          - path: /
-            pathType: Prefix
-    tls:
-      - secretName: kguardian-tls
-        hosts:
-          - kguardian.example.com
-
-# PostgreSQL configuration (uses bitnami/postgresql chart)
-postgresql:
+# Frontend (UI) — gated by `frontend.enabled`
+frontend:
   enabled: true
-  auth:
-    username: kguardian
-    password: "change-me-in-production"
-    database: kguardian
-  primary:
-    persistence:
-      enabled: true
-      size: 20Gi
-    resources:
-      requests:
-        memory: "256Mi"
-        cpu: "250m"
+  replicaCount: 1
+
+# Bundled PostgreSQL — see "Use External PostgreSQL" below to disable.
+database:
+  enabled: true
+  user: rust
+  databaseName: kube
+  image:
+    tag: "18-alpine"
+  persistence:
+    enabled: true
+    # Auto-provisioned PVC sizing (only used when existingClaim is unset)
+    size: "10Gi"
+    # Empty string => use the cluster's default StorageClass.
+    storageClassName: ""
+    # Or BYO PVC:
+    # existingClaim: "my-pg-pvc"
 ```
 
 Install with custom values:
 
 ```bash
 helm install kguardian oci://ghcr.io/kguardian-dev/charts/kguardian \
-  --version 1.9.1 \
   --namespace kguardian \
   --create-namespace \
   --values values.yaml \
   --wait
 ```
 
+For the full list of values, see [`charts/kguardian/values.yaml`](https://github.com/kguardian-dev/kguardian/blob/main/charts/kguardian/values.yaml) or the auto-generated [chart README](https://github.com/kguardian-dev/kguardian/blob/main/charts/kguardian/README.md).
+
 ### Use External PostgreSQL
 
-For production, use a managed database:
+For production-grade deployments — managed services like AWS RDS / Cloud SQL / a CloudNativePG cluster you already run — disable the bundled Postgres and point the broker at the external instance:
 
 ```yaml
-# Disable built-in PostgreSQL
-postgresql:
+database:
+  # Disable the bundled in-cluster Postgres deployment, PVC, secret, and SA.
   enabled: false
 
-# Configure broker to use external DB
-broker:
-  postgresql:
-    host: "my-postgres.rds.amazonaws.com"
+  # Role + database the broker will connect as. Must already exist on the
+  # external instance.
+  user: kguardian
+  databaseName: kguardian_prod
+
+  # The chart will not create a credentials secret when external — supply
+  # your own and reference it here.
+  existingSecret: kguardian-db-secret
+  passwordSecretKey: password
+
+  external:
+    # FQDN or hostname of the external Postgres. Can be in any namespace
+    # (or outside the cluster) — the broker resolves it via DNS.
+    host: postgres.databases.svc.cluster.local
     port: 5432
-    database: "kguardian_prod"
-    username: "kguardian_user"
-    existingSecret: "kguardian-db-secret"  # Create this manually
-    existingSecretPasswordKey: "password"
+    # libpq sslmode. Cloud-managed Postgres typically requires "require".
+    sslMode: prefer
 ```
 
-Create the secret:
+Create the secret in the kguardian namespace before installing:
 
 ```bash
+kubectl create namespace kguardian
 kubectl create secret generic kguardian-db-secret \
   --namespace kguardian \
   --from-literal=password='your-secure-password'
+```
+
+Then install:
+
+```bash
+helm install kguardian oci://ghcr.io/kguardian-dev/charts/kguardian \
+  --namespace kguardian \
+  --values values.yaml --wait
 ```
 
 ---
@@ -290,30 +276,6 @@ After deploying the controller, install the CLI to generate policies.
     - Downloads the latest CLI release
     - Installs to `/usr/local/bin/kubectl-kguardian`
     - Validates the installation
-  </Tab>
-
-  <Tab title="Krew">
-    ```bash
-    # 1. Install Krew (if not already installed)
-    (
-      set -x; cd "$(mktemp -d)" &&
-      OS="$(uname | tr '[:upper:]' '[:lower:]')" &&
-      ARCH="$(uname -m | sed -e 's/x86_64/amd64/' -e 's/\(arm\)\(64\)\?.*/\1\2/' -e 's/aarch64$/arm64/')" &&
-      KREW="krew-${OS}_${ARCH}" &&
-      curl -fsSLO "https://github.com/kubernetes-sigs/krew/releases/latest/download/${KREW}.tar.gz" &&
-      tar zxvf "${KREW}.tar.gz" &&
-      ./"${KREW}" install krew
-    )
-
-    # 2. Add Krew to PATH (add to ~/.bashrc or ~/.zshrc)
-    export PATH="${KREW_ROOT:-$HOME/.krew}/bin:$PATH"
-
-    # 3. Install kguardian plugin
-    kubectl krew install kguardian
-
-    # 4. Verify
-    kubectl kguardian --version
-    ```
   </Tab>
 
   <Tab title="Manual Download">
@@ -368,11 +330,11 @@ After installation, verify all components are working:
 kubectl get pods -n kguardian
 
 # Expected output:
-# NAME                                 READY   STATUS    RESTARTS   AGE
-# kguardian-controller-xxxxx           1/1     Running   0          5m
-# kguardian-broker-xxxxxxxxxx-xxxxx    1/1     Running   0          5m
-# kguardian-postgresql-0               1/1     Running   0          5m
-# kguardian-ui-xxxxxxxxxx-xxxxx        1/1     Running   0          5m
+# NAME                                  READY   STATUS    RESTARTS   AGE
+# kguardian-controller-xxxxx            1/1     Running   0          5m
+# kguardian-broker-xxxxxxxxxx-xxxxx     1/1     Running   0          5m
+# kguardian-db-xxxxxxxxxx-xxxxx         1/1     Running   0          5m
+# kguardian-frontend-xxxxxxxxxx-xxxxx   1/1     Running   0          5m
 ```
 
 ### 2. Check Controller Logs
@@ -452,10 +414,7 @@ helm uninstall kguardian --namespace kguardian
 # 2. Delete namespace (removes all resources)
 kubectl delete namespace kguardian
 
-# 3. Remove CLI plugin (if using Krew)
-kubectl krew uninstall kguardian
-
-# Or remove manual installation
+# 3. Remove CLI plugin
 sudo rm /usr/local/bin/kubectl-kguardian
 ```
 

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -90,20 +90,6 @@ The kguardian CLI is a kubectl plugin for generating policies.
     ```
   </Tab>
 
-  <Tab title="Krew">
-    ```bash
-    # Install via Krew plugin manager
-    kubectl krew install kguardian
-
-    # Verify installation
-    kubectl kguardian --version
-    ```
-
-    <Note>
-    Don't have Krew? Install it from [krew.sigs.k8s.io](https://krew.sigs.k8s.io/docs/user-guide/setup/install/)
-    </Note>
-  </Tab>
-
   <Tab title="Manual Download">
     ```bash
     # Download the binary for your platform


### PR DESCRIPTION
Stacks on #845. Addresses Discord feedback from cactus.

## The complaints

> is it even possible to use external postgres with this anymore? 🤔 it looks like the manifests aren't conditional and the docs seem to conflict (\`postgresql.enabled: false\` seems to be long gone, database deployment is always created, etc.)

> it also assumes the database service is in the kguardian namespace which for a centralized external database isn't going to be the case. for me my databases cluster, manifests, and service are located in a single postgres namespace...some hard coded user refs too

Both correct. The chart unconditionally renders the in-cluster Postgres deployment, and \`rust\`/\`kube\`/\`kguardian-db-credentials\` are hardcoded throughout. The docs reference \`postgresql.enabled\` and \`broker.postgresql.{host,database,...}\` config blocks that don't exist anywhere in \`values.yaml\` — pure fiction.

## Chart changes

New values (defaults match prior behaviour exactly — backwards compatible):

| Value | Default | Purpose |
|---|---|---|
| \`database.enabled\` | \`true\` | Gate for the bundled in-cluster Postgres |
| \`database.user\` | \`rust\` | Was hardcoded |
| \`database.databaseName\` | \`kube\` | Was hardcoded |
| \`database.existingSecret\` | \`\"\"\` | BYO credentials Secret |
| \`database.passwordSecretKey\` | \`password\` | Key inside that secret |
| \`database.external.host\` | \`\"\"\` | Required when \`enabled=false\` |
| \`database.external.port\` | \`5432\` | |
| \`database.external.sslMode\` | \`prefer\` | libpq sslmode (cloud DBs typically need \`require\`) |

\`database.enabled=false\` skips the bundled Deployment, Service, ServiceAccount, PVC, and auto-provisioned Secret. The broker's \`DATABASE_URL\` and the wait-for-db init probe are now built by new helpers (\`kguardian.dbHost\`, \`kguardian.dbPort\`, \`kguardian.dbUrl\`, \`kguardian.dbSecretName\`) — \`database.external.host\` is marked \`required\` so misconfiguration fails fast at \`helm install\` rather than producing a broken DATABASE_URL.

The bundled DB's \`POSTGRES_USER\`/\`POSTGRES_DB\` env vars and \`pg_isready\` probe args now read from \`database.user\`/\`database.databaseName\` instead of literal strings. Secret references key off \`database.passwordSecretKey\`.

NOTES.txt prints the active connection target (in-cluster FQDN vs external host) plus the secret it's reading, so operators can sanity-check.

## Doc fixes

- \`docs/installation.mdx\`: replaced two fabricated config blocks (\`broker.postgresql:\` and \`postgresql.enabled:\`) with the actual \`database.*\` schema, plus a working \"Use External PostgreSQL\" example using the new toggles.
- \`docs/installation.mdx\`: expected pod list referenced \`kguardian-postgresql-0\` — the real workload is \`kguardian-db-...\`.
- \`docs/installation.mdx\`, \`docs/quickstart.mdx\`, root \`README.md\`: removed all Krew install instructions (per @xUnholy in Discord, the project pivoted to the quick-install script). Krew-uninstall step also removed from the Uninstall section.

## Validation

- \`helm lint\`: clean
- \`helm template\`:
  - **default** → 18 resources, \`DATABASE_URL=postgres://rust:\$(DB_PASSWORD)@kguardian-db.<ns>.svc.cluster.local:5432/kube\` (identical to prior chart output)
  - **bundled + custom user/db** → \`POSTGRES_USER\`/\`POSTGRES_DB\`/\`pg_isready\`/\`DATABASE_URL\` all use the overrides
  - **external** → 13 resources (5 DB ones skipped), \`DATABASE_URL=postgres://<user>:\$(DB_PASSWORD)@<host>:<port>/<db>?sslmode=<mode>\`, broker reads password from \`database.existingSecret\`
- \`helm template --set database.enabled=false\` (no host) → fails with helpful \`database.external.host is required when database.enabled=false\`
- chart README.md regenerated via helm-docs

## Test plan

- [ ] CI \`charts-lint\` lint-test passes (depends on #845 also being merged — both are needed because #845 fixes the prior \`claimName: \"\"\` failure that's been blocking lint-test for a week)
- [ ] Manual: install with external Postgres against a real DB