### PR TITLE
fix(broker): /health checks schema state so kubelet self-heals on DB wipe

### DIFF
--- a/broker/src/main.rs
+++ b/broker/src/main.rs
@@ -113,15 +113,36 @@ async fn main() -> Result<(), std::io::Error> {
     .await
 }
 
+// Verifying schema state on /health (rather than just connectivity) is
+// what makes the broker self-heal when the database is replaced or
+// wiped beneath us. Without this, /health passes on pool.get() while
+// every real query 500s with "relation does not exist" — silent for
+// hours. With it, the kubelet sees a failing liveness probe, restarts
+// the pod, and the startup-migration retry repopulates the schema.
 #[get("/health")]
 pub async fn health_check(
     pool: web::Data<r2d2::Pool<r2d2::ConnectionManager<diesel::PgConnection>>>,
 ) -> HttpResponse {
-    match pool.get() {
-        Ok(_) => HttpResponse::Ok()
+    let pool_inner = pool.get_ref().clone();
+    let result = tokio::task::spawn_blocking(
+        move || -> Result<bool, Box<dyn Error + Send + Sync>> {
+            let mut conn = pool_inner.get()?;
+            // Empty pending list ⇒ schema is current. Anything else
+            // means the DB is fresh or behind, e.g. because the database
+            // pod was replaced after broker startup.
+            Ok(conn.pending_migrations(MIGRATIONS)?.is_empty())
+        },
+    )
+    .await;
+
+    match result {
+        Ok(Ok(true)) => HttpResponse::Ok()
             .content_type("application/json")
             .body("Healthy!"),
-        Err(_) => HttpResponse::ServiceUnavailable()
+        Ok(Ok(false)) => HttpResponse::ServiceUnavailable()
+            .content_type("application/json")
+            .body("Database schema not up to date"),
+        Ok(Err(_)) | Err(_) => HttpResponse::ServiceUnavailable()
             .content_type("application/json")
             .body("Database unavailable"),
     }

--- a/charts/kguardian/UPGRADING.md
+++ b/charts/kguardian/UPGRADING.md
@@ -1,5 +1,43 @@
 # Upgrading the kguardian Helm chart
 
+## Before any chart upgrade: back up the database
+
+The chart's bundled PostgreSQL Deployment + ReadWriteOnce PVC pattern is
+fragile across template changes. Mount-path corrections (#845), image
+tag bumps, or strategy changes can leave the new pod attached to the
+PVC at a path PostgreSQL doesn't recognise — at which point `initdb`
+runs over an empty subtree and the broker silently sees a fresh schema.
+The data isn't recoverable after the fact.
+
+Take a logical dump before every `helm upgrade` until automated
+pre-upgrade hooks land:
+
+```sh
+kubectl -n <ns> exec deploy/kguardian-db -- \
+  pg_dumpall -U "$POSTGRES_USER" --clean --if-exists \
+  > kguardian-db-$(date +%Y%m%d-%H%M).sql
+```
+
+If an upgrade lands on an empty database, the broker's `/health`
+endpoint reports `503 Database schema not up to date` and the kubelet
+restarts the pod. Startup re-runs migrations against the new instance,
+which is enough to bring the system back online — but historical rows
+in `pod_traffic`, `pod_details`, and `audit_verdicts` are gone. The
+dump above is what lets you restore them.
+
+To restore:
+
+```sh
+kubectl -n <ns> cp kguardian-db-YYYYMMDD-HHMM.sql kguardian-db-<pod>:/tmp/restore.sql
+kubectl -n <ns> exec deploy/kguardian-db -- \
+  psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -f /tmp/restore.sql
+```
+
+The kguardian data model is observability state, not source of truth —
+losing it is recoverable (the controller repopulates pod/svc snapshots
+from live cluster state on its next sync). The dump matters most for
+`audit_verdicts`, which is a time series with no other source.
+
 ## chart 1.10.0: PostgreSQL 15 → 18
 
 The `database.image.tag` default moved from `15-alpine` to `18-alpine`.


### PR DESCRIPTION
## Background — what happened

A live deployment surfaced the following: chart 1.11.0 was rolled out, helm upgrade eventually succeeded, all pods Running. **For 14+ hours** the broker had been logging hourly:

```
WARN api::retention: audit_verdicts retention: DELETE failed
     error=relation "audit_verdicts" does not exist
```

…and the controller had been logging *per minute*:

```
ERROR Pod reconciliation failed: Custom error: Broker returned error status: 500 Internal Server Error
```

The database was empty. Zero tables. Not even `__diesel_schema_migrations`.

### Root cause (chart-side, already shipped in #845)

Pre-#845 the chart mounted the PVC at `/var/lib/postgres/data` (typo, missing the `L`). PostgreSQL writes its `PGDATA` to `/var/lib/postgresql/data`, so the PVC was attached at a path postgres never read or wrote to. **Persistence had been a placebo for the entire chart history.** Every pod restart silently wiped the database; nobody noticed because the controller and broker repopulate pod/svc snapshots from live cluster state on reconnect.

#845 fixed the mount path. The first pod restart after that fix was the first time the PVC was actually attached at a path postgres recognised. PG18 found the PVC empty (because pre-#845 nothing was ever persisted to it) and ran `initdb` cleanly. Schema gone, but no observable error from the chart's perspective — the new pod came up "successfully".

The broker, meanwhile, was still running its connection pool from before the DB pod was replaced. Its 5-attempt startup-migration retry had succeeded against the old (container-local) database hours earlier and was never going to run again.

### Why nobody noticed for hours

The existing `/health` endpoint:

```rust
match pool.get() {
    Ok(_)  => 200 "Healthy!",
    Err(_) => 503 "Database unavailable",
}
```

Connection acquisition succeeded against the new (empty) DB, so `/health` returned 200 forever. The chart's livenessProbe and readinessProbe both point at `/health` — both passed. The kubelet had no signal to restart the broker, even though the broker was effectively useless.

## What this PR changes

`/health` now also checks the schema is current via diesel's `pending_migrations()`. Three states:

| state | response | result |
|---|---|---|
| schema current | `200 Healthy!` | broker serves traffic |
| migrations pending (DB fresh / wiped / behind) | `503 Database schema not up to date` | kubelet restarts pod |
| connection unavailable | `503 Database unavailable` | unchanged from before |

After a 503 → restart, `main()` runs the existing startup-migration retry block against the new database. Tables are recreated. Self-heal complete. **Kubernetes probes ARE the watchdog** — no separate periodic task needed.

`UPGRADING.md` gets a general pre-upgrade `pg_dumpall` backup section. Self-heal restores the schema; only a logical dump restores the rows. Chart template changes can mismount the PVC again (mount path, PG major bump, PGDATA env, etc.) and operators need a documented manual recovery path until automated pre-upgrade hooks land.

## What's deliberately not in this PR

- **StatefulSet conversion** — orthogonal architectural debate (whether the DB belongs in-cluster at all).
- **Init-container that aborts on unexpected fresh datadir** — wouldn't have caught *this* incident (the PVC was empty, so the new pod legitimately needed `initdb`). Useful for future PG major-version transitions; separate PR.
- **values.schema.json** — generic best practice unrelated to the failure mode here.
- **Pre-upgrade `pg_dump` Helm hook** — proper fix for the backup story; needs its own design (where the dump goes, retention, etc.).
- **Prometheus `broker_db_schema_ready` gauge** — would be valuable; folded into a follow-up that builds out broker metrics generally.

## Test plan
- [x] `cargo check` clean
- [ ] Manual: drop a table, hit `/health`, confirm 503
- [ ] Manual: restart broker pod, confirm `main()` re-runs migrations and `/health` returns 200
- [ ] Verify livenessProbe restart-on-failure semantics under k8s in a real cluster