### PR TITLE
feat(chart): startupProbe, topologySpreadConstraints, PDB, ServiceMonitor

### DIFF
--- a/charts/kguardian/README.md
+++ b/charts/kguardian/README.md
@@ -90,9 +90,18 @@ The following table lists the configurable parameters of the kguardian chart and
 | broker.initContainer.image.sha | string | `""` | Overrides the init container image tag using SHA digest |
 | broker.initContainer.image.tag | string | `"latest"` | Broker init container image tag |
 | broker.initContainer.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsNonRoot":true,"runAsUser":65534}` | Broker init container security context |
+| broker.metrics.serviceMonitor.enabled | bool | `false` | Create a ServiceMonitor for prometheus-operator. The broker does not currently expose /metrics — this is a forward-compatible toggle. |
+| broker.metrics.serviceMonitor.interval | string | `"30s"` | Scrape interval. |
+| broker.metrics.serviceMonitor.labels | object | `{}` | Extra labels to add to the ServiceMonitor (so prometheus-operator picks it up — usually `release: kube-prometheus-stack`). |
+| broker.metrics.serviceMonitor.path | string | `"/metrics"` | Endpoint path on the broker's HTTP service. |
+| broker.metrics.serviceMonitor.port | string | `"http"` | Service port name to scrape. |
+| broker.metrics.serviceMonitor.scrapeTimeout | string | `"10s"` | Scrape timeout. |
 | broker.nameOverride | string | `""` | Override the name of the broker resources |
 | broker.nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Node labels for the kguardian broker pod assignment |
 | broker.podAnnotations | object | `{}` | Annotations to add to broker pods |
+| broker.podDisruptionBudget.enabled | bool | `false` | Create a PodDisruptionBudget for the broker. Defaults to false; enable when running >1 replica so voluntary evictions can't take all of them out. |
+| broker.podDisruptionBudget.maxUnavailable | string | `""` |  |
+| broker.podDisruptionBudget.minAvailable | int | `1` | Either minAvailable or maxUnavailable can be set (not both). Accepts integer or percentage string ("50%"). |
 | broker.podSecurityContext | object | `{"fsGroup":1000,"fsGroupChangePolicy":"OnRootMismatch","runAsGroup":1000,"runAsUser":1000,"seccompProfile":{"type":"RuntimeDefault"},"supplementalGroups":[1000]}` | Broker pod security context. Runs as non-root user 1000 |
 | broker.priorityClassName | string | `""` | Priority class to be used for the kguardian broker pods |
 | broker.replicaCount | int | `1` | Number of broker replicas to deploy |
@@ -105,7 +114,9 @@ The following table lists the configurable parameters of the kguardian chart and
 | broker.serviceAccount.automountServiceAccountToken | bool | `false` | Automount API credentials for a service account |
 | broker.serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
 | broker.serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template |
+| broker.startupProbe | object | `{}` | Startup probe. Empty by default — opt in when slow startup is expected (e.g. cold image pull on small nodes). Replaces the default startup probe. |
 | broker.tolerations | list | `[]` | Tolerations for the kguardian broker pod assignment |
+| broker.topologySpreadConstraints | list | `[]` | Topology spread constraints applied to broker pods. Useful when running multiple replicas across zones/nodes. See https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/ |
 | controller.affinity | object | `{}` | Affinity rules for controller pod assignment |
 | controller.autoscaling.enabled | bool | `false` | Enable horizontal pod autoscaling for controller |
 | controller.autoscaling.maxReplicas | int | `100` | Maximum number of controller replicas |
@@ -196,9 +207,18 @@ The following table lists the configurable parameters of the kguardian chart and
 | frontend.ingress.enabled | bool | `false` | Enable ingress for frontend |
 | frontend.ingress.hosts | list | `[{"host":"kguardian.example.com","paths":[{"path":"/","pathType":"Prefix"}]}]` | Ingress hosts configuration |
 | frontend.ingress.tls | list | `[]` | Ingress TLS configuration |
