### PR TITLE
fix(evaluator): plug informer-goroutine leak on cache-sync failure

### DIFF
--- a/evaluator/main.go
+++ b/evaluator/main.go
@@ -2,10 +2,6 @@
 // CRDs and evaluates observed flows (POSTed by the broker on /evaluate)
 // against them, emitting "would deny" verdicts as logs and Prometheus
 // metrics.
-//
-// MVP scope: HTTP server, in-memory CRD/pod/namespace cache, podSelector
-// + namespaceSelector + numeric port matching. Status updates back onto
-// the CRD and ipBlock / named-port matching are tracked as follow-ups.
 package main
 
 import (

--- a/evaluator/pkg/matcher/types.go
+++ b/evaluator/pkg/matcher/types.go
@@ -12,10 +12,10 @@
 //   - An empty `from:` / `to:` block matches *any* peer; an empty `ports:`
 //     block matches *any* port. An empty rule list (`ingress: []`) means
 //     no flow is permitted in that direction.
-//
-// MVP scope: podSelector + namespaceSelector + numeric ports (with
-// endPort ranges). ipBlock and named-port resolution are stubbed and
-// noted as follow-ups in the matcher's Match() result.
+//   - Peers are matched by namespaceSelector + podSelector OR ipBlock
+//     (mutually exclusive per upstream schema). Ports support numeric
+//     matching with optional endPort ranges and named ports resolved
+//     against the destination pod's container declarations.
 package matcher
 
 import (

--- a/evaluator/pkg/store/store.go
+++ b/evaluator/pkg/store/store.go
@@ -103,6 +103,15 @@ func New(cfg *rest.Config, log *logrus.Logger) (*Store, error) {
 
 // Start launches the informers and blocks on cache sync.
 func (s *Store) Start(ctx context.Context) error {
+	// Wire stopCh to ctx before starting informers so the goroutines
+	// shut down even if WaitForCacheSync fails — otherwise a sync
+	// failure leaves four informer goroutines running until process
+	// exit.
+	go func() {
+		<-ctx.Done()
+		close(s.stopCh)
+	}()
+
 	go s.podInformer.Run(s.stopCh)
 	go s.nsInformer.Run(s.stopCh)
 	go s.anpInformer.Run(s.stopCh)
@@ -117,11 +126,6 @@ func (s *Store) Start(ctx context.Context) error {
 		return context.Canceled
 	}
 	s.log.Info("informer caches synced (pods, namespaces, auditnetworkpolicies, auditclusternetworkpolicies)")
-
-	go func() {
-		<-ctx.Done()
-		close(s.stopCh)
-	}()
 	return nil
 }
 


### PR DESCRIPTION
## Summary
- Wire `stopCh` close goroutine **before** `WaitForCacheSync` in `store.Start` so the four informer goroutines (pods, namespaces, ANP, ACNP) shut down on cache-sync failure too. Previously a sync failure left them running until process exit.
- Drop stale package-doc paragraphs in `evaluator/main.go` and `evaluator/pkg/matcher/types.go` that listed `ipBlock` and named-port resolution as "follow-ups" — both have been implemented (see `peerEntryMatches` / `portEntryMatches` in `matcher.go`).

## Test plan
- [x] `go build ./...` clean
- [x] `go test ./...` — all four packages pass
- Functional behaviour unchanged on the success path (cache-sync goroutine cleanup runs identically); only the failure path is fixed.