### PR TITLE
fix(evaluator,controller): two log-spam sources reported in the wild

### DIFF
--- a/controller/src/bpf.rs
+++ b/controller/src/bpf.rs
@@ -8,9 +8,23 @@ use libbpf_rs::skel::{OpenSkel, Skel, SkelBuilder};
 use libbpf_rs::{MapCore, MapFlags, RingBufferBuilder};
 use std::mem::MaybeUninit;
 use std::net::Ipv4Addr;
+use std::sync::atomic::{AtomicBool, Ordering};
 use tokio::sync::mpsc::{Receiver, Sender};
 use tokio::{task, task::JoinHandle};
-use tracing::info;
+use tracing::{info, warn};
+
+// Each ring-buffer callback runs on the libbpf-rs poll thread, which is
+// inside a `task::spawn_blocking` and therefore not cancelable by Tokio.
+// If the corresponding mpsc receiver is dropped (e.g. its task in
+// `try_join!` got cancelled because a sister task errored), every
+// subsequent eBPF event would log a "(receiver closed)" line, flooding
+// stderr at syscall frequency. Latch the first failure per channel,
+// log it loudly via the structured logger, then drop subsequent events
+// silently — the operator still sees the signal once and the logs stay
+// readable.
+static NETWORK_SEND_FAILED: AtomicBool = AtomicBool::new(false);
+static SYSCALL_SEND_FAILED: AtomicBool = AtomicBool::new(false);
+static POLICY_DROP_SEND_FAILED: AtomicBool = AtomicBool::new(false);
 
 /// Populate the syscall allowlist with security-relevant syscalls
 /// This dramatically reduces overhead by filtering out noisy syscalls
@@ -179,7 +193,9 @@ pub fn ebpf_handle(
                     unsafe { *(data.as_ptr() as *const NetworkEventData) };
 
                 if let Err(e) = network_event_sender.blocking_send(network_event_data) {
-                    eprintln!("Failed to send network event (receiver closed): {:?}", e);
+                    if !NETWORK_SEND_FAILED.swap(true, Ordering::Relaxed) {
+                        warn!(error = ?e, "network event channel closed; subsequent events will be dropped silently");
+                    }
                 }
                 0 // Return 0 for success
             })
@@ -201,7 +217,9 @@ pub fn ebpf_handle(
                 let syscall_event_data: SyscallEventData =
                     unsafe { *(data.as_ptr() as *const SyscallEventData) };
                 if let Err(e) = syscall_event_sender.blocking_send(syscall_event_data) {
-                    eprintln!("Failed to send syscall event (receiver closed): {:?}", e);
+                    if !SYSCALL_SEND_FAILED.swap(true, Ordering::Relaxed) {
+                        warn!(error = ?e, "syscall event channel closed; subsequent events will be dropped silently");
+                    }
                 }
                 0 // Return 0 for success
             })
@@ -225,10 +243,9 @@ pub fn ebpf_handle(
                     let policy_drop_event: PolicyDropEvent =
                         unsafe { *(data.as_ptr() as *const PolicyDropEvent) };
                     if let Err(e) = netpolicy_drop_sender.blocking_send(policy_drop_event) {
-                        eprintln!(
-                            "Failed to send network policy drop event (receiver closed): {:?}",
-                            e
-                        );
+                        if !POLICY_DROP_SEND_FAILED.swap(true, Ordering::Relaxed) {
+                            warn!(error = ?e, "network policy drop event channel closed; subsequent events will be dropped silently");
+                        }
                     }
                     0 // Return 0 for success
                 },

--- a/evaluator/pkg/server/server.go
+++ b/evaluator/pkg/server/server.go
@@ -132,7 +132,13 @@ func (s *Server) handleEvaluate(w http.ResponseWriter, r *http.Request) {
 		policies = append(policies, s.store.PoliciesInNamespace(flow.SrcPodNamespace)...)
 	}
 