+| frontend.metrics.serviceMonitor.enabled | bool | `false` | Create a ServiceMonitor for prometheus-operator. The frontend does not currently expose /metrics — forward-compatible toggle. |
+| frontend.metrics.serviceMonitor.interval | string | `"30s"` |  |
+| frontend.metrics.serviceMonitor.labels | object | `{}` |  |
+| frontend.metrics.serviceMonitor.path | string | `"/metrics"` |  |
+| frontend.metrics.serviceMonitor.port | string | `"http"` |  |
+| frontend.metrics.serviceMonitor.scrapeTimeout | string | `"10s"` |  |
 | frontend.nameOverride | string | `""` | Override the name of the frontend resources |
 | frontend.nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Node labels for the kguardian frontend pod assignment |
 | frontend.podAnnotations | object | `{}` | Annotations to add to frontend pods |
+| frontend.podDisruptionBudget.enabled | bool | `false` | Create a PodDisruptionBudget for the frontend. Defaults to false; enable when running >1 replica. |
+| frontend.podDisruptionBudget.maxUnavailable | string | `""` |  |
+| frontend.podDisruptionBudget.minAvailable | int | `1` |  |
 | frontend.podSecurityContext | object | `{"fsGroup":1337,"fsGroupChangePolicy":"OnRootMismatch","runAsGroup":1337,"runAsUser":1337,"seccompProfile":{"type":"RuntimeDefault"},"supplementalGroups":[1337]}` | Frontend pod security context. Runs as non-root user (1337) |
 | frontend.priorityClassName | string | `""` | Priority class to be used for the kguardian frontend pods |
 | frontend.replicaCount | int | `1` | Number of frontend replicas to deploy |
@@ -211,7 +231,9 @@ The following table lists the configurable parameters of the kguardian chart and
 | frontend.serviceAccount.automountServiceAccountToken | bool | `false` | Automount API credentials for a service account |
 | frontend.serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
 | frontend.serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template |
+| frontend.startupProbe | object | `{}` | Startup probe. Empty by default — opt in when slow startup is expected. |
 | frontend.tolerations | list | `[]` | Tolerations for the kguardian frontend pod assignment |
+| frontend.topologySpreadConstraints | list | `[]` | Topology spread constraints applied to frontend pods. |
 | global.annotations | object | `{}` | Annotations to apply to all resources |
 | global.labels | object | `{}` | Labels to apply to all resources |
 | global.priorityClassName | string | `""` | Priority class to be used for the kguardian pods |
@@ -229,9 +251,18 @@ The following table lists the configurable parameters of the kguardian chart and
 | llmBridge.image.sha | string | `""` | Overrides the image tag using SHA digest |
 | llmBridge.image.tag | string | `"1.2.3"` | LLM Bridge version tag (auto-updated by release-please) |
 | llmBridge.imagePullSecrets | list | `[]` | List of image pull secrets for private registries |
+| llmBridge.metrics.serviceMonitor.enabled | bool | `false` | Create a ServiceMonitor for prometheus-operator. llm-bridge does not currently expose /metrics — forward-compatible toggle. |
+| llmBridge.metrics.serviceMonitor.interval | string | `"30s"` |  |
+| llmBridge.metrics.serviceMonitor.labels | object | `{}` |  |
+| llmBridge.metrics.serviceMonitor.path | string | `"/metrics"` |  |
+| llmBridge.metrics.serviceMonitor.port | string | `"http"` |  |
+| llmBridge.metrics.serviceMonitor.scrapeTimeout | string | `"10s"` |  |
 | llmBridge.nameOverride | string | `""` | Override the name of the llm-bridge resources |
 | llmBridge.nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Node labels for the kguardian llm-bridge pod assignment |
 | llmBridge.podAnnotations | object | `{}` | Annotations to add to llm-bridge pods |
