### PR TITLE
fix(chart): use Recreate strategy on database deployment

### DIFF
--- a/charts/kguardian/templates/database/deployment.yaml
+++ b/charts/kguardian/templates/database/deployment.yaml
@@ -5,6 +5,15 @@ metadata:
   name: {{ .Values.database.name }}
 spec:
   replicas: 1
+  # Recreate (not RollingUpdate) because the database owns a singleton
+  # ReadWriteOnce PVC. A rolling update would try to schedule the new
+  # pod while the old pod still holds the volume; the new pod would
+  # block in ContainerCreating waiting for an attach that can't happen
+  # under RWO, helm --wait would time out, the upgrade would fail.
+  # Recreate kills the old pod first, frees the PVC, then starts the
+  # new one. There's a brief downtime window but no upgrade deadlock.
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ .Values.database.service.name }}


### PR DESCRIPTION
The database is a singleton with a ReadWriteOnce PVC. The default \`RollingUpdate\` strategy tries to schedule the new pod while the old one still holds the volume; the new pod blocks in \`ContainerCreating\` waiting for an attach that can't happen under RWO, \`helm --wait\` times out, the upgrade fails. Subsequent retries fail the same way.

\`Recreate\` kills the old pod first, frees the PVC, then starts the new one. Brief downtime window but no upgrade deadlock.

## Symptom that triggered this

A real chart 1.9.1 → 1.11.0 upgrade stalled on the database deployment. \`helm history\` showed:

\`\`\`
111  failed  kguardian-1.11.0+187b84a626e3  Upgrade "kguardian" failed: failed early due to stalled resources: [Deployment/kguardian/kguardian-db status: 'Failed']
112  failed  kguardian-1.11.0+187b84a626e3  Upgrade "kguardian" failed: failed early due to stalled resources: [Deployment/kguardian/kguardian-db status: 'Failed']
\`\`\`

The new db pod sat in ContainerCreating for 9 hours while the old pod kept the PVC mounted. With \`strategy: Recreate\` the rollout completes cleanly: old pod terminates first, PVC releases, new pod attaches and starts.

Knock-on effect of the deadlock: helm's partial-apply state left some downstream resources unapplied (specifically the evaluator ServiceAccount), which surfaced as \`FailedMount: serviceaccounts "evaluator" not found\` on every retry of the evaluator pod. That self-resolves once helm completes a successful upgrade.

## Tradeoff

Recreate has a brief window where the database is down between old-pod-terminating and new-pod-becoming-ready. For an audit/observability database (not on the request path of any application), this is acceptable. Operators who need zero-downtime DB upgrades should be running an external Postgres anyway (\`database.enabled: false\`, configured via \`database.external.host\`) — the chart's bundled DB is for getting started, not for HA production.

## Validation

- \`helm lint\`: clean
- \`helm template\`: \`strategy: { type: Recreate }\` renders on the kguardian-db Deployment

## Test plan

- [ ] CI \`lint-test\` (chart-testing's \`ct install\`) still passes
- [ ] Manual: upgrade a chart 1.10.0/1.11.0 install to this version against an existing PVC; confirm the new pod starts and the upgrade completes