### PR TITLE
feat(broker): audit_verdicts retention loop

### DIFF
--- a/broker/src/lib.rs
+++ b/broker/src/lib.rs
@@ -2,12 +2,14 @@ mod add;
 mod audit;
 mod error;
 mod get;
+mod retention;
 mod telemetry;
 mod types;
 pub use add::{
     add_pod_details, add_pods, add_pods_batch, add_pods_syscalls, add_svc_details, mark_pod_dead,
 };
 pub use audit::AuditClient;
+pub use retention::spawn as spawn_retention;
 pub use error::*;
 pub use telemetry::*;
 pub use types::*;

--- a/broker/src/main.rs
+++ b/broker/src/main.rs
@@ -6,7 +6,7 @@ use api::{
     add_pod_details, add_pods, add_pods_batch, add_pods_syscalls, add_svc_details,
     establish_connection, get_pod_by_ip, get_pod_by_name, get_pod_details, get_pod_syscall_name,
     get_pod_traffic, get_pod_traffic_name, get_pods_by_node, get_svc_by_ip, get_svc_details,
-    mark_pod_dead, AuditClient,
+    mark_pod_dead, spawn_retention, AuditClient,
 };
 
 use diesel::r2d2;
@@ -73,6 +73,11 @@ async fn main() -> Result<(), std::io::Error> {
     } else {
         info!("audit evaluator integration disabled (set EVALUATOR_URL to enable)");
     }
