### PR TITLE
feat(frontend,broker): audit verdicts panel — Allow + WouldDeny preview

### DIFF
--- a/broker/db/migrations/2026-05-08-100000_audit_verdict_column/down.sql
+++ b/broker/db/migrations/2026-05-08-100000_audit_verdict_column/down.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS idx_audit_verdicts_verdict_time;
+ALTER TABLE audit_verdicts DROP COLUMN IF EXISTS verdict;

--- a/broker/db/migrations/2026-05-08-100000_audit_verdict_column/up.sql
+++ b/broker/db/migrations/2026-05-08-100000_audit_verdict_column/up.sql
@@ -1,0 +1,15 @@
+-- Add a `verdict` column so we can persist Allow rows alongside
+-- WouldDeny ones. Without this, operators only see "what's blocked"
+-- — they can't verify "what's permitted" or spot policies whose
+-- selectors don't match anything (which would have zero of either).
+--
+-- Existing rows pre-date this column. They were all WouldDeny by
+-- construction (the broker's audit forwarder previously filtered to
+-- that single verdict before insert), so the default is safe.
+ALTER TABLE audit_verdicts
+  ADD COLUMN verdict VARCHAR NOT NULL DEFAULT 'WouldDeny';
+
+-- Composite index for "show me only Allow / only WouldDeny within a
+-- time window" queries surfaced in the frontend's verdict filter.
+CREATE INDEX idx_audit_verdicts_verdict_time
+  ON audit_verdicts (verdict, observed_at DESC);

--- a/broker/src/audit.rs
+++ b/broker/src/audit.rs
@@ -88,6 +88,9 @@ struct AuditVerdictInsert {
     protocol: String,
     reason: Option<String>,
     observed_at: chrono::NaiveDateTime,
+    /// "Allow" or "WouldDeny". NotApplicable verdicts are dropped at
+    /// the filter site and never reach this struct.
+    verdict: String,
 }
 
 /// Long-lived client cached by the actix application state. Holds the
@@ -188,14 +191,18 @@ impl AuditClient {
             }
         };
 
-        // Persist only WouldDeny verdicts. Allow / NotApplicable are
-        // expected and high-volume; storing them all would defeat the
-        // point of an audit log.
+        // Persist Allow + WouldDeny verdicts so operators can preview
+        // both sides of policy impact (what's permitted, what would be
+        // blocked). NotApplicable is dropped — every flow checks
+        // against every cluster-scoped policy plus all namespaced ones
+        // in scope, and most produce NotApplicable; storing them all
+        // would inflate audit_verdicts by 1-2 orders of magnitude with
+        // no analytical value.
         let now = Utc::now().naive_utc();
         let to_insert: Vec<AuditVerdictInsert> = body
             .results
             .into_iter()