+| llmBridge.podDisruptionBudget.enabled | bool | `false` | Create a PodDisruptionBudget for the llm-bridge. Defaults to false; enable when running >1 replica. |
+| llmBridge.podDisruptionBudget.maxUnavailable | string | `""` |  |
+| llmBridge.podDisruptionBudget.minAvailable | int | `1` |  |
 | llmBridge.podSecurityContext | object | `{"fsGroup":1000,"fsGroupChangePolicy":"OnRootMismatch","runAsGroup":1000,"runAsUser":1000,"seccompProfile":{"type":"RuntimeDefault"},"supplementalGroups":[1000]}` | LLM Bridge pod security context. Runs as non-root user (node:1000) |
 | llmBridge.priorityClassName | string | `""` | Priority class to be used for the kguardian llm-bridge pods |
 | llmBridge.replicaCount | int | `2` | Number of llm-bridge replicas to deploy |
@@ -253,7 +284,9 @@ The following table lists the configurable parameters of the kguardian chart and
 | llmBridge.serviceAccount.automountServiceAccountToken | bool | `false` | Automount API credentials for a service account |
 | llmBridge.serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
 | llmBridge.serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template |
+| llmBridge.startupProbe | object | `{}` | Startup probe. Empty by default — opt in when slow startup is expected. |
 | llmBridge.tolerations | list | `[]` | Tolerations for the kguardian llm-bridge pod assignment |
+| llmBridge.topologySpreadConstraints | list | `[]` | Topology spread constraints applied to llm-bridge pods. |
 | mcpServer.affinity | object | `{}` | Affinity rules for mcp-server pod assignment |
 | mcpServer.autoscaling.enabled | bool | `false` | Enable horizontal pod autoscaling for mcp-server |
 | mcpServer.autoscaling.maxReplicas | int | `5` | Maximum number of mcp-server replicas |
@@ -268,9 +301,18 @@ The following table lists the configurable parameters of the kguardian chart and
 | mcpServer.image.sha | string | `""` | Overrides the image tag using SHA digest |
 | mcpServer.image.tag | string | `"1.3.4"` | MCP Server version tag (auto-updated by release-please) |
 | mcpServer.imagePullSecrets | list | `[]` | List of image pull secrets for private registries |
+| mcpServer.metrics.serviceMonitor.enabled | bool | `false` | Create a ServiceMonitor for prometheus-operator. mcp-server has a /metrics endpoint configured via kmcp.yaml; toggle this on once the exposed port matches `service.port`. |
+| mcpServer.metrics.serviceMonitor.interval | string | `"30s"` |  |
+| mcpServer.metrics.serviceMonitor.labels | object | `{}` |  |
+| mcpServer.metrics.serviceMonitor.path | string | `"/metrics"` |  |
+| mcpServer.metrics.serviceMonitor.port | string | `"http"` |  |
+| mcpServer.metrics.serviceMonitor.scrapeTimeout | string | `"10s"` |  |
 | mcpServer.nameOverride | string | `""` | Override the name of the mcp-server resources |
 | mcpServer.nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Node labels for the kguardian mcp-server pod assignment |
 | mcpServer.podAnnotations | object | `{}` | Annotations to add to mcp-server pods |
+| mcpServer.podDisruptionBudget.enabled | bool | `false` | Create a PodDisruptionBudget for the mcp-server. Defaults to false; enable when running >1 replica. |
+| mcpServer.podDisruptionBudget.maxUnavailable | string | `""` |  |
+| mcpServer.podDisruptionBudget.minAvailable | int | `1` |  |
 | mcpServer.podSecurityContext | object | `{"fsGroup":1000,"fsGroupChangePolicy":"OnRootMismatch","runAsGroup":1000,"runAsUser":1000,"seccompProfile":{"type":"RuntimeDefault"},"supplementalGroups":[1000]}` | MCP Server pod security context. Runs as non-root user (mcp:1000) |
 | mcpServer.priorityClassName | string | `""` | Priority class to be used for the kguardian mcp-server pods |
 | mcpServer.replicaCount | int | `1` | Number of mcp-server replicas to deploy (ignored if useKmcp is true and autoscaling is enabled) |