+
+    // Background pruner for audit_verdicts. Runs in-process so the
+    // broker is self-contained — no separate CronJob needed in the
+    // chart. Disable by setting AUDIT_VERDICTS_RETENTION_DAYS=0.
+    spawn_retention(pool.clone());
 
     HttpServer::new(move || {
         let cors = Cors::default()

--- a/broker/src/retention.rs
+++ b/broker/src/retention.rs
@@ -1,0 +1,120 @@
+//! Periodic cleanup of old audit_verdicts rows.
+//!
+//! The audit_verdicts table grows monotonically with the volume of
+//! "would deny" flow events. Without a retention policy, indexes
+//! degrade and disk usage climbs indefinitely on busy clusters.
+//!
+//! This module spawns a tokio task on broker startup that wakes every
+//! `RETENTION_INTERVAL` and runs:
+//!
+//!     DELETE FROM audit_verdicts WHERE observed_at < NOW() - INTERVAL '<N> days';
+//!
+//! Configuration:
+//!
+//! - `AUDIT_VERDICTS_RETENTION_DAYS` (default 30) — anything older than
+//!   N days is eligible for deletion. Setting to 0 disables retention.
+//! - `AUDIT_VERDICTS_RETENTION_INTERVAL_SECS` (default 3600 = 1h) — how
+//!   often the cleanup task runs.
+//!
+//! Errors are logged and the task continues; a transient DB outage
+//! never crashes the broker.
+
+use diesel::pg::PgConnection;
+use diesel::prelude::*;
+use diesel::r2d2::{self, ConnectionManager};
+use diesel::sql_query;
+use std::time::Duration;
+use tracing::{debug, info, warn};
+
+type DbPool = r2d2::Pool<ConnectionManager<PgConnection>>;
+
+const DEFAULT_RETENTION_DAYS: u32 = 30;
+const DEFAULT_INTERVAL_SECS: u64 = 3600;
+
+/// Spawn a background task that periodically prunes audit_verdicts.
+/// Returns immediately; the task lives for the broker's lifetime.
+///
+/// When `AUDIT_VERDICTS_RETENTION_DAYS=0`, retention is disabled and
+/// the task is not spawned.
+pub fn spawn(pool: DbPool) {
+    let days = retention_days();
+    if days == 0 {
+        info!("audit_verdicts retention disabled (AUDIT_VERDICTS_RETENTION_DAYS=0)");
+        return;
+    }
+    let interval = retention_interval();
+    info!(
+        days,
+        interval_secs = interval.as_secs(),
+        "audit_verdicts retention loop scheduled"
+    );
+
+    actix_web::rt::spawn(async move {
+        // First pass after a short warmup so the broker doesn't hammer
+        // a cold pool the second it starts.
+        tokio::time::sleep(Duration::from_secs(60)).await;
+        loop {
+            run_pass(&pool, days).await;
+            tokio::time::sleep(interval).await;
+        }
+    });
+}
+
+/// One cleanup pass — runs in a blocking pool task because diesel is
+/// sync. Logs the result and never propagates errors.
+async fn run_pass(pool: &DbPool, days: u32) {
+    let pool = pool.clone();
+    let result = tokio::task::spawn_blocking(move || -> Result<usize, RetentionError> {
+        let mut conn = pool.get().map_err(RetentionError::Pool)?;
+        let interval = format!("{} days", days);
+        // The interval value is server-side computed (NOW() -
+        // INTERVAL ...) using a parameterised value via diesel's
+        // sql_query bind. We construct the literal in code and bind
+        // as text — the server casts to interval. That avoids any
+        // SQL-injection surface even if `days` were ever sourced from
+        // user input (it isn't, but defensible).
+        let deleted = sql_query(
+            "DELETE FROM audit_verdicts \
+             WHERE observed_at < (NOW() - $1::interval)",
+        )
+        .bind::<diesel::sql_types::Text, _>(interval)
+        .execute(&mut conn)
+        .map_err(RetentionError::Diesel)?;
+        Ok(deleted)
+    })
+    .await;
+    match result {
+        Ok(Ok(0)) => debug!("audit_verdicts retention: 0 rows pruned"),
+        Ok(Ok(n)) => info!(rows = n, "audit_verdicts retention pruned old rows"),
+        Ok(Err(RetentionError::Pool(e))) => {
+            warn!(error = %e, "audit_verdicts retention: could not get db conn")
+        }
+        Ok(Err(RetentionError::Diesel(e))) => {
+            warn!(error = %e, "audit_verdicts retention: DELETE failed")
+        }
+        Err(e) => warn!(error = %e, "audit_verdicts retention task panicked"),
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+enum RetentionError {
+    #[error("connection pool: {0}")]
+    Pool(#[from] diesel::r2d2::PoolError),
+    #[error("delete: {0}")]
+    Diesel(#[from] diesel::result::Error),
+}
+
+fn retention_days() -> u32 {
+    std::env::var("AUDIT_VERDICTS_RETENTION_DAYS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(DEFAULT_RETENTION_DAYS)
+}
+
+fn retention_interval() -> Duration {
+    let secs = std::env::var("AUDIT_VERDICTS_RETENTION_INTERVAL_SECS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(DEFAULT_INTERVAL_SECS);
+    Duration::from_secs(secs.max(60))
+}

--- a/charts/kguardian/README.md
+++ b/charts/kguardian/README.md
@@ -74,6 +74,8 @@ The following table lists the configurable parameters of the kguardian chart and
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | broker.affinity | object | `{}` | Affinity rules for broker pod assignment |
+| broker.audit.retention.days | int | `30` | Retain audit_verdicts rows for this many days. Older rows are pruned by a tokio task in the broker that wakes every `intervalSeconds`. Set to 0 to disable retention entirely (table grows unbounded). |
+| broker.audit.retention.intervalSeconds | int | `3600` | How often the cleanup pass runs, in seconds. Minimum 60. |
 | broker.autoscaling.enabled | bool | `false` | Enable horizontal pod autoscaling for broker |
 | broker.autoscaling.maxReplicas | int | `100` | Maximum number of broker replicas |
 | broker.autoscaling.minReplicas | int | `1` | Minimum number of broker replicas |

--- a/charts/kguardian/templates/broker/deployment.yaml
+++ b/charts/kguardian/templates/broker/deployment.yaml
@@ -67,6 +67,14 @@ spec:
             - name: EVALUATOR_URL
               value: "http://{{ .Values.evaluator.service.name }}.{{ include "kguardian.namespace" . | trim }}.svc.cluster.local:{{ .Values.evaluator.service.port }}"
             {{- end }}
+            {{- with .Values.broker.audit.retention.days }}
+            - name: AUDIT_VERDICTS_RETENTION_DAYS
+              value: {{ . | quote }}
+            {{- end }}
+            {{- with .Values.broker.audit.retention.intervalSeconds }}
+            - name: AUDIT_VERDICTS_RETENTION_INTERVAL_SECS
+              value: {{ . | quote }}
+            {{- end }}
           {{- with .Values.broker.startupProbe }}
           startupProbe:
             {{- toYaml . | nindent 12 }}

--- a/charts/kguardian/values.yaml
+++ b/charts/kguardian/values.yaml
@@ -261,6 +261,16 @@ broker:
   # -- Priority class to be used for the kguardian broker pods
   priorityClassName: ""
 
+  audit:
+    retention:
+      # -- Retain audit_verdicts rows for this many days. Older rows are
+      # pruned by a tokio task in the broker that wakes every
+      # `intervalSeconds`. Set to 0 to disable retention entirely
+      # (table grows unbounded).
+      days: 30
+      # -- How often the cleanup pass runs, in seconds. Minimum 60.
+      intervalSeconds: 3600
+
   # -- Startup probe. Empty by default — opt in when slow startup is expected
   # (e.g. cold image pull on small nodes). Replaces the default startup probe.
   startupProbe: {}


### PR DESCRIPTION
Closes the retention follow-up documented in the \`audit_verdicts\` migration. Without retention the table grew monotonically with WouldDeny traffic; on busy clusters this degraded the \`(policy_uid, observed_at)\` index and inflated disk usage indefinitely.

## What this does

A small tokio task in the broker wakes on a configurable interval and runs:

\`\`\`sql
DELETE FROM audit_verdicts WHERE observed_at < (NOW() - INTERVAL '<N> days');
\`\`\`

The task spawns from \`main.rs\` after the pool is built. Tokio's \`spawn_blocking\` keeps the diesel call off the actix runtime workers. Errors are logged and swallowed — a transient DB issue never crashes the broker.

## Configuration

| Env var | Default | Purpose |
|---|---|---|
| \`AUDIT_VERDICTS_RETENTION_DAYS\` | 30 | Anything older than N days is pruned. \`0\` disables the loop. |
| \`AUDIT_VERDICTS_RETENTION_INTERVAL_SECS\` | 3600 (1h) | How often the cleanup pass runs. Floored to 60s. |

Surfaced in the chart as \`broker.audit.retention.{days,intervalSeconds}\` so operators tune via values.yaml.

## Why in-broker, not a CronJob or pg_cron

- **Self-contained chart**: no extra resources, no extension dependency. Users on vanilla Postgres get retention without provisioning \`pg_partman\` / \`pg_cron\`.
- **One DB connection from the existing r2d2 pool**: zero additional RBAC, no second container, no new failure mode.
- **Tied to broker lifecycle**: when the broker is down nothing's writing to \`audit_verdicts\` anyway.

If high-volume clusters later need partition-based retention (faster than DELETE), the SQL can change without affecting this loop.

## Validation

- \`cargo check --manifest-path broker/Cargo.toml\` clean (against PG18-linked libpq)
- \`helm lint\` clean
- \`helm template --set evaluator.enabled=true\` renders \`AUDIT_VERDICTS_RETENTION_DAYS\` + \`AUDIT_VERDICTS_RETENTION_INTERVAL_SECS\` on the broker deployment

## Test plan

- [ ] CI \`build-broker\` passes (Rust changes — \`retention\` module + \`spawn_retention\` import)
- [ ] CI \`lint-test\` passes (chart additions are env-only)
- [ ] Manual: deploy with \`broker.audit.retention.days=1\` against a populated audit_verdicts table; observe broker log line \`audit_verdicts retention pruned old rows\` within \`intervalSeconds\` and confirm rows older than 1 day are gone