-            .filter(|r| r.verdict == "WouldDeny")
+            .filter(|r| r.verdict == "Allow" || r.verdict == "WouldDeny")
             .map(|r| AuditVerdictInsert {
                 policy_uid: r.policy_uid,
                 policy_namespace: r.policy_namespace,
@@ -209,6 +216,7 @@ impl AuditClient {
                 protocol: protocol.to_owned(),
                 reason: if r.reason.is_empty() { None } else { Some(r.reason) },
                 observed_at: now,
+                verdict: r.verdict,
             })
             .collect();
 

--- a/broker/src/get.rs
+++ b/broker/src/get.rs
@@ -256,3 +256,54 @@ pub fn pod_syscalls_by_name(
         .optional()?;
     Ok(pod_tr)
 }
+
+#[derive(serde::Deserialize)]
+pub struct AuditVerdictsQuery {
+    /// Filter to a single policy by name. Pair with `namespace` for
+    /// AuditNetworkPolicy; leave `namespace` empty for AuditClusterNetworkPolicy.
+    pub policy: Option<String>,
+    pub namespace: Option<String>,
+    /// Cap rows returned. Defaults to 100, hard cap 500.
+    pub limit: Option<i64>,
+}
+
+#[get("/audit/verdicts")]
+pub async fn get_audit_verdicts(
+    pool: web::Data<DbPool>,
+    query: web::Query<AuditVerdictsQuery>,
+) -> actix_web::Result<impl Responder> {
+    let q = query.into_inner();
+    let limit = q.limit.unwrap_or(100).clamp(1, 500);
+    let policy_name = q.policy.clone();
+    let policy_ns = q.namespace.clone();
+
+    let rows = web::block(move || {
+        let mut conn = pool.get()?;
+        audit_verdicts_query(&mut conn, policy_name, policy_ns, limit)
+    })
+    .await?
+    .map_err(actix_web::error::ErrorInternalServerError)?;
+
+    Ok(HttpResponse::Ok().json(rows))
+}
+
+pub fn audit_verdicts_query(
+    conn: &mut PgConnection,
+    by_policy: Option<String>,
+    by_namespace: Option<String>,
+    row_limit: i64,
+) -> Result<Vec<crate::AuditVerdict>, DbError> {
+    use schema::audit_verdicts::dsl::*;
+    let mut q = audit_verdicts.into_boxed();
+    if let Some(name) = by_policy {
+        q = q.filter(policy_name.eq(name));
+    }
+    if let Some(ns) = by_namespace {
+        q = q.filter(policy_namespace.eq(ns));
+    }
+    let rows = q
+        .order(observed_at.desc())
+        .limit(row_limit)
+        .load::<crate::AuditVerdict>(conn)?;
+    Ok(rows)
+}

--- a/broker/src/lib.rs
+++ b/broker/src/lib.rs
@@ -17,7 +17,7 @@ mod conn;
 pub use conn::*;
 mod schema;
 pub use get::{
-    get_pod_by_ip, get_pod_by_name, get_pod_details, get_pod_syscall_name, get_pod_traffic,
-    get_pod_traffic_name, get_pods_by_node, get_svc_by_ip, get_svc_details,
+    get_audit_verdicts, get_pod_by_ip, get_pod_by_name, get_pod_details, get_pod_syscall_name,
+    get_pod_traffic, get_pod_traffic_name, get_pods_by_node, get_svc_by_ip, get_svc_details,
 };
 pub use schema::{pod_details, pod_packet_drop, pod_traffic};

--- a/broker/src/main.rs
+++ b/broker/src/main.rs
@@ -4,9 +4,9 @@ use actix_cors::Cors;
 use actix_web::{get, web, App, HttpResponse, HttpServer};
 use api::{
     add_pod_details, add_pods, add_pods_batch, add_pods_syscalls, add_svc_details,
-    establish_connection, get_pod_by_ip, get_pod_by_name, get_pod_details, get_pod_syscall_name,
-    get_pod_traffic, get_pod_traffic_name, get_pods_by_node, get_svc_by_ip, get_svc_details,
-    mark_pod_dead, spawn_retention, AuditClient,
+    establish_connection, get_audit_verdicts, get_pod_by_ip, get_pod_by_name, get_pod_details,
+    get_pod_syscall_name, get_pod_traffic, get_pod_traffic_name, get_pods_by_node, get_svc_by_ip,
+    get_svc_details, mark_pod_dead, spawn_retention, AuditClient,
 };
 
 use diesel::r2d2;
@@ -104,6 +104,7 @@ async fn main() -> Result<(), std::io::Error> {
             .service(get_pod_traffic_name)
             .service(get_pod_syscall_name)
             .service(get_pods_by_node)
+            .service(get_audit_verdicts)
             .service(mark_pod_dead)
             .service(health_check)
     })

--- a/broker/src/schema.rs
+++ b/broker/src/schema.rs
@@ -81,6 +81,7 @@ diesel::table! {
         protocol -> Varchar,
         reason -> Nullable<Varchar>,
         observed_at -> Timestamp,
+        verdict -> Varchar,
     }
 }
 

--- a/broker/src/types.rs
+++ b/broker/src/types.rs
@@ -1,4 +1,4 @@
-use crate::schema::{pod_details, pod_syscalls, pod_traffic, svc_details};
+use crate::schema::{audit_verdicts, pod_details, pod_syscalls, pod_traffic, svc_details};
 use chrono::NaiveDateTime;
 use diesel::{AsChangeset, Identifiable, Insertable, Queryable, Selectable};
 use serde::{Deserialize, Serialize};
@@ -106,4 +106,22 @@ pub struct PodInputSyscalls {
     pub syscalls: Vec<String>,
     pub arch: String,
     pub time_stamp: NaiveDateTime,
+}
+
+#[derive(Debug, Clone, Queryable, Selectable, Serialize, Deserialize)]
+#[diesel(table_name = audit_verdicts)]
+pub struct AuditVerdict {
+    pub id: i64,
+    pub policy_uid: String,
+    pub policy_namespace: String,
+    pub policy_name: String,
+    pub direction: String,
+    pub src_namespace: Option<String>,
+    pub src_pod: Option<String>,
+    pub dst_namespace: Option<String>,
+    pub dst_pod: Option<String>,
+    pub dst_port: i32,
+    pub protocol: String,
+    pub reason: Option<String>,
+    pub observed_at: NaiveDateTime,
 }