@@ -283,7 +325,9 @@ The following table lists the configurable parameters of the kguardian chart and
 | mcpServer.serviceAccount.automountServiceAccountToken | bool | `false` | Automount API credentials for a service account |
 | mcpServer.serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
 | mcpServer.serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template |
+| mcpServer.startupProbe | object | `{}` | Startup probe. Empty by default — opt in when slow startup is expected. |
 | mcpServer.tolerations | list | `[]` | Tolerations for the kguardian mcp-server pod assignment |
+| mcpServer.topologySpreadConstraints | list | `[]` | Topology spread constraints applied to mcp-server pods. |
 | namespace.annotations | object | `{}` | Annotations to add to the namespace |
 | namespace.labels | object | `{}` | Labels to add to the namespace |
 | namespace.name | string | `""` | Namespace name. If empty, uses the release namespace |

--- a/charts/kguardian/templates/broker/deployment.yaml
+++ b/charts/kguardian/templates/broker/deployment.yaml
@@ -63,6 +63,10 @@ spec:
                   key: {{ .Values.database.passwordSecretKey }}
             - name: DATABASE_URL
               value: {{ include "kguardian.dbUrl" . | quote }}
+          {{- with .Values.broker.startupProbe }}
+          startupProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           livenessProbe:
             httpGet:
               path: /health
@@ -93,5 +97,9 @@ spec:
       {{- end }}
       {{- with .Values.broker.tolerations }}
       tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.broker.topologySpreadConstraints }}
+      topologySpreadConstraints:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/kguardian/templates/broker/pdb.yaml
+++ b/charts/kguardian/templates/broker/pdb.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.broker.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "kguardian.name" . }}-broker
+  labels:
+    {{- include "kguardian.labels" . | nindent 4 }}
+spec:
+  {{- if .Values.broker.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.broker.podDisruptionBudget.maxUnavailable }}
+  {{- else }}
+  minAvailable: {{ .Values.broker.podDisruptionBudget.minAvailable | default 1 }}
+  {{- end }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ .Values.broker.service.name }}
+{{- end }}

--- a/charts/kguardian/templates/broker/servicemonitor.yaml
+++ b/charts/kguardian/templates/broker/servicemonitor.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.broker.metrics.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "kguardian.name" . }}-broker
+  {{- with .Values.broker.metrics.serviceMonitor.namespace }}
+  namespace: {{ . | quote }}
+  {{- end }}
+  labels:
+    {{- include "kguardian.labels" . | nindent 4 }}
+    {{- with .Values.broker.metrics.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ .Values.broker.service.name }}
+  namespaceSelector:
+    matchNames:
+      - {{ include "kguardian.namespace" . | trim }}
+  endpoints:
+    - port: {{ .Values.broker.metrics.serviceMonitor.port }}
+      path: {{ .Values.broker.metrics.serviceMonitor.path }}
+      interval: {{ .Values.broker.metrics.serviceMonitor.interval }}
+      scrapeTimeout: {{ .Values.broker.metrics.serviceMonitor.scrapeTimeout }}
+{{- end }}

--- a/charts/kguardian/templates/frontend/deployment.yaml
+++ b/charts/kguardian/templates/frontend/deployment.yaml
@@ -51,6 +51,10 @@ spec:
             - name: VITE_LLM_BRIDGE_URL
               value: "http://{{ .Values.llmBridge.service.name }}.{{ include "kguardian.namespace" . }}.svc.cluster.local:{{ .Values.llmBridge.service.port }}"
             {{- end }}
+          {{- with .Values.frontend.startupProbe }}
+          startupProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           livenessProbe:
             httpGet:
               path: /
