### PR TITLE
fix(ci): unpin SLSA builder from SHA to v2.1.0 tag

### DIFF
--- a/.github/workflows/advisor-release.yml
+++ b/.github/workflows/advisor-release.yml
@@ -65,8 +65,9 @@ jobs:
         arch:
           - amd64
           - arm64
-    # TODO: Do not pin this action to a SHA!
-    uses: slsa-framework/slsa-github-generator/.github/workflows/builder_go_slsa3.yml@f7dd8c54c2067bafc12ca7a55595d5ee9b75204a # v2.1.0
+    # NOTE: Do NOT pin this reusable workflow to a SHA — the SLSA generator
+    # rejects non-tag refs ("Expected ref of the form refs/tags/vX.Y.Z").
+    uses: slsa-framework/slsa-github-generator/.github/workflows/builder_go_slsa3.yml@v2.1.0
     with:
       go-version: "1.24"
       config-file: .slsa-goreleaser/advisor/${{matrix.os}}-${{matrix.arch}}.yml


### PR DESCRIPTION
## Problem
`advisor-release` fails at the SLSA builder step:
```
Invalid ref: f7dd8c54c2067bafc12ca7a55595d5ee9b75204a. Expected ref of the form refs/tags/vX.Y.Z
```
This is a regression from #295 (Renovate's "pin slsa-github-generator to f7dd8c5"). The SLSA `builder_go_slsa3.yml` reusable workflow **rejects non-tag refs** by design — it cannot be SHA-pinned. The file even carried a `# TODO: Do not pin this action to a SHA!` note that the pin violated.

## Fix
Restore the version-tag ref (`@v2.1.0`) and replace the TODO with an explanatory NOTE so future pins are avoided.

## Scope
- Only fixes the new-in-#295 regression. The separate pre-existing `Cannot upload assets to an immutable release` failure (advisor-release on v1.4.0 / v1.3.1) is **not** addressed here and needs a maintainer decision.
- Follow-up worth considering: a Renovate `packageRules` ignore so it doesn't re-pin this reusable workflow.