--- a/broker/src/types.rs
+++ b/broker/src/types.rs
@@ -124,4 +124,5 @@ pub struct AuditVerdict {
     pub protocol: String,
     pub reason: Option<String>,
     pub observed_at: NaiveDateTime,
+    pub verdict: String, // "Allow" | "WouldDeny"
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,10 +1,11 @@
 import { useState, useCallback, useEffect } from 'react';
-import { RefreshCw, Shield, Sparkles } from 'lucide-react';
+import { AlertTriangle, RefreshCw, Shield, Sparkles } from 'lucide-react';
 import NetworkGraph from './components/NetworkGraph';
 import NamespaceSelector from './components/NamespaceSelector';
 import DataTable from './components/DataTable';
 import ThemeToggle from './components/ThemeToggle';
 import AIAssistant from './components/AIAssistant';
+import AuditVerdictsPanel from './components/AuditVerdictsPanel';
 import NetworkPolicyEditor from './components/NetworkPolicyEditor';
 import { usePodData } from './hooks/usePodData';
 import { useNamespaces } from './hooks/useNamespaces';
@@ -15,6 +16,7 @@ function App() {
   const [namespace, setNamespace] = useState('default');
   const [selectedPod, setSelectedPod] = useState<PodNodeData | null>(null);
   const [isAIAssistantOpen, setIsAIAssistantOpen] = useState(false);
+  const [isAuditPanelOpen, setIsAuditPanelOpen] = useState(false);
   const [isPolicyEditorOpen, setIsPolicyEditorOpen] = useState(false);
   const [policyEditorPod, setPolicyEditorPod] = useState<PodNodeData | null>(null);
   const [aiSidePanel, setAISidePanel] = useState<{
@@ -133,6 +135,17 @@ function App() {
           </div>
 
           <div className="flex items-center gap-4">
+            <button
+              onClick={() => setIsAuditPanelOpen(true)}
+              className="flex items-center gap-2 px-4 py-2 bg-hubble-card border border-hubble-border
+                         rounded-lg text-secondary hover:bg-hubble-dark hover:border-hubble-warning
+                         hover:text-hubble-warning transition-all"
+              title="Audit verdicts — would-deny flows"
+            >
+              <AlertTriangle className="w-4 h-4" />
+              <span className="hidden sm:inline font-medium">Audit</span>
+            </button>
+
             <button
               onClick={() => setIsAIAssistantOpen(true)}
               className="flex items-center gap-2 px-4 py-2 bg-hubble-accent/10 border border-hubble-accent/30
@@ -259,6 +272,12 @@ function App() {
         onClose={() => setIsPolicyEditorOpen(false)}
         pod={policyEditorPod}
         allPods={pods}
+      />
+
+      {/* Audit Verdicts Modal — would-deny flows from AuditNetworkPolicies */}
+      <AuditVerdictsPanel
+        isOpen={isAuditPanelOpen}
+        onClose={() => setIsAuditPanelOpen(false)}
       />
     </div>
   );

--- a/frontend/src/components/AuditVerdictsPanel.tsx
+++ b/frontend/src/components/AuditVerdictsPanel.tsx
@@ -1,0 +1,247 @@
+import React, { useEffect, useMemo, useState, useCallback } from 'react';
+import { X, RefreshCw, AlertTriangle, Filter } from 'lucide-react';
+import type { AuditVerdict } from '../types';
+import api from '../services/api';
+
+interface Props {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+/**
+ * AuditVerdictsPanel — modal table of "would-deny" flows.
+ *
+ * Each row is one observation that an `AuditNetworkPolicy` (or the
+ * cluster-scoped sibling) would have blocked if it were enforced.
+ * Operators use this to triage false positives before promoting an
+ * audit policy to a real `networking.k8s.io/v1.NetworkPolicy`.
+ *
+ * Backend is `GET /audit/verdicts` on the broker, which reads from
+ * the `audit_verdicts` table populated by the broker -> evaluator
+ * forwarder.
+ */
+const AuditVerdictsPanel: React.FC<Props> = ({ isOpen, onClose }) => {
+  const [verdicts, setVerdicts] = useState<AuditVerdict[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [policyFilter, setPolicyFilter] = useState('');
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const rows = await api.getAuditVerdicts({ limit: 200 });
+      setVerdicts(rows);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to load audit verdicts');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    void load();
+  }, [isOpen, load]);
+
+  // Group verdicts by policy for the side filter list. We don't
+  // server-side filter by name because the broker's index is on
+  // (policy_uid, observed_at) — the API supports it, but for the UI
+  // it's snappier to filter the already-loaded set client-side.
+  const byPolicy = useMemo(() => {
+    const m = new Map<string, AuditVerdict[]>();
+    for (const v of verdicts) {
+      const key = v.policy_namespace ? `${v.policy_namespace}/${v.policy_name}` : v.policy_name;
+      const list = m.get(key) || [];
+      list.push(v);
+      m.set(key, list);
+    }
+    return m;
+  }, [verdicts]);
+
+  const visible = useMemo(() => {
+    if (!policyFilter) return verdicts;
+    return verdicts.filter(v => {
+      const key = v.policy_namespace ? `${v.policy_namespace}/${v.policy_name}` : v.policy_name;
+      return key === policyFilter;
+    });
+  }, [verdicts, policyFilter]);
+
+  if (!isOpen) return null;
+
+  return (
+    <div
+      className="fixed inset-0 bg-black/50 z-50 flex items-center justify-center p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="audit-verdicts-title"
+      onClick={onClose}
+    >
+      <div
+        className="bg-hubble-darker border border-hubble-border rounded-lg w-full max-w-6xl max-h-[90vh] flex flex-col"
+        onClick={e => e.stopPropagation()}
+      >
+        {/* Header */}
+        <header className="flex items-center justify-between px-6 py-4 border-b border-hubble-border">
+          <div className="flex items-center gap-3">
+            <AlertTriangle className="w-6 h-6 text-hubble-warning" />
+            <div>
+              <h2 id="audit-verdicts-title" className="text-xl font-semibold text-primary">
+                Audit Verdicts — would-deny flows
+              </h2>
+              <p className="text-xs text-tertiary">
+                Flows your AuditNetworkPolicies would have blocked. Nothing was actually dropped.
+              </p>
+            </div>
+          </div>
+          <div className="flex items-center gap-2">
+            <button
+              onClick={() => void load()}
+              disabled={loading}
+              className="flex items-center gap-2 px-3 py-1.5 bg-hubble-card border border-hubble-border rounded text-secondary hover:bg-hubble-dark hover:border-hubble-accent transition-all disabled:opacity-50"
+              title="Refresh"
+            >
+              <RefreshCw className={`w-4 h-4 ${loading ? 'animate-spin' : ''}`} />
+              <span className="hidden sm:inline">Refresh</span>
+            </button>
+            <button
+              onClick={onClose}
+              className="p-2 text-tertiary hover:text-primary transition-colors"
+              aria-label="Close"
+            >
+              <X className="w-5 h-5" />
+            </button>
+          </div>
+        </header>
+
+        {/* Body */}
+        <div className="flex-1 flex overflow-hidden">
+          {/* Sidebar — policies */}
+          <aside className="w-64 border-r border-hubble-border overflow-y-auto p-3 bg-hubble-dark">
+            <div className="flex items-center gap-2 text-xs font-medium text-tertiary uppercase tracking-wide mb-2">
+              <Filter className="w-3.5 h-3.5" /> Policies
+            </div>
+            <button
+              onClick={() => setPolicyFilter('')}
+              className={`w-full text-left px-2 py-1.5 rounded text-sm transition-colors ${
+                policyFilter === ''
+                  ? 'bg-hubble-accent/20 text-hubble-accent'
+                  : 'text-secondary hover:bg-hubble-card'
+              }`}
+            >
+              All ({verdicts.length})
+            </button>
+            {Array.from(byPolicy.entries())
+              .sort(([, a], [, b]) => b.length - a.length)
+              .map(([key, list]) => (
+                <button
+                  key={key}
+                  onClick={() => setPolicyFilter(key)}
+                  className={`w-full text-left px-2 py-1.5 rounded text-sm transition-colors mt-1 ${
+                    policyFilter === key
+                      ? 'bg-hubble-accent/20 text-hubble-accent'
+                      : 'text-secondary hover:bg-hubble-card'
+                  }`}
+                  title={key}
+                >
+                  <span className="truncate block">
+                    {key} <span className="text-tertiary">({list.length})</span>
+                  </span>
+                </button>
+              ))}
+          </aside>
+
+          {/* Main — table */}
+          <main className="flex-1 overflow-auto">
+            {error && (
+              <div className="m-4 p-3 bg-hubble-error/10 border border-hubble-error/40 text-hubble-error rounded">
+                {error}
+              </div>
+            )}
+            {!error && !loading && visible.length === 0 && (
+              <div className="m-8 text-center text-tertiary">
+                No audit verdicts in the rolling window.
+                {policyFilter && (
+                  <>
+                    {' '}
+                    <button
+                      onClick={() => setPolicyFilter('')}
+                      className="text-hubble-accent underline"
+                    >
+                      Clear filter
+                    </button>
+                    .
+                  </>
+                )}
+              </div>
+            )}
+            {visible.length > 0 && (
+              <table className="w-full text-sm">
+                <thead className="sticky top-0 bg-hubble-dark z-10 border-b border-hubble-border">
+                  <tr className="text-left text-xs font-medium text-tertiary uppercase tracking-wide">
+                    <th className="px-4 py-2">When</th>
+                    <th className="px-4 py-2">Policy</th>
+                    <th className="px-4 py-2">Dir</th>
+                    <th className="px-4 py-2">Source</th>
+                    <th className="px-4 py-2">Destination</th>
+                    <th className="px-4 py-2">Port</th>
+                    <th className="px-4 py-2">Reason</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {visible.map(v => {
+                    const policyKey = v.policy_namespace
+                      ? `${v.policy_namespace}/${v.policy_name}`
+                      : v.policy_name;
+                    return (
+                      <tr key={v.id} className="border-b border-hubble-border/60 hover:bg-hubble-card/40">
+                        <td className="px-4 py-2 text-tertiary whitespace-nowrap">
+                          {formatTimestamp(v.observed_at)}
+                        </td>
+                        <td className="px-4 py-2 font-mono text-xs">
+                          {policyKey}
+                          {!v.policy_namespace && (
+                            <span className="ml-1 text-xs text-hubble-accent">(cluster)</span>
+                          )}
+                        </td>
+                        <td className="px-4 py-2 text-secondary">{v.direction}</td>
+                        <td className="px-4 py-2 font-mono text-xs">{formatPodRef(v.src_namespace, v.src_pod)}</td>
+                        <td className="px-4 py-2 font-mono text-xs">{formatPodRef(v.dst_namespace, v.dst_pod)}</td>
+                        <td className="px-4 py-2 font-mono text-xs">
+                          {v.dst_port}/{v.protocol}
+                        </td>
+                        <td className="px-4 py-2 text-tertiary text-xs">{v.reason ?? ''}</td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            )}
+          </main>
+        </div>
+
+        <footer className="px-6 py-2 border-t border-hubble-border text-xs text-tertiary">
+          Showing the most recent {verdicts.length} verdict{verdicts.length === 1 ? '' : 's'}.
+          Backed by <code className="font-mono">audit_verdicts</code>; rotated by the broker's retention loop.
+        </footer>
+      </div>
+    </div>
+  );
+};
+
+function formatTimestamp(iso: string): string {
+  try {
+    return new Date(iso).toLocaleString();
+  } catch {
+    return iso;
+  }
+}
+
+function formatPodRef(ns: string | null, name: string | null): string {
+  if (!ns && !name) return '—';
+  if (!ns) return name || '—';
+  if (!name) return `${ns}/?`;
+  return `${ns}/${name}`;
+}
+
+export default AuditVerdictsPanel;

--- a/frontend/src/components/AuditVerdictsPanel.tsx
+++ b/frontend/src/components/AuditVerdictsPanel.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useMemo, useState, useCallback } from 'react';
-import { X, RefreshCw, AlertTriangle, Filter } from 'lucide-react';
-import type { AuditVerdict } from '../types';
+import { X, RefreshCw, AlertTriangle, CheckCircle2, Filter } from 'lucide-react';
+import type { AuditVerdict, AuditVerdictKind } from '../types';
 import api from '../services/api';
 
 interface Props {
@@ -8,16 +8,25 @@ interface Props {
   onClose: () => void;
 }
 
+type VerdictTab = 'WouldDeny' | 'Allow' | 'All';
+
 /**
- * AuditVerdictsPanel — modal table of "would-deny" flows.
+ * AuditVerdictsPanel — modal table of evaluator verdicts.
  *
- * Each row is one observation that an `AuditNetworkPolicy` (or the
- * cluster-scoped sibling) would have blocked if it were enforced.
- * Operators use this to triage false positives before promoting an
- * audit policy to a real `networking.k8s.io/v1.NetworkPolicy`.
+ * Each row is one observation of a flow checked against an
+ * AuditNetworkPolicy or AuditClusterNetworkPolicy. Two verdicts are
+ * surfaced:
  *
- * Backend is `GET /audit/verdicts` on the broker, which reads from
- * the `audit_verdicts` table populated by the broker -> evaluator
+ *   - WouldDeny: the policy *would have blocked* this flow if enforced
+ *   - Allow:     the policy explicitly *permits* this flow
+ *
+ * Both matter when previewing impact. Allow tells you the policy is
+ * actually selecting the pods you intended (zero allows + zero denies
+ * usually means a podSelector typo). WouldDeny tells you what to
+ * triage before promoting.
+ *
+ * Backend: `GET /audit/verdicts` on the broker, reading the
+ * `audit_verdicts` table populated by the broker → evaluator
  * forwarder.
  */
 const AuditVerdictsPanel: React.FC<Props> = ({ isOpen, onClose }) => {
@@ -25,12 +34,16 @@ const AuditVerdictsPanel: React.FC<Props> = ({ isOpen, onClose }) => {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [policyFilter, setPolicyFilter] = useState('');
+  const [verdictTab, setVerdictTab] = useState<VerdictTab>('WouldDeny');
 
   const load = useCallback(async () => {
     setLoading(true);
     setError(null);
     try {
-      const rows = await api.getAuditVerdicts({ limit: 200 });
+      // Fetch both verdicts in one shot; client-side filter by tab.
+      // 400-row cap leaves headroom for the busiest pol/window combo
+      // we expect operators to triage in one sitting.
+      const rows = await api.getAuditVerdicts({ limit: 400 });
       setVerdicts(rows);
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Failed to load audit verdicts');
@@ -44,28 +57,42 @@ const AuditVerdictsPanel: React.FC<Props> = ({ isOpen, onClose }) => {
     void load();
   }, [isOpen, load]);
 
-  // Group verdicts by policy for the side filter list. We don't
-  // server-side filter by name because the broker's index is on
-  // (policy_uid, observed_at) — the API supports it, but for the UI
-  // it's snappier to filter the already-loaded set client-side.
+  // Group verdicts by policy for the side filter list. Each entry
+  // shows the (deny, allow) split so operators can see at a glance
+  // which policies are noisy on either side.
   const byPolicy = useMemo(() => {
-    const m = new Map<string, AuditVerdict[]>();
+    const m = new Map<string, { deny: number; allow: number; total: number }>();
     for (const v of verdicts) {
       const key = v.policy_namespace ? `${v.policy_namespace}/${v.policy_name}` : v.policy_name;
-      const list = m.get(key) || [];
-      list.push(v);
-      m.set(key, list);
+      const cur = m.get(key) || { deny: 0, allow: 0, total: 0 };
+      cur.total++;
+      if (v.verdict === 'WouldDeny') cur.deny++;
+      else if (v.verdict === 'Allow') cur.allow++;
+      m.set(key, cur);
     }
     return m;
   }, [verdicts]);
 
+  const counts = useMemo(() => {
+    let deny = 0;
+    let allow = 0;
+    for (const v of verdicts) {
+      if (v.verdict === 'WouldDeny') deny++;
+      else if (v.verdict === 'Allow') allow++;
+    }
+    return { deny, allow, total: verdicts.length };
+  }, [verdicts]);
+
   const visible = useMemo(() => {
-    if (!policyFilter) return verdicts;
     return verdicts.filter(v => {
-      const key = v.policy_namespace ? `${v.policy_namespace}/${v.policy_name}` : v.policy_name;
-      return key === policyFilter;
+      if (verdictTab !== 'All' && v.verdict !== verdictTab) return false;
+      if (policyFilter) {
+        const key = v.policy_namespace ? `${v.policy_namespace}/${v.policy_name}` : v.policy_name;
+        if (key !== policyFilter) return false;
+      }
+      return true;
     });
-  }, [verdicts, policyFilter]);
+  }, [verdicts, verdictTab, policyFilter]);
 
   if (!isOpen) return null;
 
@@ -87,10 +114,10 @@ const AuditVerdictsPanel: React.FC<Props> = ({ isOpen, onClose }) => {
             <AlertTriangle className="w-6 h-6 text-hubble-warning" />
             <div>
               <h2 id="audit-verdicts-title" className="text-xl font-semibold text-primary">
-                Audit Verdicts — would-deny flows
+                Audit Verdicts
               </h2>
               <p className="text-xs text-tertiary">
-                Flows your AuditNetworkPolicies would have blocked. Nothing was actually dropped.
+                Flows your AuditNetworkPolicies would block (or already permit). Nothing was actually dropped.
               </p>
             </div>
           </div>
@@ -114,6 +141,34 @@ const AuditVerdictsPanel: React.FC<Props> = ({ isOpen, onClose }) => {
           </div>
         </header>
 
+        {/* Verdict tabs */}
+        <nav className="flex border-b border-hubble-border bg-hubble-dark px-2" aria-label="Verdict filter">
+          <VerdictTabButton
+            active={verdictTab === 'WouldDeny'}
+            onClick={() => setVerdictTab('WouldDeny')}
+            icon={<AlertTriangle className="w-4 h-4" />}
+            color="text-hubble-warning"
+            label="Would-Deny"
+            count={counts.deny}
+          />
+          <VerdictTabButton
+            active={verdictTab === 'Allow'}
+            onClick={() => setVerdictTab('Allow')}
+            icon={<CheckCircle2 className="w-4 h-4" />}
+            color="text-hubble-accent"
+            label="Allow"
+            count={counts.allow}
+          />
+          <VerdictTabButton
+            active={verdictTab === 'All'}
+            onClick={() => setVerdictTab('All')}
+            icon={null}
+            color="text-secondary"
+            label="All"
+            count={counts.total}
+          />
+        </nav>
+
         {/* Body */}
         <div className="flex-1 flex overflow-hidden">
           {/* Sidebar — policies */}
@@ -132,8 +187,8 @@ const AuditVerdictsPanel: React.FC<Props> = ({ isOpen, onClose }) => {
               All ({verdicts.length})
             </button>
             {Array.from(byPolicy.entries())
-              .sort(([, a], [, b]) => b.length - a.length)
-              .map(([key, list]) => (
+              .sort(([, a], [, b]) => b.total - a.total)
+              .map(([key, c]) => (
                 <button
                   key={key}
                   onClick={() => setPolicyFilter(key)}
@@ -144,8 +199,11 @@ const AuditVerdictsPanel: React.FC<Props> = ({ isOpen, onClose }) => {
                   }`}
                   title={key}
                 >
-                  <span className="truncate block">
-                    {key} <span className="text-tertiary">({list.length})</span>
+                  <span className="truncate block">{key}</span>
+                  <span className="text-[11px] text-tertiary tabular-nums">
+                    {c.deny > 0 && <span className="text-hubble-warning">{c.deny} deny</span>}
+                    {c.deny > 0 && c.allow > 0 && <span> · </span>}
+                    {c.allow > 0 && <span className="text-hubble-accent">{c.allow} allow</span>}
                   </span>
                 </button>
               ))}
@@ -160,7 +218,7 @@ const AuditVerdictsPanel: React.FC<Props> = ({ isOpen, onClose }) => {
             )}
             {!error && !loading && visible.length === 0 && (
               <div className="m-8 text-center text-tertiary">
-                No audit verdicts in the rolling window.
+                No {verdictTab === 'All' ? '' : verdictTab.toLowerCase()} verdicts in the rolling window.
                 {policyFilter && (
                   <>
                     {' '}
@@ -179,6 +237,7 @@ const AuditVerdictsPanel: React.FC<Props> = ({ isOpen, onClose }) => {
               <table className="w-full text-sm">
                 <thead className="sticky top-0 bg-hubble-dark z-10 border-b border-hubble-border">
                   <tr className="text-left text-xs font-medium text-tertiary uppercase tracking-wide">
+                    <th className="px-4 py-2">Verdict</th>
                     <th className="px-4 py-2">When</th>
                     <th className="px-4 py-2">Policy</th>
                     <th className="px-4 py-2">Dir</th>
@@ -195,6 +254,9 @@ const AuditVerdictsPanel: React.FC<Props> = ({ isOpen, onClose }) => {
                       : v.policy_name;
                     return (
                       <tr key={v.id} className="border-b border-hubble-border/60 hover:bg-hubble-card/40">
+                        <td className="px-4 py-2">
+                          <VerdictBadge verdict={v.verdict as AuditVerdictKind} />
+                        </td>
                         <td className="px-4 py-2 text-tertiary whitespace-nowrap">
                           {formatTimestamp(v.observed_at)}
                         </td>
@@ -221,11 +283,60 @@ const AuditVerdictsPanel: React.FC<Props> = ({ isOpen, onClose }) => {
         </div>
 
         <footer className="px-6 py-2 border-t border-hubble-border text-xs text-tertiary">
-          Showing the most recent {verdicts.length} verdict{verdicts.length === 1 ? '' : 's'}.
+          Showing {visible.length} of {verdicts.length} most recent verdict{verdicts.length === 1 ? '' : 's'} ·
+          {' '}<span className="text-hubble-warning">{counts.deny} deny</span>
+          {' '}·
+          {' '}<span className="text-hubble-accent">{counts.allow} allow</span>.
           Backed by <code className="font-mono">audit_verdicts</code>; rotated by the broker's retention loop.
         </footer>
       </div>
     </div>
+  );
+};
+
+interface VerdictTabButtonProps {
+  active: boolean;
+  onClick: () => void;
+  icon: React.ReactNode;
+  color: string;
+  label: string;
+  count: number;
+}
+
+const VerdictTabButton: React.FC<VerdictTabButtonProps> = ({ active, onClick, icon, color, label, count }) => (
+  <button
+    onClick={onClick}
+    className={`flex items-center gap-2 px-4 py-2 text-sm font-medium border-b-2 transition-colors ${
+      active
+        ? 'border-hubble-accent text-primary bg-hubble-card/40'
+        : 'border-transparent text-secondary hover:text-primary'
+    }`}
+  >
+    {icon && <span className={color}>{icon}</span>}
+    {label}
+    <span className={`text-xs tabular-nums ${active ? 'text-tertiary' : 'text-tertiary'}`}>({count})</span>
+  </button>
+);
+
+const VerdictBadge: React.FC<{ verdict: AuditVerdictKind | string }> = ({ verdict }) => {
+  if (verdict === 'WouldDeny') {
+    return (
+      <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs bg-hubble-warning/20 text-hubble-warning">
+        <AlertTriangle className="w-3 h-3" /> Deny
+      </span>
+    );
+  }
+  if (verdict === 'Allow') {
+    return (
+      <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs bg-hubble-accent/20 text-hubble-accent">
+        <CheckCircle2 className="w-3 h-3" /> Allow
+      </span>
+    );
+  }
+  return (
+    <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs bg-hubble-card text-tertiary">
+      {verdict}
+    </span>
   );
 };
 

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,6 +1,6 @@
 import axios from 'axios';
 import type { AxiosInstance } from 'axios';
-import type { PodInfo, NetworkTraffic, SyscallInfo, ServiceInfo } from '../types';
+import type { PodInfo, NetworkTraffic, SyscallInfo, ServiceInfo, AuditVerdict } from '../types';
 
 class BrokerAPIClient {
   private client: AxiosInstance;
@@ -17,6 +17,29 @@ class BrokerAPIClient {
         'Content-Type': 'application/json',
       },
     });
+  }
+
+  /**
+   * Get recent audit-mode verdicts — flows that would have been denied
+   * by an AuditNetworkPolicy / AuditClusterNetworkPolicy if enforced.
+   * Optional filters: policy name, policy namespace, row limit.
+   */
+  async getAuditVerdicts(opts: {
+    policy?: string;
+    namespace?: string;
+    limit?: number;
+  } = {}): Promise<AuditVerdict[]> {
+    try {
+      const params: Record<string, string | number> = {};
+      if (opts.policy) params.policy = opts.policy;
+      if (opts.namespace) params.namespace = opts.namespace;
+      if (opts.limit) params.limit = opts.limit;
+      const response = await this.client.get('/audit/verdicts', { params });
+      return response.data || [];
+    } catch (error) {
+      console.error('Error fetching audit verdicts:', error);
+      return [];
+    }
   }
 
   /**

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -20,19 +20,23 @@ class BrokerAPIClient {
   }
 
   /**
-   * Get recent audit-mode verdicts — flows that would have been denied
-   * by an AuditNetworkPolicy / AuditClusterNetworkPolicy if enforced.
-   * Optional filters: policy name, policy namespace, row limit.
+   * Get recent audit-mode verdicts — flows the evaluator decided on
+   * for an AuditNetworkPolicy / AuditClusterNetworkPolicy. Returns
+   * both `Allow` and `WouldDeny` rows so operators can preview both
+   * sides of policy impact. Optional filters: policy, namespace,
+   * verdict, row limit.
    */
   async getAuditVerdicts(opts: {
     policy?: string;
     namespace?: string;
+    verdict?: 'Allow' | 'WouldDeny';
     limit?: number;
   } = {}): Promise<AuditVerdict[]> {
     try {
       const params: Record<string, string | number> = {};
       if (opts.policy) params.policy = opts.policy;
       if (opts.namespace) params.namespace = opts.namespace;
+      if (opts.verdict) params.verdict = opts.verdict;
       if (opts.limit) params.limit = opts.limit;
       const response = await this.client.get('/audit/verdicts', { params });
       return response.data || [];

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -70,8 +70,11 @@ export interface ServiceInfo {
   service_spec?: KubeObject; // Full Kubernetes Service object
 }
 
-// Matches broker's AuditVerdict type — one row per "would deny" flow
-// recorded by the kguardian-evaluator.
+// Matches broker's AuditVerdict type — one row per (flow, policy,
+// direction) the evaluator decided on. The broker forwarder persists
+// `Allow` and `WouldDeny`; `NotApplicable` is dropped before insert.
+export type AuditVerdictKind = 'Allow' | 'WouldDeny';
+
 export interface AuditVerdict {
   id: number;
   policy_uid: string;
@@ -86,4 +89,5 @@ export interface AuditVerdict {
   protocol: string;
   reason: string | null;
   observed_at: string; // ISO 8601
+  verdict: AuditVerdictKind | string;
 }

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -69,3 +69,21 @@ export interface ServiceInfo {
   svc_namespace: string | null;
   service_spec?: KubeObject; // Full Kubernetes Service object
 }
+
+// Matches broker's AuditVerdict type — one row per "would deny" flow
+// recorded by the kguardian-evaluator.
+export interface AuditVerdict {
+  id: number;
+  policy_uid: string;
+  policy_namespace: string; // empty string for cluster-scoped policies
+  policy_name: string;
+  direction: 'Ingress' | 'Egress' | string;
+  src_namespace: string | null;
+  src_pod: string | null;
+  dst_namespace: string | null;
+  dst_pod: string | null;
+  dst_port: number;
+  protocol: string;
+  reason: string | null;
+  observed_at: string; // ISO 8601
+}


### PR DESCRIPTION
Closes the documented frontend follow-up *and* the critical \"see what would be permitted, not just denied\" UX gap. Surfaces both verdicts the evaluator computes so operators can preview both sides of policy impact before promoting an AuditNetworkPolicy to enforced.

## Why both verdicts matter

Calico's StagedKubernetesNetworkPolicy surfaces both \`pending:[action: deny]\` and \`pending:[action: allow]\` in flow logs. We need parity:

- **WouldDeny** — what would break if you promoted now
- **Allow** — what the policy explicitly permits (verifying the rule set isn't too permissive, and that the policy is actually selecting the pods you intended)
- A policy with **zero rows in either column** is probably a selector typo — invisible if you only track denials

## What this adds

### Schema (broker)

New migration adds a \`verdict\` column to \`audit_verdicts\` with default \`'WouldDeny'\` (existing rows pre-date this PR and were all denials by construction) plus an \`(verdict, observed_at DESC)\` index for the new tab-filter queries.

### Broker

- \`GET /audit/verdicts\` supports \`?verdict=Allow|WouldDeny\` and \`?policy=\` / \`?namespace=\` / \`?limit=\` (default 100, hard cap 500).
- \`audit.rs\` forwarder now persists \`Allow\` + \`WouldDeny\` (was: \`WouldDeny\` only). \`NotApplicable\` is still dropped — every flow produces one per cluster-scoped policy, persisting them would inflate the table 1-2 orders of magnitude with no analytical value.
- New typed \`AuditVerdict\` Queryable model carries the \`verdict\` field.

### Frontend

- New header button \"Audit\" opens a modal with:
  - **Three-way tab**: Would-Deny / Allow / All, each with running counts.
  - **Policy sidebar**: each entry shows the (deny, allow) split so noisy policies on either side jump out.
  - **Verdict badge** in the leftmost column of every row (warning-coloured for deny, accent-coloured for allow).
  - **Empty state copy** adapts to which tab is active (\"No allow verdicts in the rolling window\" vs. \"No would-deny verdicts...\").

Layout follows the existing AIAssistant modal: \`bg-black/50\` backdrop, click-outside-to-close, sticky table header, \`hubble-*\` colour tokens, ARIA \`dialog\` role.

## Validation

- \`cargo check --manifest-path broker/Cargo.toml\` clean (PG18-linked libpq)
- \`npm --prefix frontend run build\` clean — tsc + vite, +3 KB gzipped for the tab UI
- Migration uses constructs verified against PG18 in #844

## Test plan

- [ ] CI \`build-broker\` passes (broker has Rust additions: types, get handler, schema, audit.rs filter logic)
- [ ] CI \`build-frontend\` passes
- [ ] Manual: post one Allow flow + one WouldDeny flow to \`/evaluate\` against a populated audit policy; refresh the modal; verify both rows appear under their respective tabs and the policy sidebar shows the correct split

## Known follow-ups

- Server-side \`?since=\` time-window filter — currently the table shows the most recent N rows regardless of age.
- Sort/group by source pod, destination pod — current ordering is observed_at desc only.
- Exporting verdicts as CSV / JSON for offline triage.