-	var results []matcher.Result
+	// Initialize as a non-nil empty slice so that JSON encoding produces
+	// `"results":[]` rather than `"results":null` when no policies match
+	// the flow (no AuditNetworkPolicy in either namespace AND no
+	// AuditClusterNetworkPolicy that returns at least NotApplicable).
+	// The broker deserialises results into Vec<VerdictResult>, which
+	// rejects null but accepts an empty array.
+	results := make([]matcher.Result, 0)
 	for _, p := range policies {
 		results = append(results, matcher.Match(flow, p, s.store)...)
 	}


### PR DESCRIPTION
A community report on Discord:

> any idea what might cause the log spam I mentioned above? the mix of `WARN api::audit: could not decode evaluator response error=error decoding response body` from the broker and `Failed to send syscall event (receiver closed): SendError { .. }` from the controller? doesn't seem like I have any debug logging enabled, just standard log level stuff spamming quite heavily

Two distinct bugs surfaced.

## 1. Evaluator emits `{"results":null}` for empty result sets

`evaluator/pkg/server/server.go::handleEvaluate` declared `var results []matcher.Result`, which Go's `encoding/json` marshals as `null` (nil-slice gotcha). The broker's `EvaluateResponse` is:

```rust
struct EvaluateResponse {
    #[serde(default)]
    results: Vec<VerdictResult>,
}
```

`#[serde(default)]` only fires when the field is **missing**. On the wire `"results":null`, serde tries to deserialise `null` → `Vec<_>` and fails with the user's exact warning.

Reproduces whenever a flow has zero matching policies — i.e. no `AuditNetworkPolicy` in either of its namespaces **and** no `AuditClusterNetworkPolicy` that returns at least a `NotApplicable` verdict. Clusters running with only namespaced policies, or with no policies at all (testing), hit this on most flows. Clusters with a default-deny `AuditClusterNetworkPolicy` (like our reference setup) don't, because `MatchCluster` always returns at least one Result.

Fix: `results := make([]matcher.Result, 0)` so the wire becomes `"results":[]`.

## 2. Controller floods stderr when a ring-buffer receiver closes

Each eBPF callback (`network_events`, `syscall_events`, `policy_drop_events`) runs on libbpf-rs's poll thread, which lives inside `task::spawn_blocking` and **cannot be cancelled by Tokio**. The matching mpsc receivers live in async tasks polled by `tokio::try_join!` in `main.rs`. When any sister future (e.g. `service`, `pod_reconciler`, `handle_network_events`) errors, `try_join!` cancels the rest by dropping them — including the receivers. But the spawn_blocking poll thread keeps polling, every event hits `Err(SendError)` on `blocking_send`, and the previous code did:

```rust
eprintln!("Failed to send syscall event (receiver closed): {:?}", e);
```

Raw `eprintln!`, no rate limiting, syscall-frequency. Hence the spam.

Latch the first failure per channel via an `AtomicBool` and switch to structured `tracing::warn!`:

```rust
if !SYSCALL_SEND_FAILED.swap(true, Ordering::Relaxed) {
    warn!(error = ?e, "syscall event channel closed; subsequent events will be dropped silently");
}
```

This preserves the signal (one warn per channel surfaces the failure to operators) without drowning the log. Same pattern for the network and policy-drop callbacks.

This PR doesn't fix the underlying *cancellation cascade* in `try_join!` — that's a structural change worth its own PR (e.g. `tokio::spawn` per task with a supervisor). It does stop the spam being the operator's first experience of the failure.

## Test plan

- [x] `go build ./...` clean (evaluator)
- [x] `go test ./pkg/server/ ./pkg/matcher/` clean
- [ ] `cargo check` for controller — fails locally on missing `libelf`-dev; CI has it
- [ ] Manual: deploy on a cluster with no AuditNetworkPolicy resources, confirm no decode warnings
- [ ] Manual: induce a sister-task error in the controller, confirm exactly one warn per channel rather than continuous spam