### PR TITLE
fix(renovate): never digest-pin the SLSA reusable workflow

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -18,6 +18,21 @@
   "configWarningReuseIssue": true,
   "suppressNotifications": ["prEditedNotification", "prIgnoreNotification"],
   "platformAutomerge": true,
+  "packageRules": [
+    {
+      // The SLSA generator's reusable workflows MUST be referenced by a version
+      // tag (refs/tags/vX.Y.Z). The builder resolves its own ref to derive the
+      // release version for provenance, so a commit SHA makes it fail with
+      // "Invalid ref ... Expected ref of the form refs/tags/vX.Y.Z".
+      // Exempt it from helpers:pinGitHubActionDigests so it is never digest-pinned,
+      // while still allowing Renovate to upgrade the version tag (vX.Y.Z -> newer).
+      // Context: regression from #295, reverted in #938.
+      "description": "Do not digest-pin the SLSA reusable workflow (breaks the generator); keep tag upgrades",
+      "matchManagers": ["github-actions"],
+      "matchDepNames": ["slsa-framework/slsa-github-generator"],
+      "pinDigests": false,
+    },
+  ],
   "pre-commit": {
     "enabled": true
   },


### PR DESCRIPTION
## Why
`helpers:pinGitHubActionDigests` (in `.github/renovate.json5`) pins every GitHub Action to a commit SHA. For ordinary actions that's good hygiene, but the **SLSA generator reusable workflows must be referenced by a version tag** — the builder resolves its own ref to derive the release version for provenance, so a SHA ref fails:
```
Invalid ref: <sha>. Expected ref of the form refs/tags/vX.Y.Z
```
That is what produced #295 (reverted in #938). Because `.github/renovate/autoMerge.json5` auto-merges `pin`/`digest` updates for github-actions, Renovate would simply re-pin and **re-break advisor-release** on its next run. The workflow revert alone is not durable.

## Change
Add a `packageRule` exempting `slsa-framework/slsa-github-generator` from digest pinning (`pinDigests: false`).

## Upgradability is preserved
Disabling digest pinning does **not** disable version updates. Renovate's github-actions manager still reads the tag and will continue to open PRs to bump `@v2.1.0 → @v2.2.0 → @v3.0.0` (majors still require manual merge per autoMerge.json5). You just never get a SHA-pin PR for it.

Validated with `renovate-config-validator` (Config validated successfully).