@@ -77,5 +81,9 @@ spec:
       {{- end }}
       {{- with .Values.frontend.tolerations }}
       tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.frontend.topologySpreadConstraints }}
+      topologySpreadConstraints:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/kguardian/templates/frontend/pdb.yaml
+++ b/charts/kguardian/templates/frontend/pdb.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.frontend.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "kguardian.name" . }}-frontend
+  labels:
+    {{- include "kguardian.labels" . | nindent 4 }}
+spec:
+  {{- if .Values.frontend.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.frontend.podDisruptionBudget.maxUnavailable }}
+  {{- else }}
+  minAvailable: {{ .Values.frontend.podDisruptionBudget.minAvailable | default 1 }}
+  {{- end }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ .Values.frontend.service.name }}
+{{- end }}

--- a/charts/kguardian/templates/frontend/servicemonitor.yaml
+++ b/charts/kguardian/templates/frontend/servicemonitor.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.frontend.metrics.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "kguardian.name" . }}-frontend
+  {{- with .Values.frontend.metrics.serviceMonitor.namespace }}
+  namespace: {{ . | quote }}
+  {{- end }}
+  labels:
+    {{- include "kguardian.labels" . | nindent 4 }}
+    {{- with .Values.frontend.metrics.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ .Values.frontend.service.name }}
+  namespaceSelector:
+    matchNames:
+      - {{ include "kguardian.namespace" . | trim }}
+  endpoints:
+    - port: {{ .Values.frontend.metrics.serviceMonitor.port }}
+      path: {{ .Values.frontend.metrics.serviceMonitor.path }}
+      interval: {{ .Values.frontend.metrics.serviceMonitor.interval }}
+      scrapeTimeout: {{ .Values.frontend.metrics.serviceMonitor.scrapeTimeout }}
+{{- end }}

--- a/charts/kguardian/templates/llm-bridge/deployment.yaml
+++ b/charts/kguardian/templates/llm-bridge/deployment.yaml
@@ -89,6 +89,10 @@ spec:
             {{- with .Values.llmBridge.env }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
+          {{- with .Values.llmBridge.startupProbe }}
+          startupProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           livenessProbe:
             httpGet:
               path: /health
@@ -115,6 +119,10 @@ spec:
       {{- end }}
       {{- with .Values.llmBridge.tolerations }}
       tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.llmBridge.topologySpreadConstraints }}
+      topologySpreadConstraints:
         {{- toYaml . | nindent 8 }}
       {{- end }}
 {{- end }}

--- a/charts/kguardian/templates/llm-bridge/pdb.yaml
+++ b/charts/kguardian/templates/llm-bridge/pdb.yaml
@@ -1,0 +1,17 @@
+{{- if and .Values.llmBridge.enabled .Values.llmBridge.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ .Values.llmBridge.service.name }}
+  labels:
+    {{- include "kguardian.labels" . | nindent 4 }}
+spec:
+  {{- if .Values.llmBridge.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.llmBridge.podDisruptionBudget.maxUnavailable }}
+  {{- else }}
+  minAvailable: {{ .Values.llmBridge.podDisruptionBudget.minAvailable | default 1 }}
+  {{- end }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ .Values.llmBridge.service.name }}
+{{- end }}

--- a/charts/kguardian/templates/llm-bridge/servicemonitor.yaml
+++ b/charts/kguardian/templates/llm-bridge/servicemonitor.yaml
@@ -1,0 +1,26 @@
+{{- if and .Values.llmBridge.enabled .Values.llmBridge.metrics.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ .Values.llmBridge.service.name }}
+  {{- with .Values.llmBridge.metrics.serviceMonitor.namespace }}
+  namespace: {{ . | quote }}
+  {{- end }}
+  labels:
+    {{- include "kguardian.labels" . | nindent 4 }}
+    {{- with .Values.llmBridge.metrics.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ .Values.llmBridge.service.name }}
+  namespaceSelector:
+    matchNames:
+      - {{ include "kguardian.namespace" . | trim }}
+  endpoints:
+    - port: {{ .Values.llmBridge.metrics.serviceMonitor.port }}
+      path: {{ .Values.llmBridge.metrics.serviceMonitor.path }}
+      interval: {{ .Values.llmBridge.metrics.serviceMonitor.interval }}
+      scrapeTimeout: {{ .Values.llmBridge.metrics.serviceMonitor.scrapeTimeout }}
+{{- end }}

--- a/charts/kguardian/templates/mcp-server/deployment.yaml
+++ b/charts/kguardian/templates/mcp-server/deployment.yaml
@@ -53,6 +53,10 @@ spec:
             {{- with .Values.mcpServer.env }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
+          {{- with .Values.mcpServer.startupProbe }}
+          startupProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           livenessProbe:
             httpGet:
               path: /healthz
@@ -79,6 +83,10 @@ spec:
       {{- end }}
       {{- with .Values.mcpServer.tolerations }}
       tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.mcpServer.topologySpreadConstraints }}
+      topologySpreadConstraints:
         {{- toYaml . | nindent 8 }}
       {{- end }}
 {{- end }}

--- a/charts/kguardian/templates/mcp-server/pdb.yaml
+++ b/charts/kguardian/templates/mcp-server/pdb.yaml
@@ -1,0 +1,17 @@
+{{- if and .Values.mcpServer.enabled .Values.mcpServer.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ .Values.mcpServer.service.name }}
+  labels:
+    {{- include "kguardian.labels" . | nindent 4 }}
+spec:
+  {{- if .Values.mcpServer.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.mcpServer.podDisruptionBudget.maxUnavailable }}
+  {{- else }}
+  minAvailable: {{ .Values.mcpServer.podDisruptionBudget.minAvailable | default 1 }}
+  {{- end }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ .Values.mcpServer.service.name }}
+{{- end }}

--- a/charts/kguardian/templates/mcp-server/servicemonitor.yaml
+++ b/charts/kguardian/templates/mcp-server/servicemonitor.yaml
@@ -1,0 +1,26 @@
+{{- if and .Values.mcpServer.enabled .Values.mcpServer.metrics.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ .Values.mcpServer.service.name }}
+  {{- with .Values.mcpServer.metrics.serviceMonitor.namespace }}
+  namespace: {{ . | quote }}
+  {{- end }}
+  labels:
+    {{- include "kguardian.labels" . | nindent 4 }}
+    {{- with .Values.mcpServer.metrics.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ .Values.mcpServer.service.name }}
+  namespaceSelector:
+    matchNames:
+      - {{ include "kguardian.namespace" . | trim }}
+  endpoints:
+    - port: {{ .Values.mcpServer.metrics.serviceMonitor.port }}
+      path: {{ .Values.mcpServer.metrics.serviceMonitor.path }}
+      interval: {{ .Values.mcpServer.metrics.serviceMonitor.interval }}
+      scrapeTimeout: {{ .Values.mcpServer.metrics.serviceMonitor.scrapeTimeout }}
+{{- end }}

--- a/charts/kguardian/values.yaml
+++ b/charts/kguardian/values.yaml
@@ -261,6 +261,53 @@ broker:
   # -- Priority class to be used for the kguardian broker pods
   priorityClassName: ""
 
+  # -- Startup probe. Empty by default — opt in when slow startup is expected
+  # (e.g. cold image pull on small nodes). Replaces the default startup probe.
+  startupProbe: {}
+  # Example:
+  # startupProbe:
+  #   httpGet: { path: /health, port: http }
+  #   failureThreshold: 30
+  #   periodSeconds: 10
+
+  # -- Topology spread constraints applied to broker pods. Useful when running
+  # multiple replicas across zones/nodes. See
+  # https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/
+  topologySpreadConstraints: []
+  # Example:
+  # - maxSkew: 1
+  #   topologyKey: kubernetes.io/hostname
+  #   whenUnsatisfiable: ScheduleAnyway
+  #   labelSelector:
+  #     matchLabels:
+  #       app.kubernetes.io/name: kguardian-broker
+
+  podDisruptionBudget:
+    # -- Create a PodDisruptionBudget for the broker. Defaults to false; enable
+    # when running >1 replica so voluntary evictions can't take all of them out.
+    enabled: false
+    # -- Either minAvailable or maxUnavailable can be set (not both).
+    # Accepts integer or percentage string ("50%").
+    minAvailable: 1
+    maxUnavailable: ""
+
+  metrics:
+    serviceMonitor:
+      # -- Create a ServiceMonitor for prometheus-operator. The broker does
+      # not currently expose /metrics — this is a forward-compatible toggle.
+      enabled: false
+      # -- Endpoint path on the broker's HTTP service.
+      path: /metrics
+      # -- Service port name to scrape.
+      port: http
+      # -- Scrape interval.
+      interval: 30s
+      # -- Scrape timeout.
+      scrapeTimeout: 10s
+      # -- Extra labels to add to the ServiceMonitor (so prometheus-operator
+      # picks it up — usually `release: kube-prometheus-stack`).
+      labels: {}
+
 database:
   # -- Deploy the bundled in-cluster PostgreSQL. Set false to use an external
   # PostgreSQL — populate `database.external.host` and provide credentials via
@@ -505,6 +552,30 @@ frontend:
   # -- Priority class to be used for the kguardian frontend pods
   priorityClassName: ""
 
+  # -- Startup probe. Empty by default — opt in when slow startup is expected.
+  startupProbe: {}
+
+  # -- Topology spread constraints applied to frontend pods.
+  topologySpreadConstraints: []
+
+  podDisruptionBudget:
+    # -- Create a PodDisruptionBudget for the frontend. Defaults to false;
+    # enable when running >1 replica.
+    enabled: false
+    minAvailable: 1
+    maxUnavailable: ""
+
+  metrics:
+    serviceMonitor:
+      # -- Create a ServiceMonitor for prometheus-operator. The frontend
+      # does not currently expose /metrics — forward-compatible toggle.
+      enabled: false
+      path: /metrics
+      port: http
+      interval: 30s
+      scrapeTimeout: 10s
+      labels: {}
+
   ingress:
     # -- Enable ingress for frontend
     enabled: false
@@ -625,6 +696,30 @@ llmBridge:
 
   # -- Priority class to be used for the kguardian llm-bridge pods
   priorityClassName: ""
+
+  # -- Startup probe. Empty by default — opt in when slow startup is expected.
+  startupProbe: {}
+
+  # -- Topology spread constraints applied to llm-bridge pods.
+  topologySpreadConstraints: []
+
+  podDisruptionBudget:
+    # -- Create a PodDisruptionBudget for the llm-bridge. Defaults to false;
+    # enable when running >1 replica.
+    enabled: false
+    minAvailable: 1
+    maxUnavailable: ""
+
+  metrics:
+    serviceMonitor:
+      # -- Create a ServiceMonitor for prometheus-operator. llm-bridge does
+      # not currently expose /metrics — forward-compatible toggle.
+      enabled: false
+      path: /metrics
+      port: http
+      interval: 30s
+      scrapeTimeout: 10s
+      labels: {}
 
   # -- Additional environment variables for llm-bridge
   env: []
@@ -772,3 +867,28 @@ mcpServer:
 
   # -- Priority class to be used for the kguardian mcp-server pods
   priorityClassName: ""
+
+  # -- Startup probe. Empty by default — opt in when slow startup is expected.
+  startupProbe: {}
+
+  # -- Topology spread constraints applied to mcp-server pods.
+  topologySpreadConstraints: []
+
+  podDisruptionBudget:
+    # -- Create a PodDisruptionBudget for the mcp-server. Defaults to false;
+    # enable when running >1 replica.
+    enabled: false
+    minAvailable: 1
+    maxUnavailable: ""
+
+  metrics:
+    serviceMonitor:
+      # -- Create a ServiceMonitor for prometheus-operator. mcp-server has a
+      # /metrics endpoint configured via kmcp.yaml; toggle this on once the
+      # exposed port matches `service.port`.
+      enabled: false
+      path: /metrics
+      port: http
+      interval: 30s
+      scrapeTimeout: 10s
+      labels: {}


### PR DESCRIPTION
Brings the kguardian chart in line with the patterns standardised in the user's k8s-gitops repo. All new toggles default to off so existing helm releases are byte-identical until users opt in.

## Tier A — startupProbe (configurable)

Added `<workload>.startupProbe: {}` for **broker**, **frontend**, **llm-bridge**, **mcp-server**. When non-empty, renders into the container spec ahead of liveness/readiness. Useful for slow-starting workloads (cold image pulls on small nodes).

Example:
```yaml
broker:
  startupProbe:
    httpGet: { path: /health, port: http }
    failureThreshold: 30
    periodSeconds: 10
```

Controller is intentionally skipped — the eBPF DaemonSet has no HTTP listener, so probes there require controller-side code work (separate follow-up).

> Note: Tier A2 (security context hardening) turned out to be already done. broker / frontend / llm-bridge / mcp-server all have proper `runAsUser` / `runAsGroup` / `fsGroup` set already. Controller's are deliberately commented because eBPF needs privileged + root.

## Tier B — topologySpreadConstraints + PodDisruptionBudget

`<workload>.topologySpreadConstraints: []` (default empty) renders into the pod spec when populated.

`<workload>.podDisruptionBudget` block:
```yaml
broker:
  podDisruptionBudget:
    enabled: false
    minAvailable: 1
    maxUnavailable: ""  # mutually exclusive with minAvailable
```

Per-workload PDB templates emit `policy/v1 PodDisruptionBudget` only when enabled. Defaults are off because the chart's default `replicaCount` is 1 and a PDB on a single-replica workload would block all voluntary evictions.

- **Database** excluded (single-replica stateful).
- **Controller** excluded (DaemonSet — disruption budget has no meaning).

## Tier C — ServiceMonitor (prometheus-operator)

`<workload>.metrics.serviceMonitor` block (default `enabled: false`) controls a `monitoring.coreos.com/v1 ServiceMonitor` template per workload, with `path`, `port`, `interval`, `scrapeTimeout`, `labels`, and override `namespace` knobs.

```yaml
broker:
  metrics:
    serviceMonitor:
      enabled: true
      path: /metrics
      port: http
      interval: 30s
      scrapeTimeout: 10s
      labels:
        release: kube-prometheus-stack   # or whatever your operator's selector is
```

**Forward-compatible:** no workload currently exposes `/metrics`, so toggles stay off until the application code is updated. The chart wiring is in place when that happens.

## Validation

- `helm lint`: clean
- `helm template` (defaults): 0 PDBs, 0 ServiceMonitors, 0 startupProbes, 0 topologySpreadConstraints rendered. Existing installs see no change.
- `helm template -f all-on.yaml` (every workload's PDB + SM enabled): 4 PDBs + 4 ServiceMonitors render with correct selectors and namespaceSelectors.
- `helm template` with `broker.startupProbe` + `broker.topologySpreadConstraints` set: both render correctly inside the broker deployment.
- `helm template --set broker.podDisruptionBudget.maxUnavailable=25%`: PDB renders with `maxUnavailable: 25%` (mutually exclusive path covered).
- `charts/kguardian/README.md` regenerated via helm-docs.

## Test plan

- [ ] CI `lint-test` passes (chart-testing's `ct install` against a kind cluster — should succeed since defaults are unchanged from main)
- [ ] Manual: enable `broker.podDisruptionBudget.enabled=true` against a 2-replica broker and confirm `kubectl drain` respects the PDB