### PR TITLE
feat: MCP/LLM integration uplift + data-path hardening

### DIFF
--- a/.github/workflows/advisor-image-release.yaml
+++ b/.github/workflows/advisor-image-release.yaml
@@ -1,0 +1,74 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+name: Build and Push Advisor Docker Images
+
+# The advisor ships two artifacts on an advisor/v* tag:
+#   - advisor-release.yml      -> the SLSA-provenanced CLI binary (kubectl plugin)
+#   - this workflow            -> the container image for `advisor serve`
+# The container image is what the Helm chart deploys (advisor.enabled=true).
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - "advisor/v*"
+
+jobs:
+  build_and_push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+
+      - name: Cache Go modules
+        uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-advisor-${{ hashFiles('advisor/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-advisor-
+            ${{ runner.os }}-go-
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4
+        with:
+          platforms: all
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
+        with:
+          install: true
+          version: latest
+
+      - name: Login to GHCR
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract tag name
+        id: extract_tag
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          VERSION="${TAG#advisor/}"
+          echo "TAG_NAME=${VERSION}" >> $GITHUB_OUTPUT
+
+      - name: Build and Push
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
+        with:
+          context: advisor/
+          file: advisor/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          build-args: |
+            VERSION=${{ steps.extract_tag.outputs.TAG_NAME }}
+            SHA=${{ github.sha }}
+          tags: |
+            ghcr.io/kguardian-dev/kguardian/advisor:${{ steps.extract_tag.outputs.TAG_NAME }}
+            ghcr.io/kguardian-dev/kguardian/advisor:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/advisor-image-release.yaml
+++ b/.github/workflows/advisor-image-release.yaml
@@ -13,6 +13,12 @@ on:
     tags:
       - "advisor/v*"
 
+# Least-privilege token: read the repo to check out, write packages to push the
+# image to GHCR. Nothing else.
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   build_and_push:
     runs-on: ubuntu-latest

--- a/advisor/Dockerfile
+++ b/advisor/Dockerfile
@@ -26,7 +26,7 @@ COPY . .
 
 RUN go build -a -installsuffix cgo \
   -ldflags="-w -extldflags '-static' \
-  -X 'main.ApplicationName=${APPLICATION_NAME}}' \
+  -X 'main.ApplicationName=${APPLICATION_NAME}' \
   -X 'main.Version=${VERSION}' -X 'main.SHA=${SHA}' \
   -X 'github.com/kguardian-dev/kguardian/advisor/pkg/k8s.Version=${VERSION}'" \
   -o advisor .

--- a/advisor/Dockerfile
+++ b/advisor/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.5-alpine3.21 as build
+FROM golang:1.26-alpine AS build
 
 # Buildx build-in ARGs
 ARG TARGETOS

--- a/advisor/cmd/root.go
+++ b/advisor/cmd/root.go
@@ -81,6 +81,7 @@ func init() {
 	}
 
 	rootCmd.AddCommand(genCmd)
+	rootCmd.AddCommand(serveCmd)
 
 	// Set up colored output with consistent RFC3339 timestamp format
 	consoleWriter := zerolog.ConsoleWriter{

--- a/advisor/cmd/serve.go
+++ b/advisor/cmd/serve.go
@@ -1,0 +1,186 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/kguardian-dev/kguardian/advisor/pkg/api"
+	"github.com/kguardian-dev/kguardian/advisor/pkg/k8s"
+	"github.com/kguardian-dev/kguardian/advisor/pkg/network"
+	log "github.com/rs/zerolog/log"
+	"github.com/spf13/cobra"
+)
+
+// serveConfig is a no-op network.ConfigProvider for the HTTP service. The
+// service only calls PolicyService.GeneratePolicy, which synthesises a policy
+// from broker data and never touches the cluster clientset or output dir
+// (those are only used by the CLI's file-writing / apply path).
+type serveConfig struct{}
+
+func (serveConfig) GetClientset() interface{} { return nil }
+func (serveConfig) IsDryRun() bool            { return true }
+func (serveConfig) GetOutputDir() string      { return "" }
+
+const defaultServePort = "8083"
+
+var serveCmd = &cobra.Command{
+	Use:   "serve",
+	Short: "Run advisor as an HTTP service exposing policy/seccomp generation",
+	Long: `Run advisor as a long-lived HTTP service (intended to run in-cluster).
+
+It exposes the same NetworkPolicy / CiliumNetworkPolicy and seccomp-profile
+synthesis as the CLI, over HTTP, so other components (e.g. the MCP server's
+chat tools) can request a generated policy for a pod by name:
+
+  GET /generate/networkpolicy?pod=<name>&type=kubernetes|cilium  -> YAML
+  GET /generate/seccomp?pod=<name>                               -> JSON
+  GET /healthz                                                   -> 200
+
+Unlike the CLI it does not port-forward; set BROKER_URL to the in-cluster
+broker (e.g. http://broker.kguardian.svc.cluster.local:9090).`,
+	Run: func(_ *cobra.Command, _ []string) {
+		setupLogger()
+
+		// In-cluster the service reaches the broker directly (no port-forward).
+		if v := strings.TrimSpace(os.Getenv("BROKER_URL")); v != "" {
+			api.BrokerBaseURL = strings.TrimRight(v, "/")
+		}
+		// Forward the broker bearer token when the broker is deployed with auth.
+		api.BrokerAuthToken = strings.TrimSpace(os.Getenv("BROKER_AUTH_TOKEN"))
+		log.Info().Msgf("advisor serve: broker base URL %s (auth=%t)", api.BrokerBaseURL, api.BrokerAuthToken != "")
+
+		port := strings.TrimSpace(os.Getenv("PORT"))
+		if port == "" {
+			port = defaultServePort
+		}
+
+		policyService := network.NewPolicyService(serveConfig{}, network.StandardPolicy)
+		policyService.RegisterGenerator(network.NewStandardPolicyGenerator())
+		policyService.RegisterGenerator(network.NewCiliumPolicyGenerator())
+
+		mux := http.NewServeMux()
+		mux.HandleFunc("/healthz", handleHealthz)
+		mux.HandleFunc("/generate/networkpolicy", networkPolicyHandler(policyService))
+		mux.HandleFunc("/generate/seccomp", handleSeccompGenerate)
+
+		srv := &http.Server{
+			Addr:              ":" + port,
+			Handler:           mux,
+			ReadHeaderTimeout: 10 * time.Second,
+			ReadTimeout:       30 * time.Second,
+			WriteTimeout:      60 * time.Second,
+			IdleTimeout:       120 * time.Second,
+		}
+
+		// Start the server, then block on a termination signal and shut down
+		// gracefully so in-flight generation requests drain on pod termination.
+		serveErr := make(chan error, 1)
+		go func() {
+			log.Info().Msgf("advisor serve: listening on :%s", port)
+			if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+				serveErr <- err
+			}
+		}()
+
+		stop := make(chan os.Signal, 1)
+		signal.Notify(stop, syscall.SIGINT, syscall.SIGTERM)
+
+		select {
+		case err := <-serveErr:
+			log.Fatal().Err(err).Msg("advisor serve: server failed")
+		case sig := <-stop:
+			log.Info().Msgf("advisor serve: received %s, shutting down", sig)
+			shutdownCtx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+			defer cancel()
+			if err := srv.Shutdown(shutdownCtx); err != nil {
+				log.Error().Err(err).Msg("advisor serve: graceful shutdown failed")
+			}
+		}
+	},
+}
+
+func handleHealthz(w http.ResponseWriter, _ *http.Request) {
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte("ok"))
+}
+
+// networkPolicyHandler returns an http.HandlerFunc that synthesises a network
+// policy for the requested pod and returns it as YAML.
+func networkPolicyHandler(svc *network.PolicyService) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			writeJSONError(w, http.StatusMethodNotAllowed, "method not allowed")
+			return
+		}
+		pod := strings.TrimSpace(r.URL.Query().Get("pod"))
+		if pod == "" {
+			writeJSONError(w, http.StatusBadRequest, "missing required query parameter: pod")
+			return
+		}
+		policyType, err := parsePolicyType(strings.TrimSpace(orDefault(r.URL.Query().Get("type"), "kubernetes")))
+		if err != nil {
+			writeJSONError(w, http.StatusBadRequest, err.Error())
+			return
+		}
+
+		output, err := svc.GeneratePolicy(pod, policyType)
+		if err != nil {
+			log.Warn().Err(err).Msgf("serve: failed to generate %s policy for pod %s", policyType, pod)
+			writeJSONError(w, http.StatusBadGateway, err.Error())
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/yaml")
+		_, _ = w.Write(output.YAML)
+	}
+}
+
+// handleSeccompGenerate builds a seccomp profile for the requested pod from its
+// observed syscalls and returns it as JSON.
+func handleSeccompGenerate(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeJSONError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+	pod := strings.TrimSpace(r.URL.Query().Get("pod"))
+	if pod == "" {
+		writeJSONError(w, http.StatusBadRequest, "missing required query parameter: pod")
+		return
+	}
+
+	syscalls, err := api.GetPodSysCall(pod)
+	if err != nil {
+		log.Warn().Err(err).Msgf("serve: failed to fetch syscalls for pod %s", pod)
+		writeJSONError(w, http.StatusBadGateway, err.Error())
+		return
+	}
+
+	profile := k8s.BuildSeccompProfile(syscalls.Syscalls, syscalls.Arch, "SCMP_ACT_ERRNO")
+	body, err := json.MarshalIndent(profile, "", "    ")
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, "failed to marshal seccomp profile")
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	_, _ = w.Write(body)
+}
+
+func writeJSONError(w http.ResponseWriter, status int, msg string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(map[string]string{"error": msg})
+}
+
+func orDefault(v, fallback string) string {
+	if strings.TrimSpace(v) == "" {
+		return fallback
+	}
+	return v
+}

--- a/advisor/cmd/serve_test.go
+++ b/advisor/cmd/serve_test.go
@@ -1,0 +1,164 @@
+package cmd
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/kguardian-dev/kguardian/advisor/pkg/api"
+	"github.com/kguardian-dev/kguardian/advisor/pkg/network"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func newServePolicyService() *network.PolicyService {
+	svc := network.NewPolicyService(serveConfig{}, network.StandardPolicy)
+	svc.RegisterGenerator(network.NewStandardPolicyGenerator())
+	svc.RegisterGenerator(network.NewCiliumPolicyGenerator())
+	return svc
+}
+
+// withStubbedAPI overrides advisor's package-global broker accessors with
+// canned data for one pod (10.0.0.1, labelled app=web) talking out to an
+// external peer (8.8.8.8:443), and restores them on cleanup.
+func withStubbedAPI(t *testing.T) {
+	t.Helper()
+	origTraffic := api.GetPodTrafficFunc
+	origPod := api.GetPodSpecFunc
+	origSvc := api.GetSvcSpecFunc
+	t.Cleanup(func() {
+		api.GetPodTrafficFunc = origTraffic
+		api.GetPodSpecFunc = origPod
+		api.GetSvcSpecFunc = origSvc
+	})
+
+	api.GetPodTrafficFunc = func(podName string) ([]api.PodTraffic, error) {
+		return []api.PodTraffic{{
+			SrcPodName:   podName,
+			SrcIP:        "10.0.0.1",
+			SrcNamespace: "prod",
+			TrafficType:  "EGRESS",
+			DstIP:        "8.8.8.8",
+			DstPort:      "443",
+			Protocol:     corev1.ProtocolTCP,
+		}}, nil
+	}
+	api.GetPodSpecFunc = func(ip string) (*api.PodDetail, error) {
+		if ip == "10.0.0.1" {
+			return &api.PodDetail{
+				Name:      "web-1",
+				Namespace: "prod",
+				PodIP:     "10.0.0.1",
+				Pod: corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "web"}},
+				},
+			}, nil
+		}
+		return nil, nil // peer 8.8.8.8 -> CIDR fallback
+	}
+	api.GetSvcSpecFunc = func(string) (*api.SvcDetail, error) { return nil, nil }
+}
+
+func TestNetworkPolicyHandler_GeneratesStandardYAML(t *testing.T) {
+	withStubbedAPI(t)
+	h := networkPolicyHandler(newServePolicyService())
+
+	req := httptest.NewRequest(http.MethodGet, "/generate/networkpolicy?pod=web-1", nil)
+	rr := httptest.NewRecorder()
+	h(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status: want 200, got %d (%s)", rr.Code, rr.Body.String())
+	}
+	if ct := rr.Header().Get("Content-Type"); ct != "application/yaml" {
+		t.Errorf("content-type: want application/yaml, got %s", ct)
+	}
+	body := rr.Body.String()
+	if !strings.Contains(body, "kind: NetworkPolicy") {
+		t.Errorf("expected a NetworkPolicy YAML; got:\n%s", body)
+	}
+	if !strings.Contains(body, "app: web") {
+		t.Errorf("expected pod selector label app=web; got:\n%s", body)
+	}
+}
+
+func TestNetworkPolicyHandler_CiliumType(t *testing.T) {
+	withStubbedAPI(t)
+	h := networkPolicyHandler(newServePolicyService())
+
+	req := httptest.NewRequest(http.MethodGet, "/generate/networkpolicy?pod=web-1&type=cilium", nil)
+	rr := httptest.NewRecorder()
+	h(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status: want 200, got %d (%s)", rr.Code, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), "kind: CiliumNetworkPolicy") {
+		t.Errorf("expected a CiliumNetworkPolicy; got:\n%s", rr.Body.String())
+	}
+}
+
+func TestNetworkPolicyHandler_MissingPodIs400(t *testing.T) {
+	h := networkPolicyHandler(newServePolicyService())
+	req := httptest.NewRequest(http.MethodGet, "/generate/networkpolicy", nil)
+	rr := httptest.NewRecorder()
+	h(rr, req)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status: want 400, got %d", rr.Code)
+	}
+}
+
+func TestNetworkPolicyHandler_InvalidTypeIs400(t *testing.T) {
+	h := networkPolicyHandler(newServePolicyService())
+	req := httptest.NewRequest(http.MethodGet, "/generate/networkpolicy?pod=web-1&type=bogus", nil)
+	rr := httptest.NewRecorder()
+	h(rr, req)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status: want 400, got %d", rr.Code)
+	}
+}
+
+func TestSeccompHandler_GeneratesProfile(t *testing.T) {
+	// handleSeccompGenerate uses api.GetPodSysCall, which hits BrokerBaseURL
+	// directly (not a func var), so point it at a mock broker.
+	broker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasPrefix(r.URL.Path, "/pod/syscalls/") {
+			http.NotFound(w, r)
+			return
+		}
+		_, _ = w.Write([]byte(`[{"pod_name":"web-1","pod_namespace":"prod","syscalls":"read,write,openat","arch":"x86_64"}]`))
+	}))
+	defer broker.Close()
+
+	orig := api.BrokerBaseURL
+	api.BrokerBaseURL = broker.URL
+	t.Cleanup(func() { api.BrokerBaseURL = orig })
+
+	req := httptest.NewRequest(http.MethodGet, "/generate/seccomp?pod=web-1", nil)
+	rr := httptest.NewRecorder()
+	handleSeccompGenerate(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status: want 200, got %d (%s)", rr.Code, rr.Body.String())
+	}
+	var profile map[string]any
+	if err := json.Unmarshal(rr.Body.Bytes(), &profile); err != nil {
+		t.Fatalf("response is not valid JSON: %v", err)
+	}
+	if profile["defaultAction"] != "SCMP_ACT_ERRNO" {
+		t.Errorf("defaultAction: want SCMP_ACT_ERRNO, got %v", profile["defaultAction"])
+	}
+	if !strings.Contains(rr.Body.String(), "openat") {
+		t.Errorf("expected observed syscalls in profile; got:\n%s", rr.Body.String())
+	}
+}
+
+func TestHealthz(t *testing.T) {
+	rr := httptest.NewRecorder()
+	handleHealthz(rr, httptest.NewRequest(http.MethodGet, "/healthz", nil))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status: want 200, got %d", rr.Code)
+	}
+}

--- a/advisor/pkg/api/broker_get_test.go
+++ b/advisor/pkg/api/broker_get_test.go
@@ -1,0 +1,63 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestBrokerGet_EscapesPathAndForwardsAuth verifies the two hardening fixes on
+// the broker client used by `advisor serve`:
+//   - the caller-supplied pod name is URL-escaped into the request path
+//     (a '/' must not split the path), and
+//   - BrokerAuthToken, when set, is sent as a Bearer token.
+func TestBrokerGet_EscapesPathAndForwardsAuth(t *testing.T) {
+	var gotPath, gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.EscapedPath()
+		gotAuth = r.Header.Get("Authorization")
+		// Valid syscalls payload so GetPodSysCall returns without error.
+		_, _ = w.Write([]byte(`[{"pod_name":"a/b","syscalls":"read","arch":"x86_64"}]`))
+	}))
+	defer srv.Close()
+
+	origURL, origTok := BrokerBaseURL, BrokerAuthToken
+	BrokerBaseURL = srv.URL
+	BrokerAuthToken = "s3cr3t"
+	t.Cleanup(func() { BrokerBaseURL = origURL; BrokerAuthToken = origTok })
+
+	if _, err := GetPodSysCall("a/b"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// '/' in the pod name must be percent-encoded, not a path separator.
+	if gotPath != "/pod/syscalls/a%2Fb" {
+		t.Errorf("path: want /pod/syscalls/a%%2Fb, got %s", gotPath)
+	}
+	if gotAuth != "Bearer s3cr3t" {
+		t.Errorf("auth header: want 'Bearer s3cr3t', got %q", gotAuth)
+	}
+}
+
+// TestBrokerGet_NoAuthHeaderWhenTokenEmpty ensures we don't send an empty
+// bearer token when auth is not configured (the default, no-auth deployment).
+func TestBrokerGet_NoAuthHeaderWhenTokenEmpty(t *testing.T) {
+	var hadAuth bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, hadAuth = r.Header["Authorization"]
+		_, _ = w.Write([]byte(`[{"pod_name":"web-1","syscalls":"read","arch":"x86_64"}]`))
+	}))
+	defer srv.Close()
+
+	origURL, origTok := BrokerBaseURL, BrokerAuthToken
+	BrokerBaseURL = srv.URL
+	BrokerAuthToken = ""
+	t.Cleanup(func() { BrokerBaseURL = origURL; BrokerAuthToken = origTok })
+
+	if _, err := GetPodSysCall("web-1"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if hadAuth {
+		t.Error("Authorization header should be absent when BrokerAuthToken is empty")
+	}
+}

--- a/advisor/pkg/api/pod_syscall.go
+++ b/advisor/pkg/api/pod_syscall.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 
 	"github.com/rs/zerolog/log"
@@ -23,9 +24,7 @@ type PodSysCallResponse struct {
 }
 
 func GetPodSysCall(podName string) (PodSysCall, error) {
-	apiURL := "http://127.0.0.1:9090/pod/syscalls/" + podName
-
-	resp, err := http.Get(apiURL)
+	resp, err := brokerGet("/pod/syscalls/" + url.PathEscape(podName))
 	if err != nil {
 		log.Error().Err(err).Msg("GetPodSysCall: Error making GET request")
 		return PodSysCall{}, err
@@ -40,7 +39,7 @@ func GetPodSysCall(podName string) (PodSysCall, error) {
 		return PodSysCall{}, fmt.Errorf("GetPodSysCall: received non-OK HTTP status code: %v", resp.StatusCode)
 	}
 
-	body, err := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxBrokerResponseBytes))
 	if err != nil {
 		log.Error().Err(err).Msg("GetPodSysCall: Error reading response body")
 		return PodSysCall{}, err

--- a/advisor/pkg/api/pod_traffic.go
+++ b/advisor/pkg/api/pod_traffic.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
+	"time"
 
 	log "github.com/rs/zerolog/log"
 
@@ -44,6 +46,45 @@ type SvcDetail struct {
 	Service      v1.Service `yaml:"service_spec" json:"service_spec"`
 }
 
+// BrokerBaseURL is the base URL of the kguardian broker. It defaults to the
+// port-forward target the kubectl-plugin CLI sets up (a forward to
+// localhost:9090). The `serve` command overrides it (from BROKER_URL) so the
+// in-cluster service reaches the broker directly without a port-forward.
+//
+// BrokerBaseURL and BrokerAuthToken are configure-once values: set them before
+// serving traffic (the CLI sets up the port-forward first; `serve` sets them
+// from the environment before ListenAndServe). They are only read afterwards,
+// so concurrent broker calls need no synchronisation.
+var BrokerBaseURL = "http://127.0.0.1:9090"
+
+// BrokerAuthToken, when non-empty, is sent as a Bearer token on every broker
+// request. The broker requires it on all data endpoints when deployed with
+// BROKER_AUTH_TOKEN set; the `serve` command wires it from the environment so
+// the in-cluster service authenticates the same way the mcp-server does.
+var BrokerAuthToken = ""
+
+// maxBrokerResponseBytes caps the broker response body read (10 MB) so a
+// long-lived `serve` process can't be OOM'd by an oversized/hostile response.
+const maxBrokerResponseBytes = 10 * 1024 * 1024
+
+// brokerHTTPClient bounds every broker call with a timeout so a hung broker
+// can't pin a goroutine until the serve WriteTimeout fires.
+var brokerHTTPClient = &http.Client{Timeout: 30 * time.Second}
+
+// brokerGet performs an authenticated, timeout-bounded GET against the broker.
+// path is the URL path (already escaped by the caller) appended to
+// BrokerBaseURL. Callers are responsible for closing the returned body.
+func brokerGet(path string) (*http.Response, error) {
+	req, err := http.NewRequest(http.MethodGet, BrokerBaseURL+path, nil)
+	if err != nil {
+		return nil, err
+	}
+	if BrokerAuthToken != "" {
+		req.Header.Set("Authorization", "Bearer "+BrokerAuthToken)
+	}
+	return brokerHTTPClient.Do(req)
+}
+
 // Function variables for easier mocking in tests
 var (
 	GetPodTrafficFunc = getRealPodTraffic
@@ -68,11 +109,9 @@ func GetSvcSpec(svcIP string) (*SvcDetail, error) {
 
 // Real implementations
 func getRealPodTraffic(podName string) ([]PodTraffic, error) {
-	// Specify the URL of the REST API endpoint you want to invoke.
-	apiURL := "http://127.0.0.1:9090/pod/traffic/" + podName
-
-	// Send an HTTP GET request to the API endpoint.
-	resp, err := http.Get(apiURL)
+	// PathEscape the caller-supplied name so a value containing '/', '?', '#'
+	// or control chars can't manipulate the broker request path/query.
+	resp, err := brokerGet("/pod/traffic/" + url.PathEscape(podName))
 	if err != nil {
 		log.Error().Err(err).Msg("GetPodTraffic: Error making GET request")
 		return nil, err
@@ -88,7 +127,7 @@ func getRealPodTraffic(podName string) ([]PodTraffic, error) {
 	}
 	var podTraffic []PodTraffic
 
-	body, err := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxBrokerResponseBytes))
 	if err != nil {
 		log.Error().Err(err).Msg("GetPodTraffic: Error reading response body")
 		return nil, err
@@ -110,11 +149,7 @@ func getRealPodTraffic(podName string) ([]PodTraffic, error) {
 
 // Should we just get the pod spec directly from the cluster and only use the DB for the SaaS version where it contains the pod spec? Would this help with reducing unnecessary chatter?And just let the client do it?
 func getRealPodSpec(ip string) (*PodDetail, error) {
-	// Specify the URL of the REST API endpoint you want to invoke.
-	apiURL := "http://127.0.0.1:9090/pod/ip/" + ip
-
-	// Send an HTTP GET request to the API endpoint.
-	resp, err := http.Get(apiURL)
+	resp, err := brokerGet("/pod/ip/" + url.PathEscape(ip))
 	if err != nil {
 		log.Error().Err(err).Msg("Error making GET request")
 		return nil, err
@@ -134,7 +169,7 @@ func getRealPodSpec(ip string) (*PodDetail, error) {
 	var details *PodDetail
 
 	// Parse the JSON response and unmarshal it into the Go struct.
-	if err := json.NewDecoder(resp.Body).Decode(&details); err != nil {
+	if err := json.NewDecoder(io.LimitReader(resp.Body, maxBrokerResponseBytes)).Decode(&details); err != nil {
 		log.Error().Err(err).Msg("Error decoding JSON")
 		return nil, err
 	}
@@ -148,11 +183,7 @@ func getRealPodSpec(ip string) (*PodDetail, error) {
 }
 
 func getRealSvcSpec(svcIp string) (*SvcDetail, error) {
-	// Specify the URL of the RESTAPI endpoint you want to invoke.
-	apiURL := "http://127.0.0.1:9090/svc/ip/" + svcIp
-
-	// Send an HTTP GET request to the API endpoint.
-	resp, err := http.Get(apiURL)
+	resp, err := brokerGet("/svc/ip/" + url.PathEscape(svcIp))
 	if err != nil {
 		log.Error().Err(err).Msg("Error making GET request")
 		return nil, err
@@ -172,7 +203,7 @@ func getRealSvcSpec(svcIp string) (*SvcDetail, error) {
 	var details SvcDetail
 
 	// Parse the JSON response and unmarshal it into the Go struct.
-	if err := json.NewDecoder(resp.Body).Decode(&details); err != nil {
+	if err := json.NewDecoder(io.LimitReader(resp.Body, maxBrokerResponseBytes)).Decode(&details); err != nil {
 		log.Error().Err(err).Msg("Error decoding JSON")
 		return nil, err
 	}

--- a/advisor/pkg/k8s/seccomp.go
+++ b/advisor/pkg/k8s/seccomp.go
@@ -36,6 +36,36 @@ type ProfileOptions struct {
 // what the generated profile actually emits.
 var ValidSeccompActions = []string{"SCMP_ACT_ERRNO", "SCMP_ACT_KILL", "SCMP_ACT_LOG"}
 
+// SeccompArchitectures maps a captured CPU architecture (as recorded by the
+// controller) to the seccomp arch tokens. Exported so callers that build a
+// profile outside the file-writing GenerateSeccompProfile path (e.g. the
+// `serve` HTTP API) reuse the same mapping rather than duplicating it.
+var SeccompArchitectures = map[string][]string{
+	"x86_64": {"SCMP_ARCH_X86_64"},
+	"ARM64":  {"SCMP_ARCH_ARM64"},
+}
+
+// BuildSeccompProfile constructs a SeccompProfile that allow-lists exactly the
+// observed syscalls and denies everything else via defaultAction. It is the
+// single source of truth for profile shape, shared between the CLI's
+// file-writing path and the serve API. An empty defaultAction falls back to
+// SCMP_ACT_ERRNO so callers always get a syntactically valid profile.
+func BuildSeccompProfile(syscalls []string, arch, defaultAction string) SeccompProfile {
+	if defaultAction == "" {
+		defaultAction = "SCMP_ACT_ERRNO"
+	}
+	return SeccompProfile{
+		DefaultAction: defaultAction,
+		Architectures: SeccompArchitectures[arch],
+		Syscalls: []Rule{
+			{
+				Names:  syscalls,
+				Action: "SCMP_ACT_ALLOW",
+			},
+		},
+	}
+}
+
 // NewProfileOptions constructs ProfileOptions from CLI input. A
 // previous version of GenerateSeccompProfile hardcoded both OutputDir
 // and DefaultAction inside the function, silently ignoring the
@@ -67,11 +97,6 @@ func NewProfileOptions(config *Config, defaultAction string) (ProfileOptions, er
 
 func GenerateSeccompProfile(options GenerateOptions, config *Config, profileOpts ProfileOptions) {
 
-	var Architectures = map[string][]string{
-		"x86_64": {"SCMP_ARCH_X86_64"},
-		"ARM64":  {"SCMP_ARCH_ARM64"},
-	}
-
 	// Defensive defaults so a caller passing the zero ProfileOptions
 	// (e.g. in a test) still produces a syntactically-valid profile.
 	if profileOpts.OutputDir == "" {
@@ -97,16 +122,7 @@ func GenerateSeccompProfile(options GenerateOptions, config *Config, profileOpts
 			continue
 		}
 
-		profile := SeccompProfile{
-			DefaultAction: profileOpts.DefaultAction,
-			Architectures: Architectures[podSysCalls.Arch],
-			Syscalls: []Rule{
-				{
-					Names:  podSysCalls.Syscalls,
-					Action: "SCMP_ACT_ALLOW",
-				},
-			},
-		}
+		profile := BuildSeccompProfile(podSysCalls.Syscalls, podSysCalls.Arch, profileOpts.DefaultAction)
 
 		// Generate profile JSON
 		profileJSON, err := json.MarshalIndent(profile, "", "    ")

--- a/advisor/pkg/network/brokerdata.go
+++ b/advisor/pkg/network/brokerdata.go
@@ -1,0 +1,38 @@
+package network
+
+import api "github.com/kguardian-dev/kguardian/advisor/pkg/api"
+
+// BrokerData is the broker read surface that policy synthesis depends on:
+// fetching a pod's observed traffic, and resolving a peer IP to its pod or
+// service identity. Injecting it (rather than calling the api package's
+// process-global accessors directly) decouples the generators and PolicyService
+// from package-global state and makes peer resolution mockable in tests.
+type BrokerData interface {
+	// PodTrafficByName returns the observed traffic baseline for a pod.
+	PodTrafficByName(name string) ([]api.PodTraffic, error)
+	// PodByIP resolves a peer IP to a pod (nil, nil if not a known pod).
+	PodByIP(ip string) (*api.PodDetail, error)
+	// ServiceByIP resolves a peer IP to a service (nil, nil if not a known svc).
+	ServiceByIP(ip string) (*api.SvcDetail, error)
+}
+
+// apiBrokerData is the default BrokerData, backed by the api package's
+// configured broker client (the CLI's port-forward target, or the URL/token the
+// `serve` command sets). It bridges the new dependency-injection seam to the
+// existing api accessors so current callers keep working unchanged.
+type apiBrokerData struct{}
+
+func (apiBrokerData) PodTrafficByName(name string) ([]api.PodTraffic, error) {
+	return api.GetPodTraffic(name)
+}
+func (apiBrokerData) PodByIP(ip string) (*api.PodDetail, error)     { return api.GetPodSpec(ip) }
+func (apiBrokerData) ServiceByIP(ip string) (*api.SvcDetail, error) { return api.GetSvcSpec(ip) }
+
+// DefaultBrokerData returns the api-backed BrokerData used when none is injected.
+func DefaultBrokerData() BrokerData { return apiBrokerData{} }
+
+// brokerDataAware is implemented by generators that accept an injected
+// BrokerData, so PolicyService can propagate its data source to them.
+type brokerDataAware interface {
+	setBrokerData(BrokerData)
+}

--- a/advisor/pkg/network/brokerdata_test.go
+++ b/advisor/pkg/network/brokerdata_test.go
@@ -1,0 +1,99 @@
+package network
+
+import (
+	"strings"
+	"testing"
+
+	api "github.com/kguardian-dev/kguardian/advisor/pkg/api"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// stubBrokerData is a fully in-memory BrokerData — no package globals, no
+// network, no api.*Func overrides. Used to prove the generators and
+// PolicyService read from the injected data source.
+type stubBrokerData struct {
+	traffic []api.PodTraffic
+	pods    map[string]*api.PodDetail // keyed by IP
+	svcs    map[string]*api.SvcDetail // keyed by IP
+}
+
+func (s stubBrokerData) PodTrafficByName(string) ([]api.PodTraffic, error) { return s.traffic, nil }
+func (s stubBrokerData) PodByIP(ip string) (*api.PodDetail, error)         { return s.pods[ip], nil }
+func (s stubBrokerData) ServiceByIP(ip string) (*api.SvcDetail, error)     { return s.svcs[ip], nil }
+
+func podDetail(name, ip string, labels map[string]string) *api.PodDetail {
+	return &api.PodDetail{
+		Name: name, Namespace: "prod", PodIP: ip,
+		Pod: corev1.Pod{ObjectMeta: metav1.ObjectMeta{Labels: labels}},
+	}
+}
+
+// TestPolicyService_UsesInjectedBrokerData proves the entire synthesis path —
+// traffic fetch, the pod's own detail lookup, AND peer resolution — reads from
+// the injected BrokerData, with no api.*Func globals overridden.
+func TestPolicyService_UsesInjectedBrokerData(t *testing.T) {
+	stub := stubBrokerData{
+		traffic: []api.PodTraffic{{
+			SrcPodName: "web-1", SrcIP: "10.0.0.1", SrcNamespace: "prod",
+			TrafficType: "EGRESS", DstIP: "10.0.0.2", DstPort: "5432", Protocol: corev1.ProtocolTCP,
+		}},
+		pods: map[string]*api.PodDetail{
+			"10.0.0.1": podDetail("web-1", "10.0.0.1", map[string]string{"app": "web"}), // the pod itself
+			"10.0.0.2": podDetail("db-1", "10.0.0.2", map[string]string{"app": "db"}),   // the egress peer
+		},
+		svcs: map[string]*api.SvcDetail{},
+	}
+
+	svc := NewPolicyService(&mockConfigProvider{}, StandardPolicy)
+	svc.UseBrokerData(stub)
+	svc.RegisterGenerator(NewStandardPolicyGenerator())
+
+	out, err := svc.GeneratePolicy("web-1", StandardPolicy)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	yaml := string(out.YAML)
+	if !strings.Contains(yaml, "kind: NetworkPolicy") {
+		t.Errorf("expected a NetworkPolicy; got:\n%s", yaml)
+	}
+	// pod selector resolved from injected pod detail (10.0.0.1 -> app=web)
+	if !strings.Contains(yaml, "app: web") {
+		t.Errorf("pod selector not from injected data; got:\n%s", yaml)
+	}
+	// egress peer resolved from injected pod (10.0.0.2 -> app=db) — this is the
+	// peer-resolution path that previously read package globals.
+	if !strings.Contains(yaml, "app: db") {
+		t.Errorf("egress peer not resolved from injected data; got:\n%s", yaml)
+	}
+}
+
+// TestRegisterGenerator_PropagatesBrokerData proves the service injects its data
+// source into generators registered after UseBrokerData was called.
+func TestRegisterGenerator_PropagatesBrokerData(t *testing.T) {
+	stub := stubBrokerData{
+		traffic: []api.PodTraffic{{
+			SrcPodName: "web-1", SrcIP: "10.0.0.1", TrafficType: "EGRESS",
+			DstIP: "10.0.0.2", DstPort: "443", Protocol: corev1.ProtocolTCP,
+		}},
+		pods: map[string]*api.PodDetail{
+			"10.0.0.1": podDetail("web-1", "10.0.0.1", map[string]string{"app": "web"}),
+			"10.0.0.2": podDetail("api-1", "10.0.0.2", map[string]string{"app": "api"}),
+		},
+		svcs: map[string]*api.SvcDetail{},
+	}
+	svc := NewPolicyService(&mockConfigProvider{}, CiliumPolicy)
+	svc.UseBrokerData(stub)
+	svc.RegisterGenerator(NewCiliumPolicyGenerator()) // registered AFTER UseBrokerData
+
+	out, err := svc.GeneratePolicy("web-1", CiliumPolicy)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(string(out.YAML), "kind: CiliumNetworkPolicy") {
+		t.Errorf("expected a CiliumNetworkPolicy; got:\n%s", out.YAML)
+	}
+	if !strings.Contains(string(out.YAML), "app: api") {
+		t.Errorf("cilium peer not resolved from injected data; got:\n%s", out.YAML)
+	}
+}

--- a/advisor/pkg/network/cilium_policy.go
+++ b/advisor/pkg/network/cilium_policy.go
@@ -24,11 +24,6 @@ func NewCiliumPolicyGenerator() *CiliumPolicyGenerator {
 	return &CiliumPolicyGenerator{data: DefaultBrokerData()}
 }
 
-// NewCiliumPolicyGeneratorWithData injects a BrokerData for peer resolution.
-func NewCiliumPolicyGeneratorWithData(d BrokerData) *CiliumPolicyGenerator {
-	return &CiliumPolicyGenerator{data: d}
-}
-
 func (g *CiliumPolicyGenerator) setBrokerData(d BrokerData) {
 	if d != nil {
 		g.data = d

--- a/advisor/pkg/network/cilium_policy.go
+++ b/advisor/pkg/network/cilium_policy.go
@@ -14,11 +14,34 @@ import (
 )
 
 // CiliumPolicyGenerator generates Cilium NetworkPolicy resources
-type CiliumPolicyGenerator struct{}
+type CiliumPolicyGenerator struct {
+	data BrokerData
+}
 
-// NewCiliumPolicyGenerator creates a new generator for Cilium NetworkPolicy resources
+// NewCiliumPolicyGenerator creates a new generator for Cilium NetworkPolicy
+// resources, resolving peers via the default (api-backed) broker data source.
 func NewCiliumPolicyGenerator() *CiliumPolicyGenerator {
-	return &CiliumPolicyGenerator{}
+	return &CiliumPolicyGenerator{data: DefaultBrokerData()}
+}
+
+// NewCiliumPolicyGeneratorWithData injects a BrokerData for peer resolution.
+func NewCiliumPolicyGeneratorWithData(d BrokerData) *CiliumPolicyGenerator {
+	return &CiliumPolicyGenerator{data: d}
+}
+
+func (g *CiliumPolicyGenerator) setBrokerData(d BrokerData) {
+	if d != nil {
+		g.data = d
+	}
+}
+
+// broker returns the injected BrokerData, falling back to the default so a
+// zero-value generator never nil-panics.
+func (g *CiliumPolicyGenerator) broker() BrokerData {
+	if g.data == nil {
+		return DefaultBrokerData()
+	}
+	return g.data
 }
 
 // GetType returns the policy type
@@ -333,7 +356,7 @@ func (g *CiliumPolicyGenerator) createCiliumEgressRuleForPeer(peerIP string, por
 // resolvePeerForCilium resolves peer IP to either EndpointSelector or CIDR
 func (g *CiliumPolicyGenerator) resolvePeerForCilium(peerIP string) ([]ciliumapi.EndpointSelector, ciliumapi.CIDRSlice) {
 	// Try to get Service info first
-	svcSpec, err := api.GetSvcSpec(peerIP)
+	svcSpec, err := g.broker().ServiceByIP(peerIP)
 	if err == nil && svcSpec != nil && len(svcSpec.Service.Spec.Selector) > 0 {
 		log.Debug().Msgf("Found service %s/%s with selector %v for IP %s",
 			svcSpec.SvcNamespace, svcSpec.SvcName, svcSpec.Service.Spec.Selector, peerIP)
@@ -344,7 +367,7 @@ func (g *CiliumPolicyGenerator) resolvePeerForCilium(peerIP string) ([]ciliumapi
 	}
 
 	// Try to get Pod info
-	podSpec, err := api.GetPodSpec(peerIP)
+	podSpec, err := g.broker().PodByIP(peerIP)
 	if err == nil && podSpec != nil && len(podSpec.Pod.Labels) > 0 {
 		log.Debug().Msgf("Found pod %s/%s with labels %v for IP %s",
 			podSpec.Namespace, podSpec.Name, podSpec.Pod.Labels, peerIP)

--- a/advisor/pkg/network/generator.go
+++ b/advisor/pkg/network/generator.go
@@ -3,7 +3,6 @@ package network
 import (
 	"fmt"
 
-	api "github.com/kguardian-dev/kguardian/advisor/pkg/api"
 	"github.com/kguardian-dev/kguardian/advisor/pkg/common"
 	log "github.com/rs/zerolog/log"
 	"sigs.k8s.io/yaml"
@@ -14,26 +13,48 @@ type PolicyService struct {
 	config      ConfigProvider
 	generators  map[PolicyType]PolicyGenerator
 	defaultType PolicyType
+	data        BrokerData
 }
 
-// NewPolicyService creates a new PolicyService
+// NewPolicyService creates a new PolicyService backed by the default
+// (api-backed) broker data source. Inject a different source with UseBrokerData.
 func NewPolicyService(config ConfigProvider, defaultType PolicyType) *PolicyService {
 	return &PolicyService{
 		config:      config,
 		generators:  make(map[PolicyType]PolicyGenerator),
 		defaultType: defaultType,
+		data:        DefaultBrokerData(),
 	}
 }
 
-// RegisterGenerator registers a policy generator for a specific policy type
+// UseBrokerData swaps the broker data source and propagates it to every
+// already-registered generator, so the whole synthesis path reads from one
+// injected source. Call it before or after RegisterGenerator.
+func (s *PolicyService) UseBrokerData(data BrokerData) {
+	if data == nil {
+		return
+	}
+	s.data = data
+	for _, g := range s.generators {
+		if aware, ok := g.(brokerDataAware); ok {
+			aware.setBrokerData(data)
+		}
+	}
+}
+
+// RegisterGenerator registers a policy generator for a specific policy type,
+// injecting the service's broker data source so peer resolution uses it.
 func (s *PolicyService) RegisterGenerator(generator PolicyGenerator) {
+	if aware, ok := generator.(brokerDataAware); ok {
+		aware.setBrokerData(s.data)
+	}
 	s.generators[generator.GetType()] = generator
 }
 
 // GeneratePolicy generates a network policy for a pod
 func (s *PolicyService) GeneratePolicy(podName string, policyType PolicyType) (*PolicyOutput, error) {
 	// Get the pod traffic data
-	podTraffic, err := api.GetPodTraffic(podName)
+	podTraffic, err := s.data.PodTrafficByName(podName)
 	if err != nil {
 		log.Debug().Err(err).Msgf("Error retrieving %s pod traffic", podName)
 		return nil, err
@@ -58,7 +79,7 @@ func (s *PolicyService) GeneratePolicy(podName string, policyType PolicyType) (*
 	}
 
 	// Get the pod details
-	podDetail, err := api.GetPodSpec(lookupIP)
+	podDetail, err := s.data.PodByIP(lookupIP)
 	if err != nil {
 		log.Error().Err(err).Msgf("Error retrieving pod spec using IP %s for pod %s", lookupIP, podName)
 		return nil, err

--- a/advisor/pkg/network/standard_policy.go
+++ b/advisor/pkg/network/standard_policy.go
@@ -14,11 +14,34 @@ import (
 )
 
 // StandardPolicyGenerator generates standard Kubernetes NetworkPolicy resources
-type StandardPolicyGenerator struct{}
+type StandardPolicyGenerator struct {
+	data BrokerData
+}
 
-// NewStandardPolicyGenerator creates a new generator for standard NetworkPolicy resources
+// NewStandardPolicyGenerator creates a new generator for standard NetworkPolicy
+// resources, resolving peers via the default (api-backed) broker data source.
 func NewStandardPolicyGenerator() *StandardPolicyGenerator {
-	return &StandardPolicyGenerator{}
+	return &StandardPolicyGenerator{data: DefaultBrokerData()}
+}
+
+// NewStandardPolicyGeneratorWithData injects a BrokerData for peer resolution.
+func NewStandardPolicyGeneratorWithData(d BrokerData) *StandardPolicyGenerator {
+	return &StandardPolicyGenerator{data: d}
+}
+
+func (g *StandardPolicyGenerator) setBrokerData(d BrokerData) {
+	if d != nil {
+		g.data = d
+	}
+}
+
+// broker returns the injected BrokerData, falling back to the default so a
+// zero-value generator never nil-panics.
+func (g *StandardPolicyGenerator) broker() BrokerData {
+	if g.data == nil {
+		return DefaultBrokerData()
+	}
+	return g.data
 }
 
 // GetType returns the policy type
@@ -283,7 +306,7 @@ func (g *StandardPolicyGenerator) createNetworkPolicyPeer(peerIP string) *networ
 	log.Debug().Msgf("Creating network policy peer for IP: %s", peerIP)
 
 	// Try to get Service info first
-	svcSpec, err := api.GetSvcSpec(peerIP)
+	svcSpec, err := g.broker().ServiceByIP(peerIP)
 	if err == nil && svcSpec != nil {
 		// Validate service has selectors before using it
 		if len(svcSpec.Service.Spec.Selector) > 0 {
@@ -311,7 +334,7 @@ func (g *StandardPolicyGenerator) createNetworkPolicyPeer(peerIP string) *networ
 	}
 
 	// Try to get Pod info
-	podSpec, err := api.GetPodSpec(peerIP)
+	podSpec, err := g.broker().PodByIP(peerIP)
 	if err == nil && podSpec != nil {
 		// Validate pod has labels before using it
 		if len(podSpec.Pod.Labels) > 0 {

--- a/advisor/pkg/network/standard_policy.go
+++ b/advisor/pkg/network/standard_policy.go
@@ -24,11 +24,6 @@ func NewStandardPolicyGenerator() *StandardPolicyGenerator {
 	return &StandardPolicyGenerator{data: DefaultBrokerData()}
 }
 
-// NewStandardPolicyGeneratorWithData injects a BrokerData for peer resolution.
-func NewStandardPolicyGeneratorWithData(d BrokerData) *StandardPolicyGenerator {
-	return &StandardPolicyGenerator{data: d}
-}
-
 func (g *StandardPolicyGenerator) setBrokerData(d BrokerData) {
 	if d != nil {
 		g.data = d

--- a/broker/src/add.rs
+++ b/broker/src/add.rs
@@ -41,18 +41,14 @@ pub async fn add_pods_batch(
         received - inserted.len()
     );
 
-    // Fire-and-forget audit eval ONLY for events that were actually new.
-    // Each evaluation runs on its own tokio task so a busy batch doesn't
-    // serialise 100 sequential 500ms HTTP round-trips on one worker.
+    // Enqueue new flows for best-effort audit eval. try_enqueue never blocks
+    // the ingest hot path and never back-pressures capture: a backed-up
+    // evaluator sheds load (the bounded queue drops the overflow and counts it)
+    // instead of accumulating unbounded waiting tasks. The dispatcher drains the
+    // queue under a concurrency cap.
     if audit.enabled() {
         for event in inserted.iter().cloned() {
-            let audit_client = audit.get_ref().clone();
-            let pool_for_audit = pool.get_ref().clone();
-            actix_web::rt::spawn(async move {
-                audit_client
-                    .evaluate_and_persist(pool_for_audit, event)
-                    .await;
-            });
+            audit.try_enqueue(event);
         }
     }
 
@@ -171,19 +167,12 @@ pub async fn add_pods(
     .await?
     .map_err(actix_web::error::ErrorInternalServerError)?;
 
-    // Fire audit eval ONLY for new events. The pre-fix code cloned
-    // the form unconditionally and spawned the audit task even when
-    // create_pod_traffic deduped — wasting evaluator capacity on
-    // already-seen flows. Same class of fix as the batch endpoint.
+    // Enqueue ONLY new events for best-effort audit eval (deduped flows are
+    // skipped). try_enqueue is non-blocking and sheds load when the evaluator
+    // is backed up — same bounded-queue path as the batch endpoint.
     if audit.enabled() {
         if let Some(event) = inserted.clone() {
-            let audit_client = audit.get_ref().clone();
-            let pool_for_audit = pool.get_ref().clone();
-            actix_web::rt::spawn(async move {
-                audit_client
-                    .evaluate_and_persist(pool_for_audit, event)
-                    .await;
-            });
+            audit.try_enqueue(event);
         }
     }
 
@@ -301,9 +290,15 @@ pub async fn add_pod_details(
 
 pub fn upsert_pod_details(
     conn: &mut PgConnection,
-    w: web::Json<PodDetail>,
+    mut w: web::Json<PodDetail>,
 ) -> Result<PodDetail, DbError> {
     use schema::pod_details::dsl::*;
+    // Slim the Pod manifest before it ever hits storage: consumers only read
+    // metadata.labels, so dropping spec/status/managedFields here (rather than
+    // recompacting on every read) shrinks the row and the serialise cost.
+    if let Some(obj) = w.pod_obj.as_mut() {
+        crate::get::compact_pod_obj(obj);
+    }
     debug!(
         "storing the pod details {:?} into pod_details table",
         w.pod_name,
@@ -481,9 +476,14 @@ pub async fn add_svc_details(
 
 pub fn upsert_svc_details(
     conn: &mut PgConnection,
-    w: web::Json<SvcDetail>,
+    mut w: web::Json<SvcDetail>,
 ) -> Result<SvcDetail, DbError> {
     use schema::svc_details::dsl::*;
+    // Slim the Service manifest before storage: consumers read spec.selector
+    // and spec.ports, so keep spec and drop status/managedFields here.
+    if let Some(obj) = w.service_spec.as_mut() {
+        crate::get::compact_svc_spec(obj);
+    }
     debug!(
         "storing the service details {:?} into svc_details table",
         w.svc_ip,

--- a/broker/src/add.rs
+++ b/broker/src/add.rs
@@ -293,9 +293,10 @@ pub fn upsert_pod_details(
     mut w: web::Json<PodDetail>,
 ) -> Result<PodDetail, DbError> {
     use schema::pod_details::dsl::*;
-    // Slim the Pod manifest before it ever hits storage: consumers only read
-    // metadata.labels, so dropping spec/status/managedFields here (rather than
-    // recompacting on every read) shrinks the row and the serialise cost.
+    // Slim the Pod manifest before it ever hits storage: consumers read only
+    // metadata.labels and spec.hostNetwork, so dropping the rest of
+    // spec/status/managedFields here (rather than recompacting on every read)
+    // shrinks the row and the serialise cost.
     if let Some(obj) = w.pod_obj.as_mut() {
         crate::get::compact_pod_obj(obj);
     }

--- a/broker/src/audit.rs
+++ b/broker/src/audit.rs
@@ -350,15 +350,13 @@ impl AuditClient {
         self.in_flight.available_permits()
     }
 
-    /// Best-effort: build a Flow from the PodTraffic event, POST to
-    /// `/evaluate`, and persist any `WouldDeny` results. Errors are
-    /// logged but never propagated — the broker's ingest path must not
-    /// stall on evaluator hiccups.
     /// Evaluate one flow against the evaluator and persist any verdicts.
-    /// Concurrency is bounded by the caller: the audit dispatcher holds an
-    /// `in_flight` permit for the duration of this call, so a large ingest
-    /// burst can't create unbounded concurrent /evaluate round-trips.
-    pub async fn evaluate_and_persist(&self, pool: DbPool, traffic: PodTraffic) {
+    /// Best-effort: errors are logged but never propagated — the ingest path
+    /// must not stall on evaluator hiccups. Concurrency is bounded by the
+    /// caller: the audit dispatcher holds an `in_flight` permit for the duration
+    /// of this call, so a large ingest burst can't create unbounded concurrent
+    /// /evaluate round-trips. Called only by the in-crate dispatcher.
+    pub(crate) async fn evaluate_and_persist(&self, pool: DbPool, traffic: PodTraffic) {
         if !self.enabled {
             return;
         }

--- a/broker/src/audit.rs
+++ b/broker/src/audit.rs
@@ -780,6 +780,51 @@ mod tests {
         }
     }
 
+    // Build a queue-wired AuditClient with a given channel capacity, without
+    // spawning the dispatcher — so the receiver is never drained and the queue
+    // fills deterministically. The caller must keep the receiver alive (else
+    // try_send sees Closed, not Full).
+    fn client_with_queue(capacity: usize) -> (AuditClient, mpsc::Receiver<PodTraffic>) {
+        let (tx, rx) = mpsc::channel::<PodTraffic>(capacity);
+        let client = AuditClient {
+            enabled: true,
+            base_url: "http://evaluator".to_string(),
+            http: reqwest::Client::new(),
+            in_flight: std::sync::Arc::new(tokio::sync::Semaphore::new(1)),
+            tx: Some(tx),
+            dropped: Arc::new(AtomicU64::new(0)),
+        };
+        (client, rx)
+    }
+
+    #[test]
+    fn try_enqueue_sheds_and_counts_when_queue_full() {
+        // capacity 1, receiver never polled: first enqueue buffers, the rest
+        // are shed and counted via broker_audit_dropped_total.
+        let (client, _rx) = client_with_queue(1);
+        client.try_enqueue(sample_traffic(Some("INGRESS")));
+        assert_eq!(client.dropped_count(), 0, "first enqueue fits");
+        client.try_enqueue(sample_traffic(Some("INGRESS")));
+        client.try_enqueue(sample_traffic(Some("INGRESS")));
+        assert_eq!(client.dropped_count(), 2, "two shed once the queue is full");
+    }
+
+    #[test]
+    fn try_enqueue_is_noop_without_a_queue() {
+        // No dispatcher wired (start() not called): drop silently, never panic,
+        // never count.
+        let client = AuditClient {
+            enabled: true,
+            base_url: "http://evaluator".to_string(),
+            http: reqwest::Client::new(),
+            in_flight: std::sync::Arc::new(tokio::sync::Semaphore::new(1)),
+            tx: None,
+            dropped: Arc::new(AtomicU64::new(0)),
+        };
+        client.try_enqueue(sample_traffic(Some("INGRESS")));
+        assert_eq!(client.dropped_count(), 0);
+    }
+
     #[test]
     fn is_persistable_verdict_accepts_allow_and_woulddeny() {
         assert!(is_persistable_verdict("Allow"));

--- a/broker/src/audit.rs
+++ b/broker/src/audit.rs
@@ -13,7 +13,10 @@ use diesel::pg::PgConnection;
 use diesel::prelude::*;
 use diesel::r2d2::{self, ConnectionManager};
 use serde::{Deserialize, Serialize};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
 use std::time::Duration;
+use tokio::sync::mpsc;
 use tracing::{debug, warn};
 
 type DbPool = r2d2::Pool<ConnectionManager<PgConnection>>;
@@ -108,12 +111,25 @@ pub struct AuditClient {
     /// futures + 1000 connection-pool waiters. Bounding here gives
     /// upstream backpressure without changing the call sites.
     in_flight: std::sync::Arc<tokio::sync::Semaphore>,
+    /// Bounded ingest→audit queue. Ingest `try_send`s onto it (never blocks);
+    /// a dispatcher task drains it under `in_flight`. `None` until `start()`
+    /// wires the dispatcher (and on disabled clients / unit tests).
+    tx: Option<mpsc::Sender<PodTraffic>>,
+    /// Count of flows shed because the queue was full (evaluator backed up).
+    /// Exposed as `broker_audit_dropped_total`.
+    dropped: Arc<AtomicU64>,
 }
 
 /// Maximum concurrent audit /evaluate calls. Sized roughly to twice
 /// `pool_max_idle_per_host(8)` so the connection pool stays the
 /// effective rate limit; further audit calls queue on this semaphore.
 const AUDIT_INFLIGHT_PERMITS: usize = 16;
+
+/// Capacity of the bounded ingest→audit queue. This caps the memory the
+/// audit path can hold under evaluator slowness: ingest sheds (drops +
+/// counts) once the queue is full rather than spawning unbounded waiting
+/// tasks. Audit is best-effort, so shedding is the correct overload response.
+const AUDIT_QUEUE_CAPACITY: usize = 2048;
 
 /// Default audit eval timeout in milliseconds. 500ms is plenty for
 /// an in-cluster evaluator (matcher is in-memory, sub-ms); operators
@@ -216,6 +232,30 @@ fn build_flow_for_traffic(traffic: &PodTraffic) -> Option<Flow<'_>> {
     })
 }
 
+/// Drain the bounded audit queue, bounding concurrency by the `in_flight`
+/// semaphore. Acquiring a permit *before* receiving keeps the channel (not an
+/// unbounded pile of spawned tasks) as the buffer: at most `permits` evals run
+/// at once, at most `capacity` flows wait, and ingest sheds beyond that.
+fn spawn_audit_dispatcher(client: AuditClient, pool: DbPool, mut rx: mpsc::Receiver<PodTraffic>) {
+    actix_web::rt::spawn(async move {
+        loop {
+            let permit = match client.in_flight.clone().acquire_owned().await {
+                Ok(p) => p,
+                Err(_) => break, // semaphore closed → shutting down
+            };
+            let Some(traffic) = rx.recv().await else {
+                break; // all senders dropped → shutting down
+            };
+            let worker = client.clone();
+            let pool = pool.clone();
+            actix_web::rt::spawn(async move {
+                worker.evaluate_and_persist(pool, traffic).await;
+                drop(permit);
+            });
+        }
+    });
+}
+
 impl AuditClient {
     /// Construct from the `EVALUATOR_URL` env var. When unset OR
     /// whitespace-only, the client is disabled and
@@ -248,7 +288,52 @@ impl AuditClient {
             base_url,
             http,
             in_flight: std::sync::Arc::new(tokio::sync::Semaphore::new(permits)),
+            tx: None,
+            dropped: Arc::new(AtomicU64::new(0)),
         }
+    }
+
+    /// Wire up the bounded ingest→audit queue and spawn the dispatcher that
+    /// drains it. Call once at startup, after the DB pool exists. No-op (and no
+    /// queue) when audit is disabled, so `try_enqueue` silently drops. Returns
+    /// self so it composes: `AuditClient::from_env().start(pool)`.
+    pub fn start(mut self, pool: DbPool) -> Self {
+        if !self.enabled {
+            return self;
+        }
+        let capacity = std::env::var("AUDIT_QUEUE_CAPACITY")
+            .ok()
+            .and_then(|v| v.trim().parse::<usize>().ok())
+            .map(|n| n.max(1))
+            .unwrap_or(AUDIT_QUEUE_CAPACITY);
+        let (tx, rx) = mpsc::channel::<PodTraffic>(capacity);
+        self.tx = Some(tx);
+        spawn_audit_dispatcher(self.clone(), pool, rx);
+        self
+    }
+
+    /// Best-effort, non-blocking enqueue of a flow for audit evaluation. Ingest
+    /// calls this on the hot path: it never blocks and never back-pressures
+    /// capture. If the queue is full (evaluator backed up) the flow is dropped
+    /// and counted; if the dispatcher is gone the flow is silently ignored.
+    pub fn try_enqueue(&self, traffic: PodTraffic) {
+        let Some(tx) = self.tx.as_ref() else {
+            return;
+        };
+        match tx.try_send(traffic) {
+            Ok(()) => {}
+            Err(mpsc::error::TrySendError::Full(_)) => {
+                self.dropped.fetch_add(1, Ordering::Relaxed);
+                debug!("audit queue full; shedding flow (evaluator backed up)");
+            }
+            Err(mpsc::error::TrySendError::Closed(_)) => {}
+        }
+    }
+
+    /// Total flows shed because the audit queue was full. Exposed via
+    /// `/metrics` as `broker_audit_dropped_total`.
+    pub fn dropped_count(&self) -> u64 {
+        self.dropped.load(Ordering::Relaxed)
     }
 
     pub fn enabled(&self) -> bool {
@@ -269,24 +354,14 @@ impl AuditClient {
     /// `/evaluate`, and persist any `WouldDeny` results. Errors are
     /// logged but never propagated — the broker's ingest path must not
     /// stall on evaluator hiccups.
+    /// Evaluate one flow against the evaluator and persist any verdicts.
+    /// Concurrency is bounded by the caller: the audit dispatcher holds an
+    /// `in_flight` permit for the duration of this call, so a large ingest
+    /// burst can't create unbounded concurrent /evaluate round-trips.
     pub async fn evaluate_and_persist(&self, pool: DbPool, traffic: PodTraffic) {
         if !self.enabled {
             return;
         }
-        // Bound concurrent in-flight evaluations. Without this, a large
-        // ingest batch (the broker's add_pods_batch fires N tasks per
-        // event for an N-event batch) would create unbounded futures
-        // racing for the small connection pool. A failed acquire would
-        // mean the global semaphore is poisoned (extremely unlikely);
-        // treat that as 'just skip the audit step' rather than crashing
-        // the ingest path.
-        let _permit = match self.in_flight.clone().acquire_owned().await {
-            Ok(p) => p,
-            Err(e) => {
-                debug!(error = %e, "audit semaphore closed; skipping evaluation");
-                return;
-            }
-        };
         let url = format!("{}/evaluate", self.base_url.trim_end_matches('/'));
 
         let flow = match build_flow_for_traffic(&traffic) {

--- a/broker/src/get.rs
+++ b/broker/src/get.rs
@@ -378,8 +378,10 @@ pub fn pod_syscalls_by_name(
 
 #[derive(serde::Deserialize)]
 pub struct AuditVerdictsQuery {
-    /// Filter to a single policy by name. Pair with `namespace` for
-    /// AuditNetworkPolicy; leave `namespace` empty for AuditClusterNetworkPolicy.
+    /// Filter to a single policy by name. Combine with a concrete `namespace`
+    /// for an AuditNetworkPolicy; for cluster-scoped verdicts send `namespace=`
+    /// (empty value present), which matches `policy_namespace = ''`. An absent
+    /// `namespace` param spans all namespaces (cluster-scoped included).
     pub policy: Option<String>,
     pub namespace: Option<String>,
     /// Filter rows by verdict — "Allow" or "WouldDeny". The DB has the

--- a/broker/src/get.rs
+++ b/broker/src/get.rs
@@ -74,13 +74,29 @@ pub async fn get_pod_details(pool: web::Data<DbPool>) -> actix_web::Result<impl 
     })
 }
 
-/// Reduce a stored Pod manifest to just the metadata the frontend needs
-/// (labels live under metadata), dropping spec, status, and the verbose
+/// Reduce a stored Pod manifest to just the metadata consumers need (labels
+/// live under metadata — advisor uses them for the policy podSelector, the
+/// frontend for the same), dropping spec, status, and the verbose
 /// metadata.managedFields. Operates in place; non-object values are left
-/// untouched.
-fn compact_pod_obj(v: &mut serde_json::Value) {
+/// untouched. Applied at write time (add.rs) so the bulk never reaches storage,
+/// and kept here as a defensive read-time pass for rows written before that.
+pub(crate) fn compact_pod_obj(v: &mut serde_json::Value) {
     if let Some(obj) = v.as_object_mut() {
         obj.remove("spec");
+        obj.remove("status");
+        if let Some(meta) = obj.get_mut("metadata").and_then(|m| m.as_object_mut()) {
+            meta.remove("managedFields");
+        }
+    }
+}
+
+/// Reduce a stored Service manifest to the fields consumers read — `spec`
+/// carries the selector (advisor/frontend) and ports (mcp-server/frontend) —
+/// dropping status (loadBalancer, etc.) and metadata.managedFields. Operates in
+/// place; non-object values are left untouched. Applied at write time so the
+/// bulk never reaches storage.
+pub(crate) fn compact_svc_spec(v: &mut serde_json::Value) {
+    if let Some(obj) = v.as_object_mut() {
         obj.remove("status");
         if let Some(meta) = obj.get_mut("metadata").and_then(|m| m.as_object_mut()) {
             meta.remove("managedFields");
@@ -536,6 +552,50 @@ mod tests {
             "metadata.labels must be preserved"
         );
         assert_eq!(meta.get("name").and_then(|x| x.as_str()), Some("web-1"));
+    }
+
+    #[test]
+    fn compact_svc_spec_keeps_spec_drops_status() {
+        // The Service slim must keep spec (selector + ports — read by advisor,
+        // mcp-server, and the frontend) while dropping status and managedFields.
+        let mut v = serde_json::json!({
+            "metadata": {
+                "name": "web",
+                "namespace": "prod",
+                "managedFields": [{"manager": "kube-controller", "big": "y".repeat(1000)}]
+            },
+            "spec": {
+                "selector": {"app": "web"},
+                "ports": [{"port": 80, "protocol": "TCP"}],
+                "type": "ClusterIP"
+            },
+            "status": {"loadBalancer": {"ingress": [{"ip": "1.2.3.4"}]}}
+        });
+        compact_svc_spec(&mut v);
+        assert!(v.get("status").is_none(), "status must be dropped");
+        let meta = v.get("metadata").expect("metadata kept");
+        assert!(
+            meta.get("managedFields").is_none(),
+            "managedFields must be dropped"
+        );
+        // spec.selector and spec.ports must survive for policy generation.
+        assert_eq!(
+            v.pointer("/spec/selector/app").and_then(|x| x.as_str()),
+            Some("web"),
+            "spec.selector must be preserved"
+        );
+        assert_eq!(
+            v.pointer("/spec/ports/0/port").and_then(|x| x.as_u64()),
+            Some(80),
+            "spec.ports must be preserved"
+        );
+    }
+
+    #[test]
+    fn compact_svc_spec_tolerates_non_object() {
+        let mut v = serde_json::Value::Null;
+        compact_svc_spec(&mut v); // must not panic
+        assert!(v.is_null());
     }
 
     #[test]

--- a/broker/src/get.rs
+++ b/broker/src/get.rs
@@ -74,15 +74,33 @@ pub async fn get_pod_details(pool: web::Data<DbPool>) -> actix_web::Result<impl 
     })
 }
 
-/// Reduce a stored Pod manifest to just the metadata consumers need (labels
-/// live under metadata — advisor uses them for the policy podSelector, the
-/// frontend for the same), dropping spec, status, and the verbose
-/// metadata.managedFields. Operates in place; non-object values are left
-/// untouched. Applied at write time (add.rs) so the bulk never reaches storage,
-/// and kept here as a defensive read-time pass for rows written before that.
+/// Reduce a stored Pod manifest to just the fields consumers need: labels
+/// (under metadata — advisor uses them for the policy podSelector, the frontend
+/// for the same) and `spec.hostNetwork` (the advisor's Cilium generator reads it
+/// to skip host-networked / node-IP pods). Everything else in spec, all of
+/// status, and the verbose metadata.managedFields are dropped. Operates in
+/// place; non-object values are left untouched. Applied at write time (add.rs)
+/// so the bulk never reaches storage, and kept here as a defensive read-time
+/// pass for rows written before that.
 pub(crate) fn compact_pod_obj(v: &mut serde_json::Value) {
     if let Some(obj) = v.as_object_mut() {
-        obj.remove("spec");
+        // Preserve only spec.hostNetwork, dropping the rest of spec. When the
+        // manifest has no spec.hostNetwork (the common, non-host-networked
+        // case — the field is omitempty), drop spec entirely; the advisor then
+        // deserializes HostNetwork=false, which is correct.
+        let host_network = obj
+            .get("spec")
+            .and_then(|s| s.get("hostNetwork"))
+            .filter(|hn| !hn.is_null())
+            .cloned();
+        match host_network {
+            Some(hn) => {
+                obj.insert("spec".to_string(), serde_json::json!({ "hostNetwork": hn }));
+            }
+            None => {
+                obj.remove("spec");
+            }
+        }
         obj.remove("status");
         if let Some(meta) = obj.get_mut("metadata").and_then(|m| m.as_object_mut()) {
             meta.remove("managedFields");
@@ -535,11 +553,10 @@ mod tests {
                 "labels": {"app": "web"},
                 "managedFields": [{"manager": "kubelet", "big": "x".repeat(1000)}]
             },
-            "spec": {"containers": [{"name": "c", "image": "nginx"}]},
+            "spec": {"hostNetwork": true, "containers": [{"name": "c", "image": "nginx"}]},
             "status": {"phase": "Running", "conditions": [{"type": "Ready"}]}
         });
         compact_pod_obj(&mut v);
-        assert!(v.get("spec").is_none(), "spec must be dropped");
         assert!(v.get("status").is_none(), "status must be dropped");
         let meta = v.get("metadata").expect("metadata kept");
         assert!(
@@ -552,6 +569,35 @@ mod tests {
             "metadata.labels must be preserved"
         );
         assert_eq!(meta.get("name").and_then(|x| x.as_str()), Some("web-1"));
+        // spec.hostNetwork must survive (the Cilium generator reads it) but the
+        // rest of spec (containers, etc.) must be dropped.
+        assert_eq!(
+            v.pointer("/spec/hostNetwork").and_then(|x| x.as_bool()),
+            Some(true),
+            "spec.hostNetwork must be preserved"
+        );
+        assert!(
+            v.pointer("/spec/containers").is_none(),
+            "the rest of spec must be dropped"
+        );
+    }
+
+    #[test]
+    fn compact_pod_obj_drops_spec_when_no_host_network() {
+        // Non-host-networked pods omit spec.hostNetwork; spec is dropped wholesale.
+        let mut v = serde_json::json!({
+            "metadata": {"labels": {"app": "db"}},
+            "spec": {"containers": [{"name": "c"}]}
+        });
+        compact_pod_obj(&mut v);
+        assert!(
+            v.get("spec").is_none(),
+            "spec must be dropped when no hostNetwork"
+        );
+        assert_eq!(
+            v.pointer("/metadata/labels/app").and_then(|x| x.as_str()),
+            Some("db")
+        );
     }
 
     #[test]

--- a/broker/src/main.rs
+++ b/broker/src/main.rs
@@ -191,7 +191,11 @@ async fn main() -> Result<(), std::io::Error> {
         }
         std::thread::sleep(std::time::Duration::from_secs(2));
     }
-    let audit_client = AuditClient::from_env();
+    // start() wires the bounded ingest→audit queue + dispatcher (no-op when
+    // audit is disabled). Ingest enqueues onto it instead of spawning a task
+    // per flow, so a slow evaluator sheds load rather than back-pressuring
+    // capture or growing memory unbounded.
+    let audit_client = AuditClient::from_env().start(pool.clone());
 
     // Optional bearer-token auth on the broker API. Off unless
     // BROKER_AUTH_TOKEN is set, so existing deployments are unaffected.
@@ -297,11 +301,13 @@ pub async fn health_check(
 /// Build the Prometheus text-format payload for the broker. Pure
 /// formatting — no I/O — so it's testable in isolation without
 /// spinning up the actix runtime.
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn render_metrics_text(
     schema_ready: u8,
     db_reachable: u8,
     audit_enabled: u8,
     audit_inflight_available: usize,
+    audit_dropped_total: u64,
     db_pool_idle: u32,
     db_pool_max: u32,
     uptime_secs: u64,
@@ -320,6 +326,9 @@ pub(crate) fn render_metrics_text(
             "# HELP broker_audit_inflight_available Number of free permits on the audit semaphore (saturation = configured cap - this)\n",
             "# TYPE broker_audit_inflight_available gauge\n",
             "broker_audit_inflight_available {audit_inflight_available}\n",
+            "# HELP broker_audit_dropped_total Flows shed because the bounded audit queue was full (evaluator backed up)\n",
+            "# TYPE broker_audit_dropped_total counter\n",
+            "broker_audit_dropped_total {audit_dropped_total}\n",
             "# HELP broker_db_pool_idle Idle connections in the r2d2 pool (saturation = broker_db_pool_max - this)\n",
             "# TYPE broker_db_pool_idle gauge\n",
             "broker_db_pool_idle {db_pool_idle}\n",
@@ -334,6 +343,7 @@ pub(crate) fn render_metrics_text(
         db_reachable = db_reachable,
         audit_enabled = audit_enabled,
         audit_inflight_available = audit_inflight_available,
+        audit_dropped_total = audit_dropped_total,
         db_pool_idle = db_pool_idle,
         db_pool_max = db_pool_max,
         uptime_secs = uptime_secs,
@@ -384,6 +394,7 @@ pub async fn metrics(
     };
 
     let audit_inflight = audit.get_ref().available_permits();
+    let audit_dropped = audit.get_ref().dropped_count();
     // r2d2 pool state — paired metrics let operators compute
     // saturation = max - idle. broker_db_pool_idle pegged at 0 for
     // sustained time means the pool is fully utilised; bump
@@ -398,6 +409,7 @@ pub async fn metrics(
         u8::from(db_reachable),
         u8::from(audit.get_ref().enabled()),
         audit_inflight,
+        audit_dropped,
         db_pool_idle,
         db_pool_max,
         uptime_secs,
@@ -420,12 +432,13 @@ mod tests {
 
     #[test]
     fn renders_all_metric_names() {
-        let body = render_metrics_text(1, 1, 1, 16, 16, 16, 0);
+        let body = render_metrics_text(1, 1, 1, 16, 0, 16, 16, 0);
         for name in [
             "broker_db_schema_ready",
             "broker_db_reachable",
             "broker_audit_enabled",
             "broker_audit_inflight_available",
+            "broker_audit_dropped_total",
             "broker_db_pool_idle",
             "broker_db_pool_max",
             "broker_uptime_seconds",
@@ -436,13 +449,14 @@ mod tests {
 
     #[test]
     fn each_metric_has_help_and_type() {
-        let body = render_metrics_text(1, 1, 1, 16, 16, 16, 0);
+        let body = render_metrics_text(1, 1, 1, 16, 0, 16, 16, 0);
         // Each metric must have a # HELP and a # TYPE line.
         for name in [
             "broker_db_schema_ready",
             "broker_db_reachable",
             "broker_audit_enabled",
             "broker_audit_inflight_available",
+            "broker_audit_dropped_total",
             "broker_db_pool_idle",
             "broker_db_pool_max",
             "broker_uptime_seconds",
@@ -458,11 +472,12 @@ mod tests {
     fn renders_zero_state() {
         // All-zero state: DB unreachable, audit disabled, no permits available,
         // pool saturated (0 idle).
-        let body = render_metrics_text(0, 0, 0, 0, 0, 0, 0);
+        let body = render_metrics_text(0, 0, 0, 0, 0, 0, 0, 0);
         assert!(body.contains("\nbroker_db_schema_ready 0\n"));
         assert!(body.contains("\nbroker_db_reachable 0\n"));
         assert!(body.contains("\nbroker_audit_enabled 0\n"));
         assert!(body.contains("\nbroker_audit_inflight_available 0\n"));
+        assert!(body.contains("\nbroker_audit_dropped_total 0\n"));
         assert!(body.contains("\nbroker_db_pool_idle 0\n"));
         assert!(body.contains("\nbroker_db_pool_max 0\n"));
         assert!(body.contains("\nbroker_uptime_seconds 0\n"));
@@ -470,9 +485,10 @@ mod tests {
 
     #[test]
     fn renders_populated_state() {
-        let body = render_metrics_text(1, 1, 1, 16, 12, 16, 12345);
+        let body = render_metrics_text(1, 1, 1, 16, 7, 12, 16, 12345);
         assert!(body.contains("\nbroker_db_schema_ready 1\n"));
         assert!(body.contains("\nbroker_audit_inflight_available 16\n"));
+        assert!(body.contains("\nbroker_audit_dropped_total 7\n"));
         // 12 idle out of 16 max = 4 in use; pin both so saturation is computable
         assert!(body.contains("\nbroker_db_pool_idle 12\n"));
         assert!(body.contains("\nbroker_db_pool_max 16\n"));
@@ -482,7 +498,7 @@ mod tests {
     #[test]
     fn wire_shape_is_prometheus_compatible() {
         // Each non-comment line must look like `<name> <value>\n`.
-        let body = render_metrics_text(1, 1, 0, 8, 4, 16, 60);
+        let body = render_metrics_text(1, 1, 0, 8, 0, 4, 16, 60);
         for line in body.lines() {
             if line.is_empty() || line.starts_with('#') {
                 continue;

--- a/charts/kguardian/README.md
+++ b/charts/kguardian/README.md
@@ -73,6 +73,31 @@ The following table lists the configurable parameters of the kguardian chart and
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| advisor.affinity | object | `{}` | Affinity rules for advisor pods |
+| advisor.container.port | int | `8083` | Advisor HTTP port (distinct from the evaluator's 8082) |
+| advisor.enabled | bool | `false` | Deploy the advisor HTTP service. When false, the workload, Service, ServiceAccount, and NetworkPolicy are skipped (the CLI/kubectl-plugin is unaffected — it does not use this service). |
+| advisor.env | list | `[]` | Additional environment variables for the advisor process |
+| advisor.image.pullPolicy | string | `"IfNotPresent"` | Advisor image pull policy |
+| advisor.image.repository | string | `"ghcr.io/kguardian-dev/kguardian/advisor"` | Advisor container image repository |
+| advisor.image.sha | string | `""` | Overrides the image tag using SHA digest |
+| advisor.image.tag | string | `"1.4.1"` | Advisor version tag (auto-updated by Renovate, like the other images) |
+| advisor.imagePullSecrets | list | `[]` | List of image pull secrets for private registries |
+| advisor.networkPolicy | object | `{"enabled":false}` | Restrict who may reach the unauthenticated advisor HTTP API. When enabled, only the mcp-server pod may connect. Requires a NetworkPolicy- enforcing CNI (Cilium, Calico, ...). |
+| advisor.nodeSelector | object | `{}` | Node selector for advisor pods |
+| advisor.podAnnotations | object | `{}` | Annotations to add to advisor pods |
+| advisor.podSecurityContext | object | `{"runAsNonRoot":true,"seccompProfile":{"type":"RuntimeDefault"}}` | Advisor pod security context. Runs as non-root user (nonroot:65532). |
+| advisor.replicaCount | int | `1` | Number of advisor replicas. The service is stateless (it reads the broker and synthesises a policy per request), so it scales freely. |
+| advisor.resources | object | `{"limits":{"memory":"128Mi"},"requests":{"cpu":"10m","memory":"32Mi"}}` | Advisor pod resource requests and limits |
+| advisor.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"privileged":false,"readOnlyRootFilesystem":true,"runAsNonRoot":true}` | Advisor container security context. Distroless nonroot + read-only root. |
+| advisor.service.name | string | `"kguardian-advisor"` | Advisor service name |
+| advisor.service.port | int | `8083` | Advisor service port |
+| advisor.service.type | string | `"ClusterIP"` | Advisor service type |
+| advisor.serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
+| advisor.serviceAccount.automountServiceAccountToken | bool | `false` | The advisor service only talks to the broker over HTTP; it does not call the Kubernetes API, so no token is mounted. |
+| advisor.serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
+| advisor.serviceAccount.name | string | `""` | The name of the service account to use |
+| advisor.tolerations | list | `[]` | Tolerations for advisor pods |
+| advisor.topologySpreadConstraints | list | `[]` | Topology spread constraints for advisor pods |
 | broker.affinity | object | `{}` | Affinity rules for broker pod assignment |
 | broker.audit.evalTimeoutMs | int | `500` | Per-call timeout (in milliseconds) on the broker's POST to the evaluator's /evaluate endpoint. 500ms is plenty for an in-cluster evaluator (matcher is in-memory, sub-ms) but operators running the evaluator across cells / regions / VPNs may need more. Clamped to a minimum 50ms broker-side. |
 | broker.audit.inflightPermits | int | `16` | Maximum concurrent in-flight /evaluate calls to the audit evaluator. Bound prevents an ingest spike from creating unbounded concurrent reqwest futures + connection-pool waiters. The broker's /metrics exposes broker_audit_inflight_available so operators can spot saturation. The metrics doc suggests bumping this value when the gauge sits at 0 (under sustained load you'll see "evaluator round-trips queueing"). In-broker default is 16 if unset; minimum is 1. |

--- a/charts/kguardian/templates/advisor/deployment.yaml
+++ b/charts/kguardian/templates/advisor/deployment.yaml
@@ -1,0 +1,90 @@
+{{- if .Values.advisor.enabled }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Values.advisor.service.name }}
+  labels:
+    {{- include "kguardian.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.advisor.replicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ .Values.advisor.service.name }}
+  template:
+    metadata:
+      {{- with .Values.advisor.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "kguardian.labels" . | nindent 8 }}
+        app.kubernetes.io/name: {{ .Values.advisor.service.name }}
+    spec:
+      automountServiceAccountToken: {{ .Values.advisor.serviceAccount.automountServiceAccountToken }}
+      {{- with .Values.advisor.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ default "advisor" .Values.advisor.serviceAccount.name }}
+      securityContext:
+        {{- toYaml .Values.advisor.podSecurityContext | nindent 8 }}
+      containers:
+        - name: advisor
+          securityContext:
+            {{- toYaml .Values.advisor.securityContext | nindent 12 }}
+          {{- if .Values.advisor.image.sha }}
+          image: "{{ .Values.advisor.image.repository }}@{{ .Values.advisor.image.sha }}"
+          {{- else }}
+          image: "{{ .Values.advisor.image.repository }}:{{ include "kguardian.imageTag" .Values.advisor.image.tag }}"
+          {{- end }}
+          imagePullPolicy: {{ .Values.advisor.image.pullPolicy }}
+          # The image ENTRYPOINT is the advisor CLI; run the HTTP service.
+          args:
+            - serve
+          ports:
+            - name: http
+              containerPort: {{ .Values.advisor.container.port }}
+              protocol: TCP
+          env:
+            - name: PORT
+              value: "{{ .Values.advisor.container.port }}"
+            - name: BROKER_URL
+              value: "http://{{ .Values.broker.service.name }}.{{ include "kguardian.namespace" . }}.svc.cluster.local:{{ .Values.broker.container.port }}"
+            {{- include "kguardian.brokerAuthEnv" . | nindent 12 }}
+            {{- with .Values.advisor.env }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 15
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          {{- with .Values.advisor.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.advisor.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.advisor.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.advisor.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.advisor.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/kguardian/templates/advisor/networkpolicy.yaml
+++ b/charts/kguardian/templates/advisor/networkpolicy.yaml
@@ -1,0 +1,35 @@
+{{- if and .Values.advisor.enabled .Values.advisor.networkPolicy.enabled }}
+---
+# Ingress NetworkPolicy for the advisor service.
+#
+# The advisor HTTP API is unauthenticated and can synthesise a policy/seccomp
+# profile for any pod by name (disclosing that pod's observed peers and
+# syscalls). It relies on being an in-cluster-only service, so we restrict
+# ingress to the one component that legitimately calls it: the mcp-server
+# (whose generate_* tools proxy here). Requires a NetworkPolicy-enforcing CNI.
+#
+# Egress (the broker round-trip, DNS) is intentionally left unrestricted so
+# this policy can't break the advisor's own outbound calls.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ .Values.advisor.service.name }}
+  namespace: {{ include "kguardian.namespace" . }}
+  labels:
+    {{- include "kguardian.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: {{ .Values.advisor.service.name }}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        # mcp-server — proxies generate_network_policy / generate_seccomp_profile.
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: {{ .Values.mcpServer.service.name }}
+      ports:
+        - port: http
+          protocol: TCP
+{{- end }}

--- a/charts/kguardian/templates/advisor/service.yaml
+++ b/charts/kguardian/templates/advisor/service.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.advisor.enabled }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.advisor.service.name }}
+  labels:
+    {{- include "kguardian.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.advisor.service.type }}
+  ports:
+    - port: {{ .Values.advisor.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: {{ .Values.advisor.service.name }}
+{{- end }}

--- a/charts/kguardian/templates/advisor/serviceaccount.yaml
+++ b/charts/kguardian/templates/advisor/serviceaccount.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.advisor.enabled }}
+{{- if .Values.advisor.serviceAccount.create -}}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ default "advisor" .Values.advisor.serviceAccount.name }}
+  labels:
+    {{- include "kguardian.labels" . | nindent 4 }}
+  {{- with .Values.advisor.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.advisor.serviceAccount.automountServiceAccountToken }}
+{{- end }}
+{{- end }}

--- a/charts/kguardian/templates/broker/networkpolicy.yaml
+++ b/charts/kguardian/templates/broker/networkpolicy.yaml
@@ -39,6 +39,12 @@ spec:
         - podSelector:
             matchLabels:
               app.kubernetes.io/name: {{ .Values.mcpServer.service.name }}
+        {{- if .Values.advisor.enabled }}
+        # advisor service — reads traffic/syscalls to synthesise policies.
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: {{ .Values.advisor.service.name }}
+        {{- end }}
         # frontend — reads telemetry directly for the dashboard.
         - podSelector:
             matchLabels:

--- a/charts/kguardian/templates/mcp-server/deployment.yaml
+++ b/charts/kguardian/templates/mcp-server/deployment.yaml
@@ -51,6 +51,11 @@ spec:
             {{- include "kguardian.brokerAuthEnv" . | nindent 12 }}
             - name: PORT
               value: "{{ .Values.mcpServer.container.port }}"
+            {{- if .Values.advisor.enabled }}
+            # Policy/seccomp generation tools proxy to the advisor service.
+            - name: ADVISOR_URL
+              value: "http://{{ .Values.advisor.service.name }}.{{ include "kguardian.namespace" . }}.svc.cluster.local:{{ .Values.advisor.service.port }}"
+            {{- end }}
             {{- with .Values.mcpServer.env }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/charts/kguardian/values.yaml
+++ b/charts/kguardian/values.yaml
@@ -917,6 +917,102 @@ llmBridge:
       # -- Secret name for GitHub Copilot
       name: "kguardian-copilot"
 
+# Advisor Service Configuration
+# Runs `advisor serve` as an in-cluster HTTP service exposing NetworkPolicy /
+# CiliumNetworkPolicy and seccomp generation (the same synthesis as the CLI).
+# The MCP server's generate_network_policy / generate_seccomp_profile tools
+# proxy to it; enable it alongside mcpServer to offer policy generation in chat.
+advisor:
+  # -- Deploy the advisor HTTP service. When false, the workload, Service,
+  # ServiceAccount, and NetworkPolicy are skipped (the CLI/kubectl-plugin is
+  # unaffected — it does not use this service).
+  enabled: false
+
+  # -- Number of advisor replicas. The service is stateless (it reads the
+  # broker and synthesises a policy per request), so it scales freely.
+  replicaCount: 1
+
+  image:
+    # -- Advisor container image repository
+    repository: ghcr.io/kguardian-dev/kguardian/advisor
+    # -- Advisor image pull policy
+    pullPolicy: IfNotPresent
+    # -- Advisor version tag (auto-updated by Renovate, like the other images)
+    tag: "1.4.1"
+    # -- Overrides the image tag using SHA digest
+    sha: ""
+
+  # -- Additional environment variables for the advisor process
+  env: []
+
+  container:
+    # -- Advisor HTTP port (distinct from the evaluator's 8082)
+    port: 8083
+
+  service:
+    # -- Advisor service name
+    name: "kguardian-advisor"
+    # -- Advisor service type
+    type: ClusterIP
+    # -- Advisor service port
+    port: 8083
+
+  # -- List of image pull secrets for private registries
+  imagePullSecrets: []
+
+  serviceAccount:
+    # -- Specifies whether a service account should be created
+    create: true
+    # -- Annotations to add to the service account
+    annotations: {}
+    # -- The name of the service account to use
+    name: ""
+    # -- The advisor service only talks to the broker over HTTP; it does not
+    # call the Kubernetes API, so no token is mounted.
+    automountServiceAccountToken: false
+
+  # -- Restrict who may reach the unauthenticated advisor HTTP API. When
+  # enabled, only the mcp-server pod may connect. Requires a NetworkPolicy-
+  # enforcing CNI (Cilium, Calico, ...).
+  networkPolicy:
+    enabled: false
+
+  # -- Annotations to add to advisor pods
+  podAnnotations: {}
+
+  # -- Advisor pod security context. Runs as non-root user (nonroot:65532).
+  podSecurityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+
+  # -- Advisor container security context. Distroless nonroot + read-only root.
+  securityContext:
+    privileged: false
+    capabilities:
+      drop:
+      - ALL
+    readOnlyRootFilesystem: true
+    runAsNonRoot: true
+    allowPrivilegeEscalation: false
+
+  # -- Advisor pod resource requests and limits
+  resources:
+    requests:
+      cpu: 10m
+      memory: 32Mi
+    limits:
+      memory: 128Mi
+
+  # -- Node selector for advisor pods
+  nodeSelector: {}
+  # -- Affinity rules for advisor pods
+  affinity: {}
+  # -- Tolerations for advisor pods
+  tolerations: []
+  # -- Topology spread constraints for advisor pods
+  topologySpreadConstraints: []
+
 # MCP Server Configuration (Model Context Protocol)
 # The MCP server provides external tools (like Claude Desktop) access to cluster data
 mcpServer:

--- a/frontend/src/components/AIAssistant.tsx
+++ b/frontend/src/components/AIAssistant.tsx
@@ -165,7 +165,9 @@ const AIAssistant: React.FC<AIAssistantProps> = ({ isOpen, onClose, onLayoutChan
     // Build structured context for every message
     const context = JSON.stringify({
       namespace: namespace || undefined,
-      podNames: podNames?.slice(0, 30),
+      // Cap at 20 to match the bridge's getSystemPrompt truncation — sending
+      // more just gets dropped server-side.
+      podNames: podNames?.slice(0, 20),
     });
 
     // Cancel any prior in-flight stream, then start a fresh abortable one.

--- a/frontend/src/components/AIAssistant.tsx
+++ b/frontend/src/components/AIAssistant.tsx
@@ -1,8 +1,8 @@
 import React, { useState, useRef, useEffect, useCallback } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
-import { X, Send, Sparkles, Bot, User, Minimize2, Maximize2, ChevronRight, ChevronLeft } from 'lucide-react';
-import { sendChatMessage, type HistoryMessage } from '../services/aiApi';
+import { X, Send, Sparkles, Bot, User, Minimize2, Maximize2, ChevronRight, ChevronLeft, Copy, Check } from 'lucide-react';
+import { streamChatMessage, type HistoryMessage } from '../services/aiApi';
 import { UI_DIMENSIONS } from '../constants/ui';
 
 interface Message {
@@ -10,7 +10,69 @@ interface Message {
   role: 'user' | 'assistant';
   content: string;
   timestamp: Date;
+  // Transient UI state while a streamed assistant reply is in flight.
+  activity?: string;   // e.g. "Looking up policy verdicts…" or "Thinking…"
+  streaming?: boolean; // true until the terminal done/error event
 }
+
+// Map an MCP tool name to a short human phrase for the activity indicator.
+function describeTool(name: string): string {
+  const map: Record<string, string> = {
+    get_pod_network_traffic: 'pod network traffic',
+    get_pod_syscalls: 'pod syscalls',
+    get_pod_details: 'pod details',
+    get_pod_details_by_name: 'pod details',
+    get_service_details: 'service details',
+    list_services: 'service inventory',
+    get_cluster_traffic: 'cluster traffic',
+    get_cluster_pods: 'cluster pods',
+    get_audit_verdicts: 'policy verdicts',
+    generate_network_policy: 'network policy',
+    generate_seccomp_profile: 'seccomp profile',
+  };
+  return map[name] || name.replace(/^(get|list|generate)_/, '').replace(/_/g, ' ');
+}
+
+// Activity line for a tool call — generation tools read better as "Generating…".
+function toolActivity(name: string): string {
+  const what = describeTool(name);
+  return name.startsWith('generate_') ? `Generating ${what}…` : `Looking up ${what}…`;
+}
+
+// Renders a fenced markdown code block with a Copy button. Used as the custom
+// `pre` renderer for assistant markdown so generated NetworkPolicy/seccomp
+// (and any other code) can be copied to the clipboard in one click.
+const CodeBlock: React.FC<{ children?: React.ReactNode }> = ({ children }) => {
+  const preRef = useRef<HTMLPreElement>(null);
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    const text = preRef.current?.innerText ?? '';
+    if (!text) return;
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      // Clipboard API unavailable (e.g. non-secure context) — silently ignore.
+    }
+  };
+
+  return (
+    <div className="relative group">
+      <button
+        type="button"
+        onClick={handleCopy}
+        className="absolute right-2 top-2 flex items-center gap-1 rounded bg-hubble-dark/80 px-2 py-1 text-xs text-tertiary opacity-0 transition-opacity group-hover:opacity-100 hover:text-primary"
+        aria-label="Copy code"
+      >
+        {copied ? <Check className="w-3 h-3" /> : <Copy className="w-3 h-3" />}
+        {copied ? 'Copied' : 'Copy'}
+      </button>
+      <pre ref={preRef}>{children}</pre>
+    </div>
+  );
+};
 
 interface AIAssistantProps {
   isOpen: boolean;
@@ -32,6 +94,18 @@ const AIAssistant: React.FC<AIAssistantProps> = ({ isOpen, onClose, onLayoutChan
   const [isResizing, setIsResizing] = useState(false);
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
+  // Aborts the in-flight streaming request so the model stream (and its
+  // server-side tool calls / token spend) is cancelled when the user closes,
+  // clears, navigates away, or sends a new message mid-stream.
+  const abortRef = useRef<AbortController | null>(null);
+
+  // Abort any in-flight stream on unmount.
+  useEffect(() => () => abortRef.current?.abort(), []);
+
+  // Abort the in-flight stream when the panel is closed.
+  useEffect(() => {
+    if (!isOpen) abortRef.current?.abort();
+  }, [isOpen]);
 
   // Notify parent of layout changes
   useEffect(() => {
@@ -62,43 +136,78 @@ const AIAssistant: React.FC<AIAssistantProps> = ({ isOpen, onClose, onLayoutChan
       timestamp: new Date(),
     };
 
-    setMessages(prev => [...prev, userMessage]);
+    // Conversation history (exclude the in-flight turn) before we mutate state.
+    const history: HistoryMessage[] = messages.map(msg => ({
+      role: msg.role,
+      content: msg.content,
+    }));
+
+    // Streaming placeholder the deltas accumulate into.
+    const assistantId = crypto.randomUUID();
+    const assistantPlaceholder: Message = {
+      id: assistantId,
+      role: 'assistant',
+      content: '',
+      timestamp: new Date(),
+      activity: 'Thinking…',
+      streaming: true,
+    };
+
+    setMessages(prev => [...prev, userMessage, assistantPlaceholder]);
     const currentMessage = inputValue;
     setInputValue('');
     setIsTyping(true);
 
+    // Immutably patch the in-flight assistant message by id.
+    const patchAssistant = (patch: (m: Message) => Message) =>
+      setMessages(prev => prev.map(m => (m.id === assistantId ? patch(m) : m)));
+
+    // Build structured context for every message
+    const context = JSON.stringify({
+      namespace: namespace || undefined,
+      podNames: podNames?.slice(0, 30),
+    });
+
+    // Cancel any prior in-flight stream, then start a fresh abortable one.
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+
     try {
-      // Build conversation history (exclude system messages)
-      const history: HistoryMessage[] = messages.map(msg => ({
-        role: msg.role,
-        content: msg.content,
-      }));
-
-      // Build structured context for every message
-      const context = JSON.stringify({
-        namespace: namespace || undefined,
-        podNames: podNames?.slice(0, 30),
-      });
-
-      // Call the real AI API with conversation history and context
-      const response = await sendChatMessage(currentMessage, history, undefined, undefined, context);
-
-      const assistantMessage: Message = {
-        id: crypto.randomUUID(),
-        role: 'assistant',
-        content: response.message,
-        timestamp: new Date(),
-      };
-      setMessages(prev => [...prev, assistantMessage]);
+      await streamChatMessage(currentMessage, history, context, {
+        onText: (delta) =>
+          patchAssistant(m => ({ ...m, content: m.content + delta, activity: undefined })),
+        onToolUse: (name) =>
+          patchAssistant(m => ({ ...m, activity: toolActivity(name) })),
+        onToolResult: () =>
+          patchAssistant(m => ({ ...m, activity: 'Analyzing…' })),
+        onThinking: () =>
+          // Only surface a "thinking" hint while no answer text has arrived yet.
+          patchAssistant(m => (m.content ? m : { ...m, activity: 'Thinking…' })),
+        onDone: () =>
+          patchAssistant(m => ({ ...m, streaming: false, activity: undefined })),
+        onError: (error) =>
+          patchAssistant(m => ({
+            ...m,
+            streaming: false,
+            activity: undefined,
+            content: m.content
+              ? `${m.content}\n\n_Error: ${error}_`
+              : `Error: ${error}`,
+          })),
+      }, { signal: controller.signal });
     } catch (error) {
-      const errorMessage: Message = {
-        id: crypto.randomUUID(),
-        role: 'assistant',
+      patchAssistant(m => ({
+        ...m,
+        streaming: false,
+        activity: undefined,
         content: `Error: ${error instanceof Error ? error.message : 'Failed to get AI response. Please check that your API keys are configured.'}`,
-        timestamp: new Date(),
-      };
-      setMessages(prev => [...prev, errorMessage]);
+      }));
     } finally {
+      // Finalize the placeholder in every termination case — including an
+      // aborted stream, where neither onDone nor onError fires — so no bubble
+      // is left stuck in the streaming state with a spinning activity line.
+      patchAssistant(m => (m.streaming ? { ...m, streaming: false, activity: undefined } : m));
       setIsTyping(false);
     }
   };
@@ -106,11 +215,18 @@ const AIAssistant: React.FC<AIAssistantProps> = ({ isOpen, onClose, onLayoutChan
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
     if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault();
+      // Ignore Enter while a response is streaming — the Send button is already
+      // disabled on isTyping; this guards the keyboard path too, so a second
+      // turn can't start mid-stream (which would feed a partial answer back as
+      // history and run two concurrent streams).
+      if (isTyping) return;
       handleSendMessage();
     }
   };
 
   const handleClearChat = () => {
+    // Abort any in-flight stream so it doesn't keep patching a cleared message.
+    abortRef.current?.abort();
     setMessages([]);
   };
 
@@ -284,10 +400,20 @@ const AIAssistant: React.FC<AIAssistantProps> = ({ isOpen, onClose, onLayoutChan
                     >
                       {message.role === 'assistant' ? (
                         <div className="text-sm prose prose-sm dark:prose-invert max-w-none prose-p:my-1 prose-headings:my-2 prose-ul:my-1 prose-ol:my-1 prose-li:my-0.5 prose-pre:my-2 prose-table:my-2 prose-th:px-2 prose-th:py-1 prose-td:px-2 prose-td:py-1 prose-code:text-hubble-accent prose-a:text-hubble-accent">
-                          <ReactMarkdown remarkPlugins={[remarkGfm]}>{message.content}</ReactMarkdown>
+                          <ReactMarkdown remarkPlugins={[remarkGfm]} components={{ pre: CodeBlock }}>{message.content}</ReactMarkdown>
                         </div>
                       ) : (
                         <p className="text-sm whitespace-pre-wrap">{message.content}</p>
+                      )}
+                      {message.role === 'assistant' && message.activity && (
+                        <div className="flex items-center gap-2 mt-1 text-xs text-tertiary italic">
+                          <span className="flex gap-1">
+                            <span className="w-1.5 h-1.5 bg-hubble-accent rounded-full animate-bounce" style={{ animationDelay: '0ms' }} />
+                            <span className="w-1.5 h-1.5 bg-hubble-accent rounded-full animate-bounce" style={{ animationDelay: '150ms' }} />
+                            <span className="w-1.5 h-1.5 bg-hubble-accent rounded-full animate-bounce" style={{ animationDelay: '300ms' }} />
+                          </span>
+                          <span>{message.activity}</span>
+                        </div>
                       )}
                       <p
                         className={`text-xs mt-1 ${
@@ -304,7 +430,7 @@ const AIAssistant: React.FC<AIAssistantProps> = ({ isOpen, onClose, onLayoutChan
                     )}
                   </div>
                 ))}
-                {isTyping && (
+                {isTyping && !messages.some(m => m.streaming) && (
                   <div className="flex gap-3 justify-start">
                     <div className="flex-shrink-0 w-8 h-8 rounded-lg bg-hubble-accent/20 flex items-center justify-center">
                       <Bot className="w-5 h-5 text-hubble-accent" />
@@ -509,10 +635,20 @@ const AIAssistant: React.FC<AIAssistantProps> = ({ isOpen, onClose, onLayoutChan
                 >
                   {message.role === 'assistant' ? (
                     <div className="text-sm prose prose-sm dark:prose-invert max-w-none prose-p:my-1 prose-headings:my-2 prose-ul:my-1 prose-ol:my-1 prose-li:my-0.5 prose-pre:my-2 prose-table:my-2 prose-th:px-2 prose-th:py-1 prose-td:px-2 prose-td:py-1 prose-code:text-hubble-accent prose-a:text-hubble-accent">
-                      <ReactMarkdown remarkPlugins={[remarkGfm]}>{message.content}</ReactMarkdown>
+                      <ReactMarkdown remarkPlugins={[remarkGfm]} components={{ pre: CodeBlock }}>{message.content}</ReactMarkdown>
                     </div>
                   ) : (
                     <p className="text-sm whitespace-pre-wrap">{message.content}</p>
+                  )}
+                  {message.role === 'assistant' && message.activity && (
+                    <div className="flex items-center gap-2 mt-1 text-xs text-tertiary italic">
+                      <span className="flex gap-1">
+                        <span className="w-1.5 h-1.5 bg-hubble-accent rounded-full animate-bounce" style={{ animationDelay: '0ms' }} />
+                        <span className="w-1.5 h-1.5 bg-hubble-accent rounded-full animate-bounce" style={{ animationDelay: '150ms' }} />
+                        <span className="w-1.5 h-1.5 bg-hubble-accent rounded-full animate-bounce" style={{ animationDelay: '300ms' }} />
+                      </span>
+                      <span>{message.activity}</span>
+                    </div>
                   )}
                   <p
                     className={`text-xs mt-1 ${
@@ -529,7 +665,7 @@ const AIAssistant: React.FC<AIAssistantProps> = ({ isOpen, onClose, onLayoutChan
                 )}
               </div>
             ))}
-            {isTyping && (
+            {isTyping && !messages.some(m => m.streaming) && (
               <div className="flex gap-3 justify-start">
                 <div className="flex-shrink-0 w-8 h-8 rounded-lg bg-hubble-accent/20 flex items-center justify-center">
                   <Bot className="w-5 h-5 text-hubble-accent" />

--- a/frontend/src/services/aiApi.ts
+++ b/frontend/src/services/aiApi.ts
@@ -1,5 +1,3 @@
-import axios from 'axios';
-
 // LLM Bridge URL - use relative path for proxy in production, or direct URL in development
 // In production (Vite preview), this proxies through /llm-api to the llm-bridge service
 // In development, this can connect directly to localhost:8080 or use the dev proxy
@@ -12,31 +10,6 @@ export interface HistoryMessage {
   content: string;
 }
 
-export interface ChatMessage {
-  message: string;
-  conversation_id?: string;
-  provider?: LLMProvider;
-  model?: string;
-  context?: string;
-  history?: HistoryMessage[];
-}
-
-export interface ChatResponse {
-  message: string;
-  provider: LLMProvider;
-  model: string;
-  conversation_id?: string;
-}
-
-/**
- * Send a chat message to the AI assistant
- * @param message The user's message
- * @param history Optional: Previous conversation messages for context
- * @param provider Optional: Specify which LLM provider to use (openai, anthropic, gemini, copilot)
- * @param conversationId Optional: Continue an existing conversation
- * @param context Optional: JSON string with structured context (namespace, podNames)
- * @returns The AI's response
- */
 /**
  * Callbacks invoked as a streamed chat response arrives. Every field is
  * optional so callers subscribe only to the events they render.
@@ -167,35 +140,5 @@ export async function streamChatMessage(
     // Always release the reader lock / signal the body to stop, so an aborted
     // or errored stream doesn't leak the reader and underlying connection.
     reader.cancel().catch(() => {});
-  }
-}
-
-export async function sendChatMessage(
-  message: string,
-  history?: HistoryMessage[],
-  provider?: LLMProvider,
-  conversationId?: string,
-  context?: string
-): Promise<ChatResponse> {
-  try {
-    const response = await axios.post<ChatResponse>(`${LLM_BRIDGE_URL}/api/chat`, {
-      message,
-      history,
-      provider,
-      conversationId,
-      context,
-    });
-
-    return response.data;
-  } catch (error) {
-    if (axios.isAxiosError(error)) {
-      const errorMessage = error.response?.data?.error || error.message;
-      const details = error.response?.data?.details;
-      throw new Error(
-        `Failed to get AI response: ${errorMessage}${details ? ` - ${details}` : ''}`,
-        { cause: error }
-      );
-    }
-    throw new Error('An unexpected error occurred while calling the AI API', { cause: error });
   }
 }

--- a/frontend/src/services/aiApi.ts
+++ b/frontend/src/services/aiApi.ts
@@ -37,6 +37,139 @@ export interface ChatResponse {
  * @param context Optional: JSON string with structured context (namespace, podNames)
  * @returns The AI's response
  */
+/**
+ * Callbacks invoked as a streamed chat response arrives. Every field is
+ * optional so callers subscribe only to the events they render.
+ */
+export interface StreamHandlers {
+  onText?: (delta: string) => void;
+  onThinking?: (delta: string) => void;
+  onToolUse?: (name: string) => void;
+  onToolResult?: (name: string, ok: boolean) => void;
+  onDone?: (info: { model: string; conversationId?: string }) => void;
+  onError?: (error: string) => void;
+}
+
+export interface StreamOptions {
+  provider?: LLMProvider;
+  conversationId?: string;
+  signal?: AbortSignal;
+}
+
+/**
+ * Stream a chat response over Server-Sent Events from the llm-bridge.
+ * Parses the SSE frames and dispatches typed events to `handlers`. Resolves
+ * when the stream ends; never throws for normal API failures (those arrive via
+ * `handlers.onError`), only silently returns on an aborted request.
+ */
+export async function streamChatMessage(
+  message: string,
+  history: HistoryMessage[] | undefined,
+  context: string | undefined,
+  handlers: StreamHandlers,
+  options: StreamOptions = {}
+): Promise<void> {
+  let response: Response;
+  try {
+    response = await fetch(`${LLM_BRIDGE_URL}/api/chat/stream`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        message,
+        history,
+        context,
+        provider: options.provider,
+        conversationId: options.conversationId,
+      }),
+      signal: options.signal,
+    });
+  } catch (error) {
+    if ((error as Error)?.name === 'AbortError') return;
+    handlers.onError?.((error as Error)?.message || 'Failed to reach the AI service');
+    return;
+  }
+
+  // Pre-stream failures (validation, no provider) come back as JSON, not SSE.
+  if (!response.ok) {
+    let detail = `${response.status} ${response.statusText}`;
+    try {
+      const body = await response.json();
+      detail = body.error + (body.details ? ` - ${body.details}` : '');
+    } catch {
+      // non-JSON body; keep the status line
+    }
+    handlers.onError?.(detail);
+    return;
+  }
+
+  if (!response.body) {
+    handlers.onError?.('No response stream from the AI service');
+    return;
+  }
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = '';
+
+  const dispatch = (frame: string): void => {
+    const dataLine = frame
+      .split('\n')
+      .filter((line) => line.startsWith('data:'))
+      .map((line) => line.slice(5).trimStart())
+      .join('');
+    if (!dataLine) return;
+
+    let event: Record<string, unknown>;
+    try {
+      event = JSON.parse(dataLine);
+    } catch {
+      return;
+    }
+
+    switch (event.type) {
+      case 'text':
+        handlers.onText?.(event.delta as string);
+        break;
+      case 'thinking':
+        handlers.onThinking?.(event.delta as string);
+        break;
+      case 'tool_use':
+        handlers.onToolUse?.(event.name as string);
+        break;
+      case 'tool_result':
+        handlers.onToolResult?.(event.name as string, event.ok as boolean);
+        break;
+      case 'done':
+        handlers.onDone?.({ model: event.model as string, conversationId: event.conversationId as string | undefined });
+        break;
+      case 'error':
+        handlers.onError?.(event.error as string);
+        break;
+    }
+  };
+
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      let sep: number;
+      while ((sep = buffer.indexOf('\n\n')) !== -1) {
+        dispatch(buffer.slice(0, sep));
+        buffer = buffer.slice(sep + 2);
+      }
+    }
+    if (buffer.trim()) dispatch(buffer);
+  } catch (error) {
+    if ((error as Error)?.name === 'AbortError') return;
+    handlers.onError?.((error as Error)?.message || 'The AI stream was interrupted');
+  } finally {
+    // Always release the reader lock / signal the body to stop, so an aborted
+    // or errored stream doesn't leak the reader and underlying connection.
+    reader.cancel().catch(() => {});
+  }
+}
+
 export async function sendChatMessage(
   message: string,
   history?: HistoryMessage[],

--- a/llm-bridge/README.md
+++ b/llm-bridge/README.md
@@ -59,7 +59,7 @@ A dedicated microservice that bridges the kguardian frontend with multiple LLM p
 
 ### Anthropic Claude
 - **Env Var**: `ANTHROPIC_API_KEY`
-- **Default Model**: `claude-sonnet-4-5-20250929`
+- **Default Model**: `claude-opus-4-8`
 - **Best For**: Complex security analysis, best reasoning
 
 ### Google Gemini
@@ -158,7 +158,7 @@ Send a chat message to the AI assistant.
 {
   "message": "What pods have the most network traffic?",
   "provider": "anthropic",  // optional: openai, anthropic, gemini, copilot
-  "model": "claude-sonnet-4-5-20250929",  // optional: override default
+  "model": "claude-opus-4-8",  // optional: override default
   "conversationId": "abc123",  // optional: for conversation context
   "systemPrompt": "Custom system prompt"  // optional
 }
@@ -169,7 +169,7 @@ Send a chat message to the AI assistant.
 {
   "message": "Based on the network traffic data...",
   "provider": "anthropic",
-  "model": "claude-sonnet-4-5-20250929",
+  "model": "claude-opus-4-8",
   "conversationId": "abc123"
 }
 ```

--- a/llm-bridge/package-lock.json
+++ b/llm-bridge/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.3.0",
       "license": "BUSL-1.1",
       "dependencies": {
+        "@anthropic-ai/sdk": "^0.106.0",
         "@modelcontextprotocol/sdk": "^1.23.0",
         "axios": "^1.7.9",
         "cors": "^2.8.5",
@@ -26,6 +27,36 @@
         "tsx": "^4.19.2",
         "typescript": "^6.0.0",
         "typescript-eslint": "^8.59.0"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.106.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.106.0.tgz",
+      "integrity": "sha512-ufwVvYNDBj2dzOGupBCTaNzBLxqcTnGOzI4z8Wouxlt+mT3J3HuOmatgCy1VmwCHOUueqZ41ERhm0O99OUcbWA==",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1",
+        "standardwebhooks": "^1.0.0"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -709,6 +740,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
       "license": "MIT"
     },
     "node_modules/@types/body-parser": {
@@ -1899,6 +1936,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
+    },
     "node_modules/fast-uri": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
@@ -2328,6 +2371,19 @@
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
@@ -2948,6 +3004,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
     "node_modules/statuses": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
@@ -2982,6 +3048,12 @@
       "engines": {
         "node": ">=0.6"
       }
+    },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT"
     },
     "node_modules/ts-api-utils": {
       "version": "2.5.0",

--- a/llm-bridge/package.json
+++ b/llm-bridge/package.json
@@ -22,6 +22,7 @@
   "author": "kguardian-dev",
   "license": "BUSL-1.1",
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.106.0",
     "@modelcontextprotocol/sdk": "^1.23.0",
     "axios": "^1.7.9",
     "cors": "^2.8.5",

--- a/llm-bridge/src/brokerClient.test.ts
+++ b/llm-bridge/src/brokerClient.test.ts
@@ -85,3 +85,41 @@ test("parseContext handles pre-empty arrays", () => {
   const got = BrokerClient.parseContext('{"podNames":[]}');
   assert.deepEqual(got, { namespace: undefined, podNames: [] });
 });
+
+// The MCP server is the single source of truth for the tool surface — there is
+// no static fallback. Tool discovery failing (or returning nothing) must make
+// the request fail clearly, never silently answer the user with zero tools.
+
+test("getToolsCached throws on an empty tool set (no static fallback)", async () => {
+  const C = BrokerClient as unknown as {
+    getToolDefinitionsFromMCP: () => Promise<unknown[]>;
+    toolDefsCache: unknown;
+  };
+  const orig = C.getToolDefinitionsFromMCP;
+  C.toolDefsCache = null;
+  C.getToolDefinitionsFromMCP = async () => [];
+  try {
+    await assert.rejects(() => BrokerClient.getToolsCached(), /no tools/);
+  } finally {
+    C.getToolDefinitionsFromMCP = orig;
+    C.toolDefsCache = null;
+  }
+});
+
+test("getToolsCached propagates a discovery failure (no static fallback)", async () => {
+  const C = BrokerClient as unknown as {
+    getToolDefinitionsFromMCP: () => Promise<unknown[]>;
+    toolDefsCache: unknown;
+  };
+  const orig = C.getToolDefinitionsFromMCP;
+  C.toolDefsCache = null;
+  C.getToolDefinitionsFromMCP = async () => {
+    throw new Error("MCP server unreachable");
+  };
+  try {
+    await assert.rejects(() => BrokerClient.getToolsCached(), /MCP server unreachable/);
+  } finally {
+    C.getToolDefinitionsFromMCP = orig;
+    C.toolDefsCache = null;
+  }
+});

--- a/llm-bridge/src/brokerClient.ts
+++ b/llm-bridge/src/brokerClient.ts
@@ -206,8 +206,12 @@ export class BrokerClient {
       const response = await this.mcpClient.listTools();
       return response.tools || [];
     } catch (error) {
+      // Propagate rather than swallow. The MCP server is the single source of
+      // truth for the tool surface; if discovery fails the assistant has no
+      // grounded tools, and answering ungrounded is worse than failing. The
+      // caller surfaces a clear "tool server unreachable" error to the user.
       log.error("Error fetching tools from MCP server:", error);
-      return [];
+      throw error instanceof Error ? error : new Error(String(error));
     }
   }
 
@@ -220,7 +224,7 @@ export class BrokerClient {
     try {
       const tools = await client.getAvailableTools();
 
-      // Convert MCP tool format to LLM provider format
+      // Convert MCP tool format to LLM provider format.
       return tools.map((tool: any) => ({
         name: tool.name,
         description: tool.description || "",
@@ -230,124 +234,30 @@ export class BrokerClient {
           required: [],
         },
       }));
-    } catch (error) {
-      log.error("Failed to fetch tools from MCP server, using fallback:", error);
-      // Fallback to static definitions if MCP server is unavailable
-      return BrokerClient.getToolDefinitions();
     } finally {
+      // Errors propagate (no static fallback) — the MCP server is the single
+      // source of truth for the tool surface.
       await client.close();
     }
   }
 
   /**
-   * Get tool definitions with caching — tries MCP server first, falls back to static
+   * Get tool definitions with caching. The MCP server is the single source of
+   * truth — there is no static fallback. If discovery fails or returns nothing,
+   * this throws so the request fails clearly rather than the model answering
+   * without its data tools. Only a successful, non-empty result is cached, so a
+   * transient MCP blip is retried on the next request.
    */
   static async getToolsCached(): Promise<any[]> {
     if (BrokerClient.toolDefsCache) return BrokerClient.toolDefsCache;
-    try {
-      BrokerClient.toolDefsCache = await BrokerClient.getToolDefinitionsFromMCP();
-    } catch {
-      BrokerClient.toolDefsCache = BrokerClient.getToolDefinitions();
+    const tools = await BrokerClient.getToolDefinitionsFromMCP();
+    if (!tools.length) {
+      throw new Error(
+        "MCP server returned no tools — the assistant cannot answer without its data tools. Check that the MCP server is reachable (MCP_SERVER_URL).",
+      );
     }
-    return BrokerClient.toolDefsCache;
-  }
-
-  /**
-   * Get available tools definition for LLMs (static fallback)
-   */
-  static getToolDefinitions() {
-    return [
-      {
-        name: "get_pod_network_traffic",
-        description:
-          "Get network traffic for a specific pod by name. Returns source/destination IPs, ports, protocols, ingress/egress types, and packet decisions. Use when the user asks about a specific pod's connections. Requires only pod_name (not namespace-scoped).",
-        parameters: {
-          type: "object",
-          properties: {
-            pod_name: {
-              type: "string",
-              description: "The name of the pod to query traffic for",
-            },
-          },
-          required: ["pod_name"],
-        },
-      },
-      {
-        name: "get_pod_syscalls",
-        description:
-          "Get system calls made by a specific pod. Returns syscall names, frequencies, and architecture. Use when the user asks about a pod's syscalls or seccomp profile. Requires only pod_name (not namespace-scoped).",
-        parameters: {
-          type: "object",
-          properties: {
-            pod_name: {
-              type: "string",
-              description: "The name of the pod to query syscalls for",
-            },
-          },
-          required: ["pod_name"],
-        },
-      },
-      {
-        name: "get_pod_details",
-        description:
-          "Look up a pod by its IP address. Returns pod name, namespace, IP, and full Kubernetes pod object. Requires only ip.",
-        parameters: {
-          type: "object",
-          properties: {
-            ip: {
-              type: "string",
-              description: "The IP address of the pod to query",
-            },
-          },
-          required: ["ip"],
-        },
-      },
-      {
-        name: "get_service_details",
-        description:
-          "Look up a Kubernetes service by its cluster IP. Returns service name, namespace, IP, ports, and full service spec. Requires only ip.",
-        parameters: {
-          type: "object",
-          properties: {
-            ip: {
-              type: "string",
-              description: "The IP address of the service to query",
-            },
-          },
-          required: ["ip"],
-        },
-      },
-      {
-        name: "get_cluster_traffic",
-        description:
-          "Get a summary of network traffic across the cluster. Returns per-pod traffic counts. Accepts optional namespace to filter. Use for overall traffic patterns.",
-        parameters: {
-          type: "object",
-          properties: {
-            namespace: {
-              type: "string",
-              description: "Optional namespace to filter traffic results",
-            },
-          },
-          required: [],
-        },
-      },
-      {
-        name: "get_cluster_pods",
-        description:
-          "List pods in the cluster with compact metadata. Accepts optional namespace to filter. Use when the user asks what pods are running.",
-        parameters: {
-          type: "object",
-          properties: {
-            namespace: {
-              type: "string",
-              description: "Optional namespace to filter pod results",
-            },
-          },
-          required: [],
-        },
-      },
-    ];
+    BrokerClient.toolDefsCache = tools;
+    return tools;
   }
 
   /**
@@ -358,13 +268,14 @@ export class BrokerClient {
 
 Your role is to help users understand their cluster's network traffic, security events, and system calls.
 
-IMPORTANT: You have access to 6 tools that fetch real-time data from the cluster. ALWAYS USE THESE TOOLS when users ask questions.
+IMPORTANT: You have access to tools that fetch real-time data from the cluster. ALWAYS USE THESE TOOLS when users ask questions.
 
 ## Tool Selection Guide
 
 **Pod-Specific Tools** (require only pod_name, NOT namespace):
 - get_pod_network_traffic: Get traffic for a specific pod. Use when user asks about a pod's connections.
 - get_pod_syscalls: Get syscalls for a specific pod. Use when user asks about a pod's behavior or seccomp.
+- get_pod_details_by_name: Identify a pod from its name (namespace, IP, node, workload labels). Prefer this when the user names a pod.
 
 **Lookup Tools** (require only ip):
 - get_pod_details: Find pod info by IP address.
@@ -373,14 +284,23 @@ IMPORTANT: You have access to 6 tools that fetch real-time data from the cluster
 **Cluster-Wide Tools** (accept optional namespace filter):
 - get_cluster_traffic: Get traffic summary across pods. Returns per-pod counts, not raw records.
 - get_cluster_pods: List pods with compact metadata (name, namespace, IP, node).
+- list_services: List services with name, namespace, cluster IP, selector, and ports.
+- get_pods_on_node: List pods on a specific node (blast-radius / "what runs on node X"). Requires node.
+
+**Security / Policy Tools:**
+- get_audit_verdicts: Get network-policy evaluation verdicts (Allow / WouldDeny) for observed flows, newest first. THE tool for "what would be denied", "why is this flow blocked", "show recent policy violations", or "summarize security events". Filter by policy, namespace, verdict ('WouldDeny' for violations), direction, and limit.
+
+**Generation Tools** (synthesize ready-to-apply resources from observed runtime data):
+- generate_network_policy: Generate a least-privilege NetworkPolicy or CiliumNetworkPolicy (YAML) for a pod. Use when the user asks to generate/create a network policy or lock down a pod. Pass policy_type 'cilium' only if the user asks for Cilium. Present the YAML in a fenced \`\`\`yaml code block so the user can copy or apply it.
+- generate_seccomp_profile: Generate a least-privilege seccomp profile (JSON) for a pod. Use when the user asks to generate/create a seccomp profile. Present the JSON in a fenced \`\`\`json code block.
 
 ## Constraints
 - Pod-specific tools take only pod_name — do NOT pass namespace to them.
-- Cluster tools accept an optional "namespace" parameter to scope results.`;
+- Cluster, service, and audit tools accept an optional "namespace" parameter to scope results.`;
 
     if (context?.namespace) {
       prompt += `\n\n## Current Context
-The user is viewing namespace "${context.namespace}". ALWAYS pass namespace="${context.namespace}" to get_cluster_traffic and get_cluster_pods unless the user explicitly asks for all namespaces.`;
+The user is viewing namespace "${context.namespace}". ALWAYS pass namespace="${context.namespace}" to get_cluster_traffic, get_cluster_pods, list_services, and get_audit_verdicts unless the user explicitly asks for all namespaces.`;
     }
 
     if (context?.podNames && context.podNames.length > 0) {
@@ -396,6 +316,7 @@ The user is viewing namespace "${context.namespace}". ALWAYS pass namespace="${c
 3. Highlight security concerns or anomalies
 4. Suggest network policies or seccomp profiles when relevant
 5. For large datasets, summarize key findings first
+6. Respond with your final answer only — do not narrate your reasoning or tool-selection process
 
 When a user mentions a pod name, use the appropriate tool immediately. Do NOT ask for clarification if you have the information.`;
 

--- a/llm-bridge/src/index.stream.test.ts
+++ b/llm-bridge/src/index.stream.test.ts
@@ -1,0 +1,106 @@
+import { test, before, after, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+
+import { app } from "./index.js";
+import { BrokerClient } from "./brokerClient.js";
+
+// Integration test for the SSE /api/chat/stream route: boots the real Express
+// app, points the Anthropic SDK at a mock streaming server, and asserts the
+// wire-level SSE frames the browser would receive.
+
+function sse(event: string, data: unknown): string {
+  return `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
+}
+
+function textMessageSSE(text: string): string {
+  return (
+    sse("message_start", {
+      type: "message_start",
+      message: {
+        id: "msg_test",
+        type: "message",
+        role: "assistant",
+        model: "claude-opus-4-8",
+        content: [],
+        stop_reason: null,
+        stop_sequence: null,
+        usage: { input_tokens: 1, output_tokens: 0 },
+      },
+    }) +
+    sse("content_block_start", { type: "content_block_start", index: 0, content_block: { type: "text", text: "" } }) +
+    sse("content_block_delta", { type: "content_block_delta", index: 0, delta: { type: "text_delta", text } }) +
+    sse("content_block_stop", { type: "content_block_stop", index: 0 }) +
+    sse("message_delta", { type: "message_delta", delta: { stop_reason: "end_turn" }, usage: { output_tokens: 1 } }) +
+    sse("message_stop", { type: "message_stop" })
+  );
+}
+
+let anthropicMock: http.Server;
+let appServer: http.Server;
+let appURL = "";
+
+before(async () => {
+  anthropicMock = http.createServer((_req, res) => {
+    res.writeHead(200, { "Content-Type": "text/event-stream" });
+    res.end(textMessageSSE("hello world"));
+  });
+  await new Promise<void>((resolve) => anthropicMock.listen(0, "127.0.0.1", resolve));
+  const mockPort = (anthropicMock.address() as AddressInfo).port;
+
+  // Force a clean, anthropic-only provider environment pointed at the mock.
+  process.env.ANTHROPIC_API_KEY = "test-key";
+  process.env.ANTHROPIC_BASE_URL = `http://127.0.0.1:${mockPort}`;
+  delete process.env.OPENAI_API_KEY;
+  delete process.env.GOOGLE_API_KEY;
+  delete process.env.GITHUB_TOKEN;
+
+  (BrokerClient as unknown as { getToolsCached: () => Promise<unknown[]> }).getToolsCached =
+    async () => [
+      { name: "get_cluster_pods", description: "List pods.", parameters: { type: "object", properties: {}, required: [] } },
+    ];
+
+  appServer = app.listen(0, "127.0.0.1");
+  await new Promise<void>((resolve) => appServer.once("listening", () => resolve()));
+  appURL = `http://127.0.0.1:${(appServer.address() as AddressInfo).port}`;
+});
+
+after(async () => {
+  await new Promise<void>((resolve) => appServer.close(() => resolve()));
+  await new Promise<void>((resolve) => anthropicMock.close(() => resolve()));
+});
+
+beforeEach(() => {
+  // Re-assert (other test files in the same process may have mutated these).
+  process.env.ANTHROPIC_API_KEY = "test-key";
+});
+
+test("POST /api/chat/stream emits SSE text + done frames", async () => {
+  const res = await fetch(`${appURL}/api/chat/stream`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ message: "hi", provider: "anthropic" }),
+  });
+
+  assert.equal(res.status, 200);
+  assert.match(res.headers.get("content-type") || "", /text\/event-stream/);
+
+  const body = await res.text();
+  // Wire format: a text event carrying the delta, and a terminal done event.
+  assert.match(body, /event: text\ndata: \{"type":"text","delta":"hello world"\}/);
+  assert.match(body, /event: done\ndata: \{"type":"done","model":"claude-opus-4-8"/);
+});
+
+test("POST /api/chat/stream rejects an invalid body with JSON 400 (pre-stream)", async () => {
+  const res = await fetch(`${appURL}/api/chat/stream`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ provider: "anthropic" }), // missing required `message`
+  });
+
+  assert.equal(res.status, 400);
+  assert.match(res.headers.get("content-type") || "", /application\/json/);
+  const body = await res.json();
+  assert.equal(body.error, "Invalid request format");
+});

--- a/llm-bridge/src/index.ts
+++ b/llm-bridge/src/index.ts
@@ -9,14 +9,17 @@ import { ChatRequestSchema, LLMProvider, type ErrorResponse } from "./types/inde
 import { BrokerClient } from "./brokerClient.js";
 import { log } from "./logger.js";
 import { callOpenAI } from "./providers/openai.js";
-import { callAnthropic } from "./providers/anthropic.js";
+import { callAnthropic, streamAnthropic, type StreamEvent } from "./providers/anthropic.js";
 import { callGemini } from "./providers/gemini.js";
 import { callCopilot } from "./providers/copilot.js";
+import type { ChatRequest, ChatResponse } from "./types/index.js";
 
 // Load environment variables
 dotenv.config();
 
-const app = express();
+// Exported for integration tests (the main-module guard prevents the server
+// from auto-starting on import).
+export const app = express();
 // Trim env reads so a pasted "8080\n" or "  8080" doesn't propagate
 // downstream. Node's listen() is lenient about whitespace via
 // parseInt, but `cors({ origin })` compares the env value to the
@@ -66,6 +69,57 @@ function getAvailableProviders(): LLMProvider[] {
   return availableProvidersFromEnv(process.env);
 }
 
+// Provider resolution shared by the JSON and SSE chat routes. Returns either
+// the resolved provider or a ready-to-send error (status + body) so both
+// routes apply identical "no provider" / "provider not configured" handling.
+type ProviderResolution =
+  | { ok: true; provider: LLMProvider }
+  | { ok: false; status: number; body: ErrorResponse };
+
+function resolveProvider(chatRequest: ChatRequest): ProviderResolution {
+  const availableProviders = getAvailableProviders();
+  if (availableProviders.length === 0) {
+    return {
+      ok: false,
+      status: 503,
+      body: {
+        error: "No LLM provider configured",
+        details:
+          "Please configure at least one API key: OPENAI_API_KEY, ANTHROPIC_API_KEY, GOOGLE_API_KEY, or GITHUB_TOKEN",
+      },
+    };
+  }
+  const provider = chatRequest.provider || availableProviders[0];
+  if (!availableProviders.includes(provider)) {
+    return {
+      ok: false,
+      status: 400,
+      body: {
+        error: `Provider ${provider} not configured`,
+        details: `Available providers: ${availableProviders.join(", ")}`,
+      },
+    };
+  }
+  return { ok: true, provider };
+}
+
+// Non-streaming dispatch to a provider. Used by the JSON route directly and by
+// the SSE route for providers that don't have a native streaming path yet.
+function callProvider(provider: LLMProvider, chatRequest: ChatRequest): Promise<ChatResponse> {
+  switch (provider) {
+    case LLMProvider.OPENAI:
+      return callOpenAI(chatRequest, brokerClient);
+    case LLMProvider.ANTHROPIC:
+      return callAnthropic(chatRequest, brokerClient);
+    case LLMProvider.GEMINI:
+      return callGemini(chatRequest, brokerClient);
+    case LLMProvider.COPILOT:
+      return callCopilot(chatRequest, brokerClient);
+    default:
+      return Promise.reject(new Error(`Unknown provider: ${provider}`));
+  }
+}
+
 // Health check endpoint
 app.get("/health", (req: Request, res: Response) => {
   const availableProviders = getAvailableProviders();
@@ -89,51 +143,18 @@ app.post("/api/chat", chatLimiter, async (req: Request, res: Response<any>) => {
     const chatRequest = ChatRequestSchema.parse(req.body);
 
     // Determine provider to use
-    const availableProviders = getAvailableProviders();
-
-    if (availableProviders.length === 0) {
-      return res.status(503).json({
-        error: "No LLM provider configured",
-        details: "Please configure at least one API key: OPENAI_API_KEY, ANTHROPIC_API_KEY, GOOGLE_API_KEY, or GITHUB_TOKEN",
-      } as ErrorResponse);
+    const resolution = resolveProvider(chatRequest);
+    if (!resolution.ok) {
+      return res.status(resolution.status).json(resolution.body);
     }
-
-    const provider = chatRequest.provider || availableProviders[0];
-
-    // Verify the requested provider is available
-    if (!availableProviders.includes(provider)) {
-      return res.status(400).json({
-        error: `Provider ${provider} not configured`,
-        details: `Available providers: ${availableProviders.join(", ")}`,
-      } as ErrorResponse);
-    }
+    const provider = resolution.provider;
 
     // Debug not info — this fires per chat request; a chat session
     // can produce dozens. The provider routing is part of normal
     // operation, not a per-request operator alert.
     log.debug(`Processing chat request with provider: ${provider}`);
 
-    // Route to appropriate provider
-    let response;
-    switch (provider) {
-      case LLMProvider.OPENAI:
-        response = await callOpenAI(chatRequest, brokerClient);
-        break;
-      case LLMProvider.ANTHROPIC:
-        response = await callAnthropic(chatRequest, brokerClient);
-        break;
-      case LLMProvider.GEMINI:
-        response = await callGemini(chatRequest, brokerClient);
-        break;
-      case LLMProvider.COPILOT:
-        response = await callCopilot(chatRequest, brokerClient);
-        break;
-      default:
-        return res.status(400).json({
-          error: `Unknown provider: ${provider}`,
-        } as ErrorResponse);
-    }
-
+    const response = await callProvider(provider, chatRequest);
     res.json(response);
   } catch (error) {
     log.error("Error processing chat request:", error);
@@ -155,6 +176,77 @@ app.post("/api/chat", chatLimiter, async (req: Request, res: Response<any>) => {
     res.status(500).json({
       error: "An unexpected error occurred",
     } as ErrorResponse);
+  }
+});
+
+// Streaming chat endpoint (Server-Sent Events). Emits incremental `text`,
+// summarized `thinking`, and `tool_use`/`tool_result` activity events, then a
+// terminal `done` (or `error`). Anthropic streams natively; other providers
+// run non-streaming and arrive as a single `text` chunk, so the frontend can
+// use one consistent stream transport for every provider.
+app.post("/api/chat/stream", chatLimiter, async (req: Request, res: Response) => {
+  let chatRequest: ChatRequest;
+  let provider: LLMProvider;
+
+  // Pre-stream validation + provider resolution still use JSON errors, since
+  // the SSE headers have not been written yet.
+  try {
+    chatRequest = ChatRequestSchema.parse(req.body);
+    const resolution = resolveProvider(chatRequest);
+    if (!resolution.ok) {
+      return res.status(resolution.status).json(resolution.body);
+    }
+    provider = resolution.provider;
+  } catch (error) {
+    if (error instanceof ZodError) {
+      return res.status(400).json({
+        error: "Invalid request format",
+        details: error.issues.map((e: any) => e.message).join(", "),
+      } as ErrorResponse);
+    }
+    log.error("Error validating stream request:", error);
+    return res.status(500).json({ error: "An unexpected error occurred" } as ErrorResponse);
+  }
+
+  // Open the SSE stream.
+  res.writeHead(200, {
+    "Content-Type": "text/event-stream",
+    "Cache-Control": "no-cache, no-transform",
+    Connection: "keep-alive",
+    // Disable proxy buffering (nginx) so events flush to the client live.
+    "X-Accel-Buffering": "no",
+  });
+
+  const emit = (event: StreamEvent): void => {
+    res.write(`event: ${event.type}\ndata: ${JSON.stringify(event)}\n\n`);
+  };
+
+  // Abort the in-flight model stream if the client disconnects.
+  const abort = new AbortController();
+  res.on("close", () => abort.abort());
+
+  log.debug(`Processing streaming chat request with provider: ${provider}`);
+
+  try {
+    if (provider === LLMProvider.ANTHROPIC) {
+      await streamAnthropic(chatRequest, brokerClient, emit, abort.signal);
+    } else {
+      // Providers without a native streaming path: run to completion and emit
+      // the answer as a single text chunk plus the terminal done event.
+      const response = await callProvider(provider, chatRequest);
+      emit({ type: "text", delta: response.message });
+      emit({ type: "done", model: response.model, conversationId: response.conversationId });
+    }
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : "An internal error occurred";
+    log.error("Streaming chat error:", detail);
+    // Headers are already sent, so surface the failure over SSE rather than
+    // as an HTTP status. Guard the write in case the client already closed.
+    if (!res.writableEnded) {
+      emit({ type: "error", error: detail });
+    }
+  } finally {
+    res.end();
   }
 });
 

--- a/llm-bridge/src/providers/anthropic.stream.test.ts
+++ b/llm-bridge/src/providers/anthropic.stream.test.ts
@@ -1,0 +1,156 @@
+import { test, before, after, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+
+import { streamAnthropic, type StreamEvent } from "./anthropic.js";
+import { BrokerClient } from "../brokerClient.js";
+import type { ChatRequest } from "../types/index.js";
+
+// Mock of the Anthropic Messages API streaming endpoint. Each request is
+// answered with a queued Server-Sent-Events body that the real SDK parses, so
+// this exercises the actual streaming client end to end without network egress.
+
+type Block =
+  | { kind: "text"; text: string }
+  | { kind: "thinking"; thinking: string }
+  | { kind: "tool_use"; id: string; name: string };
+
+function sse(event: string, data: unknown): string {
+  return `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
+}
+
+function sseForMessage(blocks: Block[], stopReason: string, model = "claude-opus-4-8"): string {
+  let out = sse("message_start", {
+    type: "message_start",
+    message: {
+      id: "msg_test",
+      type: "message",
+      role: "assistant",
+      model,
+      content: [],
+      stop_reason: null,
+      stop_sequence: null,
+      usage: { input_tokens: 1, output_tokens: 0 },
+    },
+  });
+
+  blocks.forEach((block, index) => {
+    if (block.kind === "text") {
+      out += sse("content_block_start", { type: "content_block_start", index, content_block: { type: "text", text: "" } });
+      out += sse("content_block_delta", { type: "content_block_delta", index, delta: { type: "text_delta", text: block.text } });
+    } else if (block.kind === "thinking") {
+      out += sse("content_block_start", { type: "content_block_start", index, content_block: { type: "thinking", thinking: "" } });
+      out += sse("content_block_delta", { type: "content_block_delta", index, delta: { type: "thinking_delta", thinking: block.thinking } });
+    } else {
+      out += sse("content_block_start", {
+        type: "content_block_start",
+        index,
+        content_block: { type: "tool_use", id: block.id, name: block.name, input: {} },
+      });
+    }
+    out += sse("content_block_stop", { type: "content_block_stop", index });
+  });
+
+  out += sse("message_delta", { type: "message_delta", delta: { stop_reason: stopReason }, usage: { output_tokens: 1 } });
+  out += sse("message_stop", { type: "message_stop" });
+  return out;
+}
+
+let server: http.Server;
+let responseQueue: string[] = [];
+
+before(async () => {
+  server = http.createServer((req, res) => {
+    let raw = "";
+    req.on("data", (c) => (raw += c));
+    req.on("end", () => {
+      const body = responseQueue.shift() ?? sseForMessage([{ kind: "text", text: "default" }], "end_turn");
+      res.writeHead(200, { "Content-Type": "text/event-stream" });
+      res.end(body);
+    });
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const { port } = server.address() as AddressInfo;
+
+  process.env.ANTHROPIC_API_KEY = "test-key";
+  process.env.ANTHROPIC_BASE_URL = `http://127.0.0.1:${port}`;
+  (BrokerClient as unknown as { getToolsCached: () => Promise<unknown[]> }).getToolsCached =
+    async () => [
+      { name: "get_cluster_pods", description: "List pods.", parameters: { type: "object", properties: {}, required: [] } },
+    ];
+});
+
+after(async () => {
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+});
+
+beforeEach(() => {
+  responseQueue = [];
+});
+
+function stubBroker(calls: string[]): BrokerClient {
+  return {
+    executeTool: async (toolCall: { name: string }) => {
+      calls.push(toolCall.name);
+      return { data: { ok: true } };
+    },
+  } as unknown as BrokerClient;
+}
+
+const baseRequest: ChatRequest = { message: "hello" } as ChatRequest;
+
+async function collect(req: ChatRequest, broker: BrokerClient): Promise<StreamEvent[]> {
+  const events: StreamEvent[] = [];
+  await streamAnthropic(req, broker, (e) => events.push(e));
+  return events;
+}
+
+test("streams text deltas then a terminal done event", async () => {
+  responseQueue.push(sseForMessage([{ kind: "text", text: "hello world" }], "end_turn"));
+
+  const events = await collect({ ...baseRequest }, stubBroker([]));
+
+  const text = events.filter((e) => e.type === "text").map((e) => (e as { delta: string }).delta).join("");
+  assert.equal(text, "hello world");
+  const done = events.at(-1);
+  assert.equal(done?.type, "done");
+  assert.equal((done as { model: string }).model, "claude-opus-4-8");
+});
+
+test("emits summarized thinking deltas before the answer", async () => {
+  responseQueue.push(
+    sseForMessage([{ kind: "thinking", thinking: "pondering" }, { kind: "text", text: "ok" }], "end_turn"),
+  );
+
+  const events = await collect({ ...baseRequest }, stubBroker([]));
+
+  const thinking = events.find((e) => e.type === "thinking");
+  assert.equal((thinking as { delta: string }).delta, "pondering");
+  const text = events.find((e) => e.type === "text");
+  assert.equal((text as { delta: string }).delta, "ok");
+});
+
+test("tool round emits tool_use + tool_result activity, then streams the answer", async () => {
+  responseQueue.push(sseForMessage([{ kind: "tool_use", id: "tu_1", name: "get_cluster_pods" }], "tool_use"));
+  responseQueue.push(sseForMessage([{ kind: "text", text: "done" }], "end_turn"));
+
+  const calls: string[] = [];
+  const events = await collect({ ...baseRequest }, stubBroker(calls));
+
+  assert.deepEqual(calls, ["get_cluster_pods"], "tool executed once");
+
+  const toolUse = events.find((e) => e.type === "tool_use");
+  assert.equal((toolUse as { name: string }).name, "get_cluster_pods");
+  assert.equal((toolUse as { id: string }).id, "tu_1");
+
+  const toolResult = events.find((e) => e.type === "tool_result");
+  assert.equal((toolResult as { ok: boolean }).ok, true);
+
+  // Activity events precede the final answer text.
+  const toolUseIdx = events.findIndex((e) => e.type === "tool_use");
+  const textIdx = events.findIndex((e) => e.type === "text");
+  assert.ok(toolUseIdx < textIdx, "tool_use is emitted before answer text");
+
+  assert.equal(events.at(-1)?.type, "done");
+});

--- a/llm-bridge/src/providers/anthropic.test.ts
+++ b/llm-bridge/src/providers/anthropic.test.ts
@@ -1,0 +1,158 @@
+import { test, before, after, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+
+import { callAnthropic } from "./anthropic.js";
+import { BrokerClient } from "../brokerClient.js";
+import type { ChatRequest } from "../types/index.js";
+
+// A scripted mock of the Anthropic Messages API. Each request pops the next
+// queued response; request bodies are captured for assertions. The official
+// SDK is pointed here via ANTHROPIC_BASE_URL, so this exercises the real
+// client (serialization, headers, error mapping) without any network egress.
+
+interface MockResponse {
+  status: number;
+  body: unknown;
+}
+
+let server: http.Server;
+let baseURL = "";
+let responseQueue: MockResponse[] = [];
+let capturedRequests: any[] = [];
+
+function message(content: unknown[], stopReason: string): MockResponse {
+  return {
+    status: 200,
+    body: {
+      id: "msg_test",
+      type: "message",
+      role: "assistant",
+      model: "claude-opus-4-8",
+      content,
+      stop_reason: stopReason,
+      stop_sequence: null,
+      usage: { input_tokens: 1, output_tokens: 1 },
+    },
+  };
+}
+
+before(async () => {
+  server = http.createServer((req, res) => {
+    let raw = "";
+    req.on("data", (c) => (raw += c));
+    req.on("end", () => {
+      capturedRequests.push(raw ? JSON.parse(raw) : null);
+      const next = responseQueue.shift() ?? message([{ type: "text", text: "default" }], "end_turn");
+      res.writeHead(next.status, { "Content-Type": "application/json" });
+      res.end(JSON.stringify(next.body));
+    });
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const { port } = server.address() as AddressInfo;
+  baseURL = `http://127.0.0.1:${port}`;
+
+  // Isolate from the real Anthropic API and the MCP server.
+  process.env.ANTHROPIC_API_KEY = "test-key";
+  process.env.ANTHROPIC_BASE_URL = baseURL;
+  // Stub the MCP-backed tool discovery so the loop has a deterministic,
+  // network-free tool set.
+  (BrokerClient as unknown as { getToolsCached: () => Promise<unknown[]> }).getToolsCached =
+    async () => [
+      {
+        name: "get_cluster_pods",
+        description: "List pods.",
+        parameters: { type: "object", properties: {}, required: [] },
+      },
+    ];
+});
+
+after(async () => {
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+});
+
+beforeEach(() => {
+  responseQueue = [];
+  capturedRequests = [];
+});
+
+function stubBroker(calls: string[]): BrokerClient {
+  return {
+    executeTool: async (toolCall: { name: string }) => {
+      calls.push(toolCall.name);
+      return { data: { ok: true, tool: toolCall.name } };
+    },
+  } as unknown as BrokerClient;
+}
+
+const baseRequest: ChatRequest = { message: "hello", provider: undefined } as ChatRequest;
+
+test("plain text response: returns text, model, provider, and sends cached system + tools", async () => {
+  responseQueue.push(message([{ type: "text", text: "hello world" }], "end_turn"));
+
+  const res = await callAnthropic({ ...baseRequest }, stubBroker([]));
+
+  assert.equal(res.message, "hello world");
+  assert.equal(res.provider, "anthropic");
+  assert.equal(res.model, "claude-opus-4-8");
+
+  const sent = capturedRequests[0];
+  assert.equal(sent.model, "claude-opus-4-8", "uses the Opus 4.8 default model");
+  // Prompt caching: system is a block array with a cache_control breakpoint.
+  assert.ok(Array.isArray(sent.system), "system is a content-block array");
+  assert.deepEqual(sent.system[0].cache_control, { type: "ephemeral" });
+  assert.ok(Array.isArray(sent.tools) && sent.tools.length > 0, "tools are sent");
+});
+
+test("tool loop: executes tool, feeds result back, returns final text", async () => {
+  responseQueue.push(
+    message([{ type: "tool_use", id: "tu_1", name: "get_cluster_pods", input: {} }], "tool_use"),
+  );
+  responseQueue.push(message([{ type: "text", text: "done" }], "end_turn"));
+
+  const calls: string[] = [];
+  const res = await callAnthropic({ ...baseRequest }, stubBroker(calls));
+
+  assert.equal(res.message, "done");
+  assert.deepEqual(calls, ["get_cluster_pods"], "tool executed exactly once");
+
+  // Second request must carry the tool_result keyed to the tool_use id.
+  const secondBody = capturedRequests[1];
+  const lastMsg = secondBody.messages[secondBody.messages.length - 1];
+  assert.equal(lastMsg.role, "user");
+  assert.equal(lastMsg.content[0].type, "tool_result");
+  assert.equal(lastMsg.content[0].tool_use_id, "tu_1");
+});
+
+test("refusal stop_reason yields a clean message instead of empty output", async () => {
+  responseQueue.push(message([], "refusal"));
+
+  const res = await callAnthropic({ ...baseRequest }, stubBroker([]));
+  assert.equal(res.message, "I can't help with that request.");
+});
+
+test("API error is normalised into a thrown Error", async () => {
+  responseQueue.push({
+    status: 400,
+    body: { type: "error", error: { type: "invalid_request_error", message: "bad input" } },
+  });
+
+  await assert.rejects(
+    () => callAnthropic({ ...baseRequest }, stubBroker([])),
+    /Anthropic API error:/,
+  );
+});
+
+test("missing API key fails fast with a clear message", async () => {
+  const saved = process.env.ANTHROPIC_API_KEY;
+  delete process.env.ANTHROPIC_API_KEY;
+  try {
+    await assert.rejects(
+      () => callAnthropic({ ...baseRequest }, stubBroker([])),
+      /ANTHROPIC_API_KEY not configured/,
+    );
+  } finally {
+    process.env.ANTHROPIC_API_KEY = saved;
+  }
+});

--- a/llm-bridge/src/providers/anthropic.ts
+++ b/llm-bridge/src/providers/anthropic.ts
@@ -1,140 +1,296 @@
-import axios from "axios";
+import Anthropic from "@anthropic-ai/sdk";
 import type { ChatRequest, ChatResponse } from "../types/index.js";
 import { LLMProvider } from "../types/index.js";
 import { BrokerClient } from "../brokerClient.js";
 import { log } from "../logger.js";
 import { serializeToolResult } from "./truncate.js";
 
-interface AnthropicTool {
-  name: string;
-  description: string;
-  input_schema: any;
-}
-
+// Upper bound on tool-calling round-trips before we force a final answer.
 const MAX_TOOL_ROUNDS = 10;
 
-export async function callAnthropic(
-  request: ChatRequest,
-  brokerClient: BrokerClient
-): Promise<ChatResponse> {
-  // Trim before the empty-check so an operator-set "  " (whitespace
-  // intended to disable the provider) doesn't slip through. Pre-fix
-  // a whitespace-only key passed `if (!apiKey)` and was sent verbatim
-  // to api.anthropic.com, producing a 401 deep in the call chain
-  // rather than a clear "not configured" message at request entry.
+// Default model. Bare alias (no date suffix) so it always resolves to the
+// current Opus 4.8 snapshot. Callers may override via request.model.
+const DEFAULT_MODEL = "claude-opus-4-8";
+
+// Output cap for the non-streaming path. 8K leaves room for tables and policy
+// snippets without risking the SDK's non-streaming timeout guard.
+const MAX_TOKENS = 8192;
+
+// Output cap for the streaming path. Streaming removes the HTTP-timeout
+// concern, so we give adaptive thinking + answer generous headroom.
+const STREAM_MAX_TOKENS = 16000;
+
+// ---------------------------------------------------------------------------
+// Streaming event contract (provider -> transport). Kept transport-agnostic so
+// the HTTP layer decides how to serialise (SSE) and the provider stays testable.
+// ---------------------------------------------------------------------------
+export type StreamEvent =
+  | { type: "text"; delta: string }
+  | { type: "thinking"; delta: string }
+  | { type: "tool_use"; name: string; id: string }
+  | { type: "tool_result"; name: string; ok: boolean }
+  | { type: "done"; model: string; conversationId?: string }
+  | { type: "error"; error: string };
+
+export type Emit = (event: StreamEvent) => void;
+
+// ---------------------------------------------------------------------------
+// Shared setup helpers (used by both the streaming and non-streaming entry
+// points so the model, prompt-caching, tool, and message wiring stay identical).
+// ---------------------------------------------------------------------------
+
+function requireApiKey(): string {
+  // Trim before the empty-check so an operator-set "  " (whitespace intended
+  // to disable the provider) is treated as unset rather than sent verbatim
+  // and surfacing as a 401 deep in the call chain.
   const apiKey = process.env.ANTHROPIC_API_KEY?.trim();
   if (!apiKey) {
     throw new Error("ANTHROPIC_API_KEY not configured");
   }
+  return apiKey;
+}
 
-  const model = request.model || "claude-sonnet-4-5-20250929";
+/**
+ * System prompt as a single cacheable block. Render order is
+ * tools -> system -> messages, so a cache_control breakpoint on the system
+ * block caches the tool definitions AND the system prompt together. That
+ * prefix is identical on every round of the tool loop (and across requests
+ * sharing the same context within the cache TTL), so rounds 2..N read it from
+ * cache instead of reprocessing it.
+ */
+function buildSystem(request: ChatRequest): Anthropic.TextBlockParam[] {
   const context = BrokerClient.parseContext(request.context);
   const systemPrompt = BrokerClient.getSystemPrompt(context);
+  return [{ type: "text", text: systemPrompt, cache_control: { type: "ephemeral" } }];
+}
 
-  // Build tools from cached MCP definitions
+async function buildTools(): Promise<Anthropic.Tool[]> {
   const toolDefs = await BrokerClient.getToolsCached();
-  const tools: AnthropicTool[] = toolDefs.map((tool) => ({
+  return toolDefs.map((tool) => ({
     name: tool.name,
     description: tool.description,
-    input_schema: tool.parameters,
+    input_schema: tool.parameters as Anthropic.Tool.InputSchema,
   }));
+}
 
-  // Build messages with history
-  const messages: any[] = [];
-
-  // Add conversation history if provided
+function buildMessages(request: ChatRequest): Anthropic.MessageParam[] {
+  // Seed with prior history (system turns are folded into the top-level system
+  // prompt, so they are filtered out here) plus the new user message.
+  const messages: Anthropic.MessageParam[] = [];
   if (request.history && request.history.length > 0) {
-    messages.push(...request.history.filter(msg => msg.role !== 'system').map(msg => ({
-      role: msg.role,
-      content: msg.content,
-    })));
+    for (const msg of request.history) {
+      if (msg.role === "system") continue;
+      messages.push({ role: msg.role, content: msg.content });
+    }
+  }
+  messages.push({ role: "user", content: request.message });
+  return messages;
+}
+
+function toolUsesOf(message: Anthropic.Message): Anthropic.ToolUseBlock[] {
+  return message.content.filter(
+    (block): block is Anthropic.ToolUseBlock => block.type === "tool_use",
+  );
+}
+
+/**
+ * Execute the model's tool calls via the broker/MCP client and build the
+ * tool_result blocks to feed back. Pushes the assistant turn (verbatim, so
+ * tool_use and thinking blocks are echoed as the API requires) onto messages.
+ * When `emit` is supplied, surfaces tool_use/tool_result activity events.
+ */
+async function runToolRound(
+  message: Anthropic.Message,
+  toolUses: Anthropic.ToolUseBlock[],
+  brokerClient: BrokerClient,
+  messages: Anthropic.MessageParam[],
+  emit?: Emit,
+): Promise<void> {
+  messages.push({ role: "assistant", content: message.content });
+
+  if (emit) {
+    for (const toolUse of toolUses) {
+      emit({ type: "tool_use", name: toolUse.name, id: toolUse.id });
+    }
   }
 
-  // Add current user message
-  messages.push({
-    role: "user",
-    content: request.message,
-  });
-
-  const headers = {
-    "x-api-key": apiKey,
-    "anthropic-version": "2023-06-01",
-    "Content-Type": "application/json",
-  };
-
-  // Multi-round tool calling loop
-  for (let round = 0; round < MAX_TOOL_ROUNDS; round++) {
-    let response;
-    try {
-      response = await axios.post(
-        "https://api.anthropic.com/v1/messages",
-        { model, max_tokens: 4096, system: systemPrompt, messages, tools },
-        { headers, timeout: 120000 }
-      );
-    } catch (error: any) {
-      log.error("Anthropic API Error:", error.response?.data?.error?.message || error.message);
-      throw new Error(`Anthropic API error: ${error.response?.data?.error?.message || error.message}`, { cause: error });
-    }
-
-    const content = response.data.content;
-
-    // Check if there are tool uses
-    const toolUses = content.filter((block: any) => block.type === "tool_use");
-
-    if (toolUses.length === 0) {
-      // No tool calls — return text response
-      const textContent = content.find((block: any) => block.type === "text");
+  const toolResults: Anthropic.ToolResultBlockParam[] = await Promise.all(
+    toolUses.map(async (toolUse) => {
+      const result = await brokerClient.executeTool({
+        name: toolUse.name,
+        arguments: toolUse.input as Record<string, unknown>,
+      });
+      if (emit) {
+        emit({ type: "tool_result", name: toolUse.name, ok: !result.error });
+      }
       return {
-        message: textContent?.text || "No response from Claude",
-        provider: LLMProvider.ANTHROPIC,
-        model: response.data.model,
-        conversationId: request.conversationId,
+        type: "tool_result" as const,
+        tool_use_id: toolUse.id,
+        content: serializeToolResult(result),
       };
+    }),
+  );
+
+  messages.push({ role: "user", content: toolResults });
+}
+
+// ---------------------------------------------------------------------------
+// Non-streaming entry point (used by the JSON /api/chat endpoint).
+// ---------------------------------------------------------------------------
+
+/**
+ * Drive a chat turn against Claude via the official Anthropic SDK, executing
+ * MCP tools in a manual agentic loop. The loop is retained (rather than the
+ * SDK tool runner) because tool execution is routed through the broker/MCP
+ * client and results are truncated before being fed back to the model.
+ */
+export async function callAnthropic(
+  request: ChatRequest,
+  brokerClient: BrokerClient,
+): Promise<ChatResponse> {
+  const apiKey = requireApiKey();
+  // The SDK reads ANTHROPIC_BASE_URL from the environment when baseURL is not
+  // passed, and handles retries (429/5xx/network) and timeout scaling.
+  const client = new Anthropic({ apiKey });
+
+  const model = request.model || DEFAULT_MODEL;
+  const system = buildSystem(request);
+  const tools = await buildTools();
+  const messages = buildMessages(request);
+
+  for (let round = 0; round < MAX_TOOL_ROUNDS; round++) {
+    let message: Anthropic.Message;
+    try {
+      message = await client.messages.create({ model, max_tokens: MAX_TOKENS, system, messages, tools });
+    } catch (error) {
+      throw toCleanError(error);
     }
 
-    // Append assistant message with full content (text + tool_use blocks)
-    messages.push({
-      role: "assistant",
-      content: content,
-    });
+    const toolUses = toolUsesOf(message);
+    if (toolUses.length === 0) {
+      return finalize(message, request);
+    }
+    await runToolRound(message, toolUses, brokerClient, messages);
+  }
 
-    // Execute tool calls and build tool results
-    const toolResults = await Promise.all(
-      toolUses.map(async (toolUse: any) => {
-        const result = await brokerClient.executeTool({
-          name: toolUse.name,
-          arguments: toolUse.input,
-        });
-        return {
-          type: "tool_result",
-          tool_use_id: toolUse.id,
-          content: serializeToolResult(result),
-        };
-      })
+  // Max rounds reached — one final call without tools to force a textual
+  // answer (the system+messages cache prefix still applies).
+  let finalMessage: Anthropic.Message;
+  try {
+    finalMessage = await client.messages.create({ model, max_tokens: MAX_TOKENS, system, messages });
+  } catch (error) {
+    throw toCleanError(error);
+  }
+  return finalize(finalMessage, request);
+}
+
+// ---------------------------------------------------------------------------
+// Streaming entry point (used by the SSE /api/chat/stream endpoint).
+// ---------------------------------------------------------------------------
+
+/**
+ * Stream a chat turn, emitting incremental text, summarized thinking, and
+ * tool-activity events. Adaptive thinking is enabled (display: "summarized")
+ * because streaming surfaces the think-time as live progress rather than a
+ * silent pause. `signal` aborts the in-flight model stream on client disconnect.
+ */
+export async function streamAnthropic(
+  request: ChatRequest,
+  brokerClient: BrokerClient,
+  emit: Emit,
+  signal?: AbortSignal,
+): Promise<void> {
+  const apiKey = requireApiKey();
+  const client = new Anthropic({ apiKey });
+
+  const model = request.model || DEFAULT_MODEL;
+  const system = buildSystem(request);
+  const tools = await buildTools();
+  const messages = buildMessages(request);
+
+  const runStream = async (withTools: boolean): Promise<Anthropic.Message> => {
+    const stream = client.messages.stream(
+      {
+        model,
+        max_tokens: STREAM_MAX_TOKENS,
+        system,
+        messages,
+        thinking: { type: "adaptive", display: "summarized" },
+        ...(withTools ? { tools } : {}),
+      },
+      { signal },
     );
 
-    // Append tool results as a user message
-    messages.push({
-      role: "user",
-      content: toolResults,
-    });
+    for await (const event of stream) {
+      if (event.type !== "content_block_delta") continue;
+      if (event.delta.type === "text_delta") {
+        emit({ type: "text", delta: event.delta.text });
+      } else if (event.delta.type === "thinking_delta") {
+        emit({ type: "thinking", delta: event.delta.thinking });
+      }
+    }
+    return stream.finalMessage();
+  };
+
+  for (let round = 0; round < MAX_TOOL_ROUNDS; round++) {
+    let message: Anthropic.Message;
+    try {
+      message = await runStream(true);
+    } catch (error) {
+      throw toCleanError(error);
+    }
+
+    const toolUses = toolUsesOf(message);
+    if (toolUses.length === 0) {
+      emit({ type: "done", model: message.model, conversationId: request.conversationId });
+      return;
+    }
+    await runToolRound(message, toolUses, brokerClient, messages, emit);
   }
 
-  // Max rounds reached — request a final response without tools
-  const finalResponse = await axios.post(
-    "https://api.anthropic.com/v1/messages",
-    { model, max_tokens: 4096, system: systemPrompt, messages },
-    { headers, timeout: 120000 }
-  );
+  // Max rounds reached — final pass without tools.
+  let finalMessage: Anthropic.Message;
+  try {
+    finalMessage = await runStream(false);
+  } catch (error) {
+    throw toCleanError(error);
+  }
+  emit({ type: "done", model: finalMessage.model, conversationId: request.conversationId });
+}
 
-  const finalContent = finalResponse.data.content.find(
-    (block: any) => block.type === "text"
-  );
+// ---------------------------------------------------------------------------
+// Result + error helpers.
+// ---------------------------------------------------------------------------
+
+/** Extract the text answer from a completed message into the wire contract. */
+function finalize(message: Anthropic.Message, request: ChatRequest): ChatResponse {
+  const text = message.content
+    .filter((block): block is Anthropic.TextBlock => block.type === "text")
+    .map((block) => block.text)
+    .join("\n")
+    .trim();
+
+  const fallback =
+    message.stop_reason === "refusal"
+      ? "I can't help with that request."
+      : "No response from Claude";
 
   return {
-    message: finalContent?.text || "No response from Claude",
+    message: text || fallback,
     provider: LLMProvider.ANTHROPIC,
-    model: finalResponse.data.model,
+    model: message.model,
     conversationId: request.conversationId,
   };
+}
+
+/** Normalise SDK/transport errors into a single Error with a clean message. */
+function toCleanError(error: unknown): Error {
+  if (error instanceof Anthropic.APIError) {
+    const detail = error.message || `status ${error.status}`;
+    log.error("Anthropic API Error:", detail);
+    return new Error(`Anthropic API error: ${detail}`, { cause: error });
+  }
+  const detail = error instanceof Error ? error.message : String(error);
+  log.error("Anthropic request failed:", detail);
+  return new Error(`Anthropic request failed: ${detail}`, { cause: error });
 }

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -27,7 +27,7 @@ This MCP server exposes kguardian's broker API as MCP tools, allowing LLMs to qu
 
 ## Available Tools
 
-The kguardian MCP server provides 6 comprehensive tools for querying Kubernetes security and network telemetry:
+The kguardian MCP server provides tools for querying Kubernetes security and network telemetry:
 
 ### `get_pod_network_traffic`
 Get network traffic data for a specific pod.
@@ -136,6 +136,68 @@ List pods in the cluster with compact metadata. Returns ALIVE pods only by defau
 - Identify monitored workloads
 - Bulk pod analysis
 - Generate reports
+
+### `get_pod_details_by_name`
+Look up a single pod by its name (the broker resolves the name cluster-wide). Returns the same compacted identity shape as `get_pod_details`, with `pod_obj` stripped. Prefer this over `get_pod_details` when you have a pod name rather than an IP.
+
+**Parameters:**
+- `pod_name` (string, required): The name of the pod to look up.
+
+**Returns:** A compacted pod record (`pod_name`, `pod_namespace`, `pod_ip`, `node_name`, `is_dead`, `pod_identity`, `workload_selector_labels`).
+
+**Use Cases:**
+- Resolve a pod name seen in a traffic record to its namespace/IP/node
+- Find the workload selector labels for NetworkPolicy construction
+
+### `list_services`
+List Kubernetes services across the cluster with compact metadata. Returns the same shape as `get_service_details` (full `service_spec` stripped; `selector` and `ports` lifted), for every service rather than a single known IP.
+
+**Parameters:**
+- `namespace` (string, optional): Restrict the list to a single namespace. Omit to list services across all namespaces.
+
+**Returns:** JSON array of compacted service records, each with `svc_name`, `svc_namespace`, `svc_ip`, `service_selector`, `service_ports`.
+
+**Use Cases:**
+- Service inventory and discovery
+- Map cluster IPs to services when interpreting egress traffic
+
+### `get_audit_verdicts`
+Get network-policy evaluation verdicts produced by the audit pipeline — observed flows scored as `Allow` or `WouldDeny` against `AuditNetworkPolicy` / `AuditClusterNetworkPolicy` resources. Rows are returned newest-first. This is the primary tool for security questions about what traffic a policy would block.
+
+**Parameters (all optional):**
+- `policy` (string): Filter to a single policy by name. Pair with `namespace` for an `AuditNetworkPolicy`; leave `namespace` empty for an `AuditClusterNetworkPolicy`.
+- `namespace` (string): Filter by policy namespace.
+- `verdict` (string): `Allow` or `WouldDeny`. Use `WouldDeny` to surface flows that would be blocked if the policy were enforced.
+- `direction` (string): `Ingress` or `Egress`.
+- `limit` (number): Cap rows returned. Defaults to 100, hard cap 500.
+
+**Returns:** JSON array of verdict records, each with `policy_name`, `policy_namespace`, `direction`, `src_namespace`/`src_pod`, `dst_namespace`/`dst_pod`, `dst_port`, `protocol`, `reason`, `verdict`, and `observed_at`.
+
+**Use Cases:**
+- "What traffic would be denied by policy X?"
+- "Why is this flow blocked?" / "Show recent policy violations"
+- Validate an audit-mode policy before promoting it to enforcement
+
+> **Note:** Requires the broker's audit pipeline to be enabled (`EVALUATOR_URL` set on the broker). With audit disabled, no verdicts are recorded and this tool returns an empty list.
+
+### `generate_network_policy`
+Generate a least-privilege Kubernetes NetworkPolicy (or CiliumNetworkPolicy) for a pod from its observed traffic. The synthesis is performed by the **advisor service** (`advisor serve`); this tool proxies to it and returns the YAML verbatim.
+
+**Parameters:**
+- `pod_name` (string, required): The pod to generate a policy for.
+- `policy_type` (string, optional): `kubernetes` (standard NetworkPolicy, default) or `cilium`.
+
+**Returns:** Ready-to-apply policy YAML.
+
+### `generate_seccomp_profile`
+Generate a least-privilege seccomp profile (JSON) for a pod from its observed syscalls. Proxies to the advisor service.
+
+**Parameters:**
+- `pod_name` (string, required): The pod to generate a profile for.
+
+**Returns:** Seccomp profile JSON (allow-lists observed syscalls, denies the rest).
+
+> **Note:** The two `generate_*` tools require the **advisor service** to be reachable. Set `ADVISOR_URL` on the MCP server (default `http://kguardian-advisor.kguardian.svc.cluster.local:8083`). The advisor service must be deployed (`advisor serve`, with `BROKER_URL` pointing at the broker).
 
 ## Development
 

--- a/mcp-server/tools/advisor_client.go
+++ b/mcp-server/tools/advisor_client.go
@@ -1,0 +1,105 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/kguardian-dev/kguardian/mcp-server/logger"
+	"github.com/sirupsen/logrus"
+)
+
+// defaultAdvisorURL is the in-cluster address of the advisor service (the
+// `advisor serve` command). Overridable via ADVISOR_URL.
+const defaultAdvisorURL = "http://kguardian-advisor.kguardian.svc.cluster.local:8083"
+
+// AdvisorClient talks to the advisor HTTP service, which synthesises
+// NetworkPolicy / CiliumNetworkPolicy YAML and seccomp JSON from observed
+// runtime data. Unlike BrokerClient it returns the raw response body (YAML or
+// JSON text) rather than decoding it — the generated artifact is presented to
+// the user verbatim.
+type AdvisorClient struct {
+	baseURL    string
+	httpClient *http.Client
+}
+
+// NewAdvisorClient resolves the advisor base URL from the argument, then
+// ADVISOR_URL, then the in-cluster default — mirroring BrokerClient's
+// defensive trimming of surrounding whitespace and trailing slashes.
+func NewAdvisorClient(baseURL string) *AdvisorClient {
+	resolved := strings.TrimSpace(baseURL)
+	if resolved == "" {
+		resolved = strings.TrimSpace(os.Getenv("ADVISOR_URL"))
+	}
+	if resolved == "" {
+		resolved = defaultAdvisorURL
+	}
+	return &AdvisorClient{
+		baseURL: strings.TrimRight(resolved, "/"),
+		httpClient: &http.Client{
+			// Policy synthesis fans out to several broker lookups per peer,
+			// so allow generous time without blocking the MCP request forever.
+			Timeout: 60 * time.Second,
+		},
+	}
+}
+
+// GenerateNetworkPolicy returns the YAML for the requested pod's network policy.
+// policyType is "kubernetes" (default) or "cilium".
+func (c *AdvisorClient) GenerateNetworkPolicy(ctx context.Context, podName, policyType string) (string, error) {
+	q := url.Values{}
+	q.Set("pod", podName)
+	if policyType != "" {
+		q.Set("type", policyType)
+	}
+	return c.getText(ctx, "/generate/networkpolicy?"+q.Encode())
+}
+
+// GenerateSeccompProfile returns the JSON seccomp profile for the requested pod.
+func (c *AdvisorClient) GenerateSeccompProfile(ctx context.Context, podName string) (string, error) {
+	q := url.Values{}
+	q.Set("pod", podName)
+	return c.getText(ctx, "/generate/seccomp?"+q.Encode())
+}
+
+// getText performs a GET and returns the response body as a string. On a
+// non-200 it extracts the advisor's `{"error": "..."}` message when present.
+func (c *AdvisorClient) getText(ctx context.Context, path string) (string, error) {
+	reqURL := c.baseURL + path
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to create request: %w", err)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		logger.Log.WithFields(logrus.Fields{"url": reqURL, "error": err.Error()}).Error("Advisor request failed")
+		return "", fmt.Errorf("failed to reach advisor: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes))
+	if err != nil {
+		return "", fmt.Errorf("failed to read advisor response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		// Advisor errors are JSON: {"error": "..."}. Surface the message if we
+		// can parse it, otherwise the raw body.
+		var parsed struct {
+			Error string `json:"error"`
+		}
+		if json.Unmarshal(body, &parsed) == nil && parsed.Error != "" {
+			return "", fmt.Errorf("advisor returned %d: %s", resp.StatusCode, parsed.Error)
+		}
+		return "", fmt.Errorf("advisor returned %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	return string(body), nil
+}

--- a/mcp-server/tools/all_tools.go
+++ b/mcp-server/tools/all_tools.go
@@ -32,11 +32,35 @@ var toolDefs = []toolDef{
 	},
 	{
 		Name:        "get_cluster_traffic",
-		Description: "Get a summary of network traffic across the cluster. Returns per-pod traffic counts (ingress/egress/peer counts), not raw records. Accepts an optional namespace parameter to filter results to a single namespace. Use when the user asks about overall traffic patterns or 'what pods are communicating'.",
+		Description: "Get a summary of network traffic across the cluster. Returns per-pod counts (ingress/egress, allow/drop, unique peers) plus a cluster-wide total_drop_count — not raw records. Dropped flows (decision=DROP) come from the eBPF network-policy-drop probe, so this also answers 'what traffic is being blocked/dropped'. Accepts an optional namespace filter. Use for overall traffic patterns, 'what pods are communicating', or 'where is traffic being dropped'.",
 	},
 	{
 		Name:        "get_cluster_pods",
 		Description: "List pods in the cluster with compact metadata (name, namespace, IP, node, status). Heavyweight fields like pod_obj are stripped. Accepts an optional namespace parameter to filter results. Use when the user asks 'what pods are running' or needs a pod inventory.",
+	},
+	{
+		Name:        "get_pod_details_by_name",
+		Description: "Look up a pod by its name. Returns identity (name, namespace, IP, node, workload selector labels) with the heavyweight pod_obj stripped. Use when the user names a pod (e.g. from a traffic record) and wants its details — prefer this over get_pod_details, which requires an IP.",
+	},
+	{
+		Name:        "list_services",
+		Description: "List Kubernetes services in the cluster with compact metadata (name, namespace, cluster IP, selector, ports). Accepts an optional namespace parameter to filter results. Use when the user asks 'what services exist' or needs a service inventory — get_service_details only resolves a single known IP.",
+	},
+	{
+		Name:        "get_pods_on_node",
+		Description: "List the pods recorded on a specific Kubernetes node (compact metadata: name, namespace, IP, node, workload labels; live pods only). Use for blast-radius / 'what runs on node X' / 'which workloads share a node' questions. Requires node.",
+	},
+	{
+		Name:        "get_audit_verdicts",
+		Description: "Get network-policy evaluation verdicts — flows the AuditNetworkPolicy/AuditClusterNetworkPolicy engine evaluated as Allow or WouldDeny. Returns source/destination pod+namespace, port, protocol, direction, the human-readable reason, and observed_at, newest first. All filters optional: policy, namespace, verdict ('Allow'|'WouldDeny'), direction ('Ingress'|'Egress'), limit (default 100, max 500). Use for security questions like 'what traffic would be denied', 'why is this flow blocked', or 'show recent policy violations'.",
+	},
+	{
+		Name:        "generate_network_policy",
+		Description: "Generate a least-privilege Kubernetes NetworkPolicy (or CiliumNetworkPolicy) for a pod from its observed traffic. Returns ready-to-apply YAML. Parameters: pod_name (required); policy_type ('kubernetes' for a standard NetworkPolicy — the default — or 'cilium'). Use when the user asks to 'generate/create a network policy', 'lock down this pod', or 'restrict traffic for X'. The policy is deterministically synthesised by the advisor from captured flows, not guessed.",
+	},
+	{
+		Name:        "generate_seccomp_profile",
+		Description: "Generate a least-privilege seccomp profile for a pod from its observed syscalls. Returns ready-to-use seccomp JSON (allow-lists the observed syscalls, denies the rest). Parameter: pod_name (required). Use when the user asks to 'generate/create a seccomp profile' or 'restrict syscalls for X'.",
 	},
 }
 
@@ -88,4 +112,37 @@ func RegisterAllTools(server *mcp.Server, brokerURL string) {
 		Name:        "get_cluster_pods",
 		Description: defs["get_cluster_pods"],
 	}, ClusterPodsHandler{client: client}.Call)
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "get_pod_details_by_name",
+		Description: defs["get_pod_details_by_name"],
+	}, PodByNameHandler{client: client}.Call)
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "list_services",
+		Description: defs["list_services"],
+	}, ClusterServicesHandler{client: client}.Call)
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "get_pods_on_node",
+		Description: defs["get_pods_on_node"],
+	}, PodsOnNodeHandler{client: client}.Call)
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "get_audit_verdicts",
+		Description: defs["get_audit_verdicts"],
+	}, AuditVerdictsHandler{client: client}.Call)
+
+	// Policy/seccomp generation proxies to the advisor service.
+	advisor := NewAdvisorClient("")
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "generate_network_policy",
+		Description: defs["generate_network_policy"],
+	}, GenerateNetworkPolicyHandler{advisor: advisor}.Call)
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "generate_seccomp_profile",
+		Description: defs["generate_seccomp_profile"],
+	}, GenerateSeccompProfileHandler{advisor: advisor}.Call)
 }

--- a/mcp-server/tools/all_tools.go
+++ b/mcp-server/tools/all_tools.go
@@ -52,7 +52,7 @@ var toolDefs = []toolDef{
 	},
 	{
 		Name:        "get_audit_verdicts",
-		Description: "Get network-policy evaluation verdicts — flows the AuditNetworkPolicy/AuditClusterNetworkPolicy engine evaluated as Allow or WouldDeny. Returns source/destination pod+namespace, port, protocol, direction, the human-readable reason, and observed_at, newest first. All filters optional: policy, namespace, verdict ('Allow'|'WouldDeny'), direction ('Ingress'|'Egress'), limit (default 100, max 500). Use for security questions like 'what traffic would be denied', 'why is this flow blocked', or 'show recent policy violations'.",
+		Description: "Get network-policy evaluation verdicts — flows the AuditNetworkPolicy/AuditClusterNetworkPolicy engine evaluated as Allow or WouldDeny. Returns source/destination pod+namespace, port, protocol, direction, the human-readable reason, and observed_at, newest first. All filters optional: policy, namespace (a single namespace; omit to span all, which includes cluster-scoped), cluster_scoped (true = ONLY cluster-scoped verdicts), verdict ('Allow'|'WouldDeny'), direction ('Ingress'|'Egress'), limit (default 100, max 500). Use for security questions like 'what traffic would be denied', 'why is this flow blocked', or 'show recent policy violations'.",
 	},
 	{
 		Name:        "generate_network_policy",

--- a/mcp-server/tools/audit_verdicts.go
+++ b/mcp-server/tools/audit_verdicts.go
@@ -1,0 +1,83 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/kguardian-dev/kguardian/mcp-server/logger"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/sirupsen/logrus"
+)
+
+// AuditVerdictsInput defines the input parameters for the audit verdicts tool.
+// All fields are optional; an empty request returns the most recent verdicts
+// across all policies (newest first, capped by the broker's default limit).
+type AuditVerdictsInput struct {
+	Policy    string `json:"policy,omitempty" jsonschema:"Optional policy name to filter by. Pair with namespace for an AuditNetworkPolicy; leave namespace empty for an AuditClusterNetworkPolicy."`
+	Namespace string `json:"namespace,omitempty" jsonschema:"Optional policy namespace to filter by. Omit to span all namespaces."`
+	Verdict   string `json:"verdict,omitempty" jsonschema:"Optional verdict filter: 'Allow' or 'WouldDeny'. Use 'WouldDeny' to see flows that the policy would block if enforced."`
+	Direction string `json:"direction,omitempty" jsonschema:"Optional direction filter: 'Ingress' or 'Egress'."`
+	Limit     int    `json:"limit,omitempty" jsonschema:"Optional cap on rows returned. Defaults to 100, hard cap 500. Results are ordered newest-first."`
+}
+
+// AuditVerdictsOutput defines the output structure
+type AuditVerdictsOutput struct {
+	Data string `json:"data" jsonschema:"Audit verdict records in JSON format"`
+}
+
+// AuditVerdictsHandler handles the get_audit_verdicts tool
+type AuditVerdictsHandler struct {
+	client *BrokerClient
+}
+
+// Call implements the tool handler
+func (h AuditVerdictsHandler) Call(
+	ctx context.Context,
+	req *mcp.CallToolRequest,
+	input AuditVerdictsInput,
+) (*mcp.CallToolResult, AuditVerdictsOutput, error) {
+	startTime := time.Now()
+	logger.Log.WithFields(logrus.Fields{
+		"policy":    input.Policy,
+		"namespace": input.Namespace,
+		"verdict":   input.Verdict,
+		"direction": input.Direction,
+		"limit":     input.Limit,
+	}).Debug("Received get_audit_verdicts request")
+
+	data, err := h.client.GetAuditVerdicts(ctx, input.Policy, input.Namespace, input.Verdict, input.Direction, input.Limit)
+	if err != nil {
+		logger.Log.WithFields(logrus.Fields{
+			"error":          err.Error(),
+			"total_duration": time.Since(startTime).String(),
+		}).Error("Error fetching audit verdicts")
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{&mcp.TextContent{Text: fmt.Sprintf("error fetching audit verdicts: %v", err)}},
+			IsError: true,
+		}, AuditVerdictsOutput{}, nil
+	}
+
+	// No compaction: audit verdict rows are already a flat, compact
+	// shape (policy/src/dst/port/protocol/reason/verdict/observed_at)
+	// and the broker bounds the row count server-side, so the result
+	// is LLM-sized without further stripping.
+	jsonData, err := json.Marshal(data)
+	if err != nil {
+		logger.Log.WithField("error", err.Error()).Error("Error marshaling response")
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{&mcp.TextContent{Text: fmt.Sprintf("error marshaling response: %v", err)}},
+			IsError: true,
+		}, AuditVerdictsOutput{}, nil
+	}
+
+	logger.Log.WithFields(logrus.Fields{
+		"response_bytes": len(jsonData),
+		"total_duration": time.Since(startTime).String(),
+	}).Info("Successfully fetched audit verdicts")
+
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{&mcp.TextContent{Text: string(jsonData)}},
+	}, AuditVerdictsOutput{}, nil
+}

--- a/mcp-server/tools/audit_verdicts.go
+++ b/mcp-server/tools/audit_verdicts.go
@@ -15,11 +15,14 @@ import (
 // All fields are optional; an empty request returns the most recent verdicts
 // across all policies (newest first, capped by the broker's default limit).
 type AuditVerdictsInput struct {
-	Policy    string `json:"policy,omitempty" jsonschema:"Optional policy name to filter by. Pair with namespace for an AuditNetworkPolicy; leave namespace empty for an AuditClusterNetworkPolicy."`
-	Namespace string `json:"namespace,omitempty" jsonschema:"Optional policy namespace to filter by. Omit to span all namespaces."`
+	Policy    string `json:"policy,omitempty" jsonschema:"Optional policy name to filter by (matches an AuditNetworkPolicy or AuditClusterNetworkPolicy by name)."`
+	Namespace string `json:"namespace,omitempty" jsonschema:"Optional policy namespace to filter to a single namespace's AuditNetworkPolicy verdicts. Omit to span all namespaces (cluster-scoped verdicts are included). To see ONLY cluster-scoped verdicts, set cluster_scoped instead of using this field."`
 	Verdict   string `json:"verdict,omitempty" jsonschema:"Optional verdict filter: 'Allow' or 'WouldDeny'. Use 'WouldDeny' to see flows that the policy would block if enforced."`
 	Direction string `json:"direction,omitempty" jsonschema:"Optional direction filter: 'Ingress' or 'Egress'."`
 	Limit     int    `json:"limit,omitempty" jsonschema:"Optional cap on rows returned. Defaults to 100, hard cap 500. Results are ordered newest-first."`
+	// ClusterScoped exposes the broker's "namespace= (empty)" mode, which a
+	// plain namespace string can't reach (empty == unset for a Go string).
+	ClusterScoped bool `json:"cluster_scoped,omitempty" jsonschema:"Set true to return ONLY cluster-scoped AuditClusterNetworkPolicy verdicts. Takes precedence over namespace."`
 }
 
 // AuditVerdictsOutput defines the output structure
@@ -40,14 +43,15 @@ func (h AuditVerdictsHandler) Call(
 ) (*mcp.CallToolResult, AuditVerdictsOutput, error) {
 	startTime := time.Now()
 	logger.Log.WithFields(logrus.Fields{
-		"policy":    input.Policy,
-		"namespace": input.Namespace,
-		"verdict":   input.Verdict,
-		"direction": input.Direction,
-		"limit":     input.Limit,
+		"policy":         input.Policy,
+		"namespace":      input.Namespace,
+		"verdict":        input.Verdict,
+		"direction":      input.Direction,
+		"limit":          input.Limit,
+		"cluster_scoped": input.ClusterScoped,
 	}).Debug("Received get_audit_verdicts request")
 
-	data, err := h.client.GetAuditVerdicts(ctx, input.Policy, input.Namespace, input.Verdict, input.Direction, input.Limit)
+	data, err := h.client.GetAuditVerdicts(ctx, input.Policy, input.Namespace, input.Verdict, input.Direction, input.Limit, input.ClusterScoped)
 	if err != nil {
 		logger.Log.WithFields(logrus.Fields{
 			"error":          err.Error(),

--- a/mcp-server/tools/broker_client.go
+++ b/mcp-server/tools/broker_client.go
@@ -117,17 +117,26 @@ func (c *BrokerClient) GetPodsOnNode(ctx context.Context, node string) (interfac
 }
 
 // GetAuditVerdicts retrieves policy-evaluation verdicts (Allow / WouldDeny)
-// from the broker's /audit/verdicts endpoint. Every filter is optional and
-// only forwarded when non-empty so the broker applies its documented
-// defaults (empty-string filters are normalised to "no filter" server-side,
-// except namespace="" which legitimately selects cluster-scoped policies —
-// so namespace is only sent when the caller explicitly set it).
-func (c *BrokerClient) GetAuditVerdicts(ctx context.Context, policy, namespace, verdict, direction string, limit int) (interface{}, error) {
+// from the broker's /audit/verdicts endpoint. Filters are optional. The
+// namespace dimension has three distinct modes that mirror the broker:
+//   - clusterScoped=true  -> sends "namespace=" (empty value PRESENT), which
+//     the broker reads as "cluster-scoped policy verdicts only"
+//     (policy_namespace = ”). This takes precedence over namespace.
+//   - namespace != ""     -> sends "namespace=<ns>" (that namespace only).
+//   - neither             -> omits the param entirely, spanning all
+//     namespaces including cluster-scoped.
+//
+// The empty-vs-absent distinction is the whole reason clusterScoped is a
+// separate flag: a bare empty string can't tell "all namespaces" apart from
+// "cluster-scoped only", so the caller signals the latter explicitly.
+func (c *BrokerClient) GetAuditVerdicts(ctx context.Context, policy, namespace, verdict, direction string, limit int, clusterScoped bool) (interface{}, error) {
 	q := url.Values{}
 	if policy != "" {
 		q.Set("policy", policy)
 	}
-	if namespace != "" {
+	if clusterScoped {
+		q.Set("namespace", "") // empty value present -> cluster-scoped only
+	} else if namespace != "" {
 		q.Set("namespace", namespace)
 	}
 	if verdict != "" {

--- a/mcp-server/tools/broker_client.go
+++ b/mcp-server/tools/broker_client.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -87,6 +88,61 @@ func (c *BrokerClient) GetAllPodTraffic(ctx context.Context) (interface{}, error
 // GetAllPods retrieves all pod details in the cluster
 func (c *BrokerClient) GetAllPods(ctx context.Context) (interface{}, error) {
 	reqURL := fmt.Sprintf("%s/pod/info", c.baseURL)
+	return c.get(ctx, reqURL)
+}
+
+// GetPodByName retrieves pod details by pod name. The broker resolves
+// the name cluster-wide, so the LLM can look a pod up directly from a
+// name it already has (e.g. from a traffic record) instead of having
+// to round-trip through an IP via GetPodByIP.
+func (c *BrokerClient) GetPodByName(ctx context.Context, name string) (interface{}, error) {
+	reqURL := fmt.Sprintf("%s/pod/name/%s", c.baseURL, url.PathEscape(name))
+	return c.get(ctx, reqURL)
+}
+
+// GetAllServices retrieves all service details in the cluster. Mirrors
+// GetAllPods for the service inventory the LLM otherwise had no way to
+// enumerate (GetServiceByIP only resolves a single known cluster IP).
+func (c *BrokerClient) GetAllServices(ctx context.Context) (interface{}, error) {
+	reqURL := fmt.Sprintf("%s/svc/info", c.baseURL)
+	return c.get(ctx, reqURL)
+}
+
+// GetPodsOnNode retrieves the pods the broker has recorded on a given node.
+// Backs blast-radius / "what runs on node X" questions, which neither the
+// namespace-scoped cluster pod list nor any per-pod lookup could answer.
+func (c *BrokerClient) GetPodsOnNode(ctx context.Context, node string) (interface{}, error) {
+	reqURL := fmt.Sprintf("%s/pod/list/%s", c.baseURL, url.PathEscape(node))
+	return c.get(ctx, reqURL)
+}
+
+// GetAuditVerdicts retrieves policy-evaluation verdicts (Allow / WouldDeny)
+// from the broker's /audit/verdicts endpoint. Every filter is optional and
+// only forwarded when non-empty so the broker applies its documented
+// defaults (empty-string filters are normalised to "no filter" server-side,
+// except namespace="" which legitimately selects cluster-scoped policies —
+// so namespace is only sent when the caller explicitly set it).
+func (c *BrokerClient) GetAuditVerdicts(ctx context.Context, policy, namespace, verdict, direction string, limit int) (interface{}, error) {
+	q := url.Values{}
+	if policy != "" {
+		q.Set("policy", policy)
+	}
+	if namespace != "" {
+		q.Set("namespace", namespace)
+	}
+	if verdict != "" {
+		q.Set("verdict", verdict)
+	}
+	if direction != "" {
+		q.Set("direction", direction)
+	}
+	if limit > 0 {
+		q.Set("limit", strconv.Itoa(limit))
+	}
+	reqURL := fmt.Sprintf("%s/audit/verdicts", c.baseURL)
+	if encoded := q.Encode(); encoded != "" {
+		reqURL += "?" + encoded
+	}
 	return c.get(ctx, reqURL)
 }
 

--- a/mcp-server/tools/broker_client.go
+++ b/mcp-server/tools/broker_client.go
@@ -121,7 +121,7 @@ func (c *BrokerClient) GetPodsOnNode(ctx context.Context, node string) (interfac
 // namespace dimension has three distinct modes that mirror the broker:
 //   - clusterScoped=true  -> sends "namespace=" (empty value PRESENT), which
 //     the broker reads as "cluster-scoped policy verdicts only"
-//     (policy_namespace = ”). This takes precedence over namespace.
+//     (policy_namespace = ''). This takes precedence over namespace.
 //   - namespace != ""     -> sends "namespace=<ns>" (that namespace only).
 //   - neither             -> omits the param entirely, spanning all
 //     namespaces including cluster-scoped.

--- a/mcp-server/tools/broker_client.go
+++ b/mcp-server/tools/broker_client.go
@@ -120,8 +120,8 @@ func (c *BrokerClient) GetPodsOnNode(ctx context.Context, node string) (interfac
 // from the broker's /audit/verdicts endpoint. Filters are optional. The
 // namespace dimension has three distinct modes that mirror the broker:
 //   - clusterScoped=true  -> sends "namespace=" (empty value PRESENT), which
-//     the broker reads as "cluster-scoped policy verdicts only"
-//     (policy_namespace = ''). This takes precedence over namespace.
+//     the broker reads as "cluster-scoped policy verdicts only" (those rows
+//     are stored with an empty policy_namespace). Takes precedence over namespace.
 //   - namespace != ""     -> sends "namespace=<ns>" (that namespace only).
 //   - neither             -> omits the param entirely, spanning all
 //     namespaces including cluster-scoped.

--- a/mcp-server/tools/cluster_services.go
+++ b/mcp-server/tools/cluster_services.go
@@ -1,0 +1,75 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/kguardian-dev/kguardian/mcp-server/logger"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/sirupsen/logrus"
+)
+
+// ClusterServicesInput defines the input parameters for the service inventory tool
+type ClusterServicesInput struct {
+	Namespace string `json:"namespace,omitempty" jsonschema:"Optional Kubernetes namespace to filter results. If omitted, returns services across all namespaces."`
+}
+
+// ClusterServicesOutput defines the output structure
+type ClusterServicesOutput struct {
+	Data string `json:"data" jsonschema:"Service inventory in JSON format"`
+}
+
+// ClusterServicesHandler handles the list_services tool
+type ClusterServicesHandler struct {
+	client *BrokerClient
+}
+
+// Call implements the tool handler
+func (h ClusterServicesHandler) Call(
+	ctx context.Context,
+	req *mcp.CallToolRequest,
+	input ClusterServicesInput,
+) (*mcp.CallToolResult, ClusterServicesOutput, error) {
+	startTime := time.Now()
+	logger.Log.WithField("namespace", input.Namespace).Debug("Received list_services request")
+
+	data, err := h.client.GetAllServices(ctx)
+	if err != nil {
+		logger.Log.WithFields(logrus.Fields{
+			"error":          err.Error(),
+			"total_duration": time.Since(startTime).String(),
+		}).Error("Error fetching services")
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{&mcp.TextContent{Text: fmt.Sprintf("error fetching services: %v", err)}},
+			IsError: true,
+		}, ClusterServicesOutput{}, nil
+	}
+
+	// Apply the optional namespace filter, then strip the full
+	// Kubernetes Service object down to identity + selector + ports
+	// (compactSvc), matching get_service_details so the inventory
+	// view and the single-IP lookup return the same shape.
+	filtered := filterByNamespace(data, input.Namespace)
+	compacted := compactSvc(filtered)
+
+	jsonData, err := json.Marshal(compacted)
+	if err != nil {
+		logger.Log.WithField("error", err.Error()).Error("Error marshaling response")
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{&mcp.TextContent{Text: fmt.Sprintf("error marshaling response: %v", err)}},
+			IsError: true,
+		}, ClusterServicesOutput{}, nil
+	}
+
+	logger.Log.WithFields(logrus.Fields{
+		"namespace":      input.Namespace,
+		"response_bytes": len(jsonData),
+		"total_duration": time.Since(startTime).String(),
+	}).Info("Successfully fetched services")
+
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{&mcp.TextContent{Text: string(jsonData)}},
+	}, ClusterServicesOutput{}, nil
+}

--- a/mcp-server/tools/filter.go
+++ b/mcp-server/tools/filter.go
@@ -41,9 +41,12 @@ func compactTrafficSummary(data interface{}) map[string]interface{} {
 	type podStats struct {
 		Ingress int
 		Egress  int
+		Allow   int
+		Drop    int
 		Peers   map[string]bool
 	}
 	pods := make(map[string]*podStats)
+	totalDrop := 0
 
 	for _, item := range items {
 		m, ok := item.(map[string]interface{})
@@ -86,6 +89,20 @@ func compactTrafficSummary(data interface{}) map[string]interface{} {
 		if peer, ok := m["traffic_in_out_ip"].(string); ok && peer != "" {
 			s.Peers[peer] = true
 		}
+
+		// Surface the policy decision so "what traffic is being dropped /
+		// blocked cluster-wide" is answerable from the summary. The broker
+		// stores decision as "ALLOW"/"DROP" (uppercase, from
+		// controller/src/network.rs); the eBPF netpolicy-drop probe lands
+		// here as decision="DROP" rows. Without this the LLM would have to
+		// pull raw per-pod traffic to find drops.
+		switch strings.ToUpper(asString(m["decision"])) {
+		case "DROP":
+			s.Drop++
+			totalDrop++
+		case "ALLOW":
+			s.Allow++
+		}
 	}
 
 	podSummaries := make(map[string]interface{}, len(pods))
@@ -93,15 +110,24 @@ func compactTrafficSummary(data interface{}) map[string]interface{} {
 		podSummaries[name] = map[string]interface{}{
 			"ingress_count":     s.Ingress,
 			"egress_count":      s.Egress,
+			"allow_count":       s.Allow,
+			"drop_count":        s.Drop,
 			"unique_peer_count": len(s.Peers),
 		}
 	}
 
 	return map[string]interface{}{
-		"total_records": len(items),
-		"pod_count":     len(pods),
-		"pods":          podSummaries,
+		"total_records":    len(items),
+		"pod_count":        len(pods),
+		"total_drop_count": totalDrop,
+		"pods":             podSummaries,
 	}
+}
+
+// asString returns the string value of v, or "" if v is not a string.
+func asString(v interface{}) string {
+	s, _ := v.(string)
+	return s
 }
 
 // compactSvcRecord strips the heavyweight `service_spec` from a

--- a/mcp-server/tools/generate_policy.go
+++ b/mcp-server/tools/generate_policy.go
@@ -1,0 +1,142 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/kguardian-dev/kguardian/mcp-server/logger"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/sirupsen/logrus"
+)
+
+// GenerateNetworkPolicyInput defines the input for the network policy generator.
+type GenerateNetworkPolicyInput struct {
+	PodName    string `json:"pod_name" jsonschema:"The name of the pod to generate a least-privilege network policy for"`
+	PolicyType string `json:"policy_type,omitempty" jsonschema:"Policy flavour: 'kubernetes' (standard NetworkPolicy, default) or 'cilium' (CiliumNetworkPolicy)"`
+}
+
+// GenerateNetworkPolicyOutput holds the generated policy YAML.
+type GenerateNetworkPolicyOutput struct {
+	Data string `json:"data" jsonschema:"Generated network policy in YAML format"`
+}
+
+// GenerateNetworkPolicyHandler handles the generate_network_policy tool.
+type GenerateNetworkPolicyHandler struct {
+	advisor *AdvisorClient
+}
+
+// Call implements the tool handler.
+func (h GenerateNetworkPolicyHandler) Call(
+	ctx context.Context,
+	_ *mcp.CallToolRequest,
+	input GenerateNetworkPolicyInput,
+) (*mcp.CallToolResult, GenerateNetworkPolicyOutput, error) {
+	start := time.Now()
+	logger.Log.WithFields(logrus.Fields{"pod_name": input.PodName, "policy_type": input.PolicyType}).
+		Debug("Received generate_network_policy request")
+
+	if input.PodName == "" {
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{&mcp.TextContent{Text: "pod_name is required"}},
+			IsError: true,
+		}, GenerateNetworkPolicyOutput{}, nil
+	}
+
+	policyType := normalizePolicyType(input.PolicyType)
+
+	yaml, err := h.advisor.GenerateNetworkPolicy(ctx, input.PodName, policyType)
+	if err != nil {
+		logger.Log.WithFields(logrus.Fields{
+			"pod_name":       input.PodName,
+			"policy_type":    policyType,
+			"error":          err.Error(),
+			"total_duration": time.Since(start).String(),
+		}).Error("Error generating network policy")
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{&mcp.TextContent{Text: fmt.Sprintf("error generating network policy: %v", err)}},
+			IsError: true,
+		}, GenerateNetworkPolicyOutput{}, nil
+	}
+
+	logger.Log.WithFields(logrus.Fields{
+		"pod_name":       input.PodName,
+		"policy_type":    policyType,
+		"response_bytes": len(yaml),
+		"total_duration": time.Since(start).String(),
+	}).Info("Successfully generated network policy")
+
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{&mcp.TextContent{Text: yaml}},
+	}, GenerateNetworkPolicyOutput{}, nil
+}
+
+// normalizePolicyType maps user-supplied aliases to the advisor's accepted
+// values, defaulting to "kubernetes". Unknown values are passed through so the
+// advisor returns its own clear validation error.
+func normalizePolicyType(in string) string {
+	switch strings.ToLower(strings.TrimSpace(in)) {
+	case "", "kubernetes", "k8s", "standard":
+		return "kubernetes"
+	case "cilium":
+		return "cilium"
+	default:
+		return in
+	}
+}
+
+// GenerateSeccompProfileInput defines the input for the seccomp generator.
+type GenerateSeccompProfileInput struct {
+	PodName string `json:"pod_name" jsonschema:"The name of the pod to generate a seccomp profile for"`
+}
+
+// GenerateSeccompProfileOutput holds the generated profile JSON.
+type GenerateSeccompProfileOutput struct {
+	Data string `json:"data" jsonschema:"Generated seccomp profile in JSON format"`
+}
+
+// GenerateSeccompProfileHandler handles the generate_seccomp_profile tool.
+type GenerateSeccompProfileHandler struct {
+	advisor *AdvisorClient
+}
+
+// Call implements the tool handler.
+func (h GenerateSeccompProfileHandler) Call(
+	ctx context.Context,
+	_ *mcp.CallToolRequest,
+	input GenerateSeccompProfileInput,
+) (*mcp.CallToolResult, GenerateSeccompProfileOutput, error) {
+	start := time.Now()
+	logger.Log.WithField("pod_name", input.PodName).Debug("Received generate_seccomp_profile request")
+
+	if input.PodName == "" {
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{&mcp.TextContent{Text: "pod_name is required"}},
+			IsError: true,
+		}, GenerateSeccompProfileOutput{}, nil
+	}
+
+	profile, err := h.advisor.GenerateSeccompProfile(ctx, input.PodName)
+	if err != nil {
+		logger.Log.WithFields(logrus.Fields{
+			"pod_name":       input.PodName,
+			"error":          err.Error(),
+			"total_duration": time.Since(start).String(),
+		}).Error("Error generating seccomp profile")
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{&mcp.TextContent{Text: fmt.Sprintf("error generating seccomp profile: %v", err)}},
+			IsError: true,
+		}, GenerateSeccompProfileOutput{}, nil
+	}
+
+	logger.Log.WithFields(logrus.Fields{
+		"pod_name":       input.PodName,
+		"response_bytes": len(profile),
+		"total_duration": time.Since(start).String(),
+	}).Info("Successfully generated seccomp profile")
+
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{&mcp.TextContent{Text: profile}},
+	}, GenerateSeccompProfileOutput{}, nil
+}

--- a/mcp-server/tools/generate_policy_test.go
+++ b/mcp-server/tools/generate_policy_test.go
@@ -1,0 +1,119 @@
+package tools
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestGenerateNetworkPolicy_ReturnsYAML(t *testing.T) {
+	var gotPath, gotQuery string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotQuery = r.URL.RawQuery
+		w.Header().Set("Content-Type", "application/yaml")
+		_, _ = w.Write([]byte("apiVersion: networking.k8s.io/v1\nkind: NetworkPolicy\n"))
+	}))
+	defer srv.Close()
+
+	h := GenerateNetworkPolicyHandler{advisor: NewAdvisorClient(srv.URL)}
+	res, _, _ := h.Call(context.Background(), nil, GenerateNetworkPolicyInput{PodName: "web-1", PolicyType: "cilium"})
+
+	if res.IsError {
+		t.Fatalf("unexpected error: %s", textOf(t, res))
+	}
+	if gotPath != "/generate/networkpolicy" {
+		t.Errorf("path: want /generate/networkpolicy, got %s", gotPath)
+	}
+	if !strings.Contains(gotQuery, "pod=web-1") || !strings.Contains(gotQuery, "type=cilium") {
+		t.Errorf("query missing pod/type: %s", gotQuery)
+	}
+	if !strings.Contains(textOf(t, res), "kind: NetworkPolicy") {
+		t.Errorf("expected YAML passed through; got: %s", textOf(t, res))
+	}
+}
+
+func TestGenerateNetworkPolicy_DefaultsToKubernetesType(t *testing.T) {
+	var gotQuery string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.RawQuery
+		_, _ = w.Write([]byte("kind: NetworkPolicy\n"))
+	}))
+	defer srv.Close()
+
+	h := GenerateNetworkPolicyHandler{advisor: NewAdvisorClient(srv.URL)}
+	_, _, _ = h.Call(context.Background(), nil, GenerateNetworkPolicyInput{PodName: "web-1"})
+
+	if !strings.Contains(gotQuery, "type=kubernetes") {
+		t.Errorf("expected default type=kubernetes; got query: %s", gotQuery)
+	}
+}
+
+func TestGenerateNetworkPolicy_EmptyPodRejected(t *testing.T) {
+	h := GenerateNetworkPolicyHandler{advisor: NewAdvisorClient("http://unused")}
+	res, _, _ := h.Call(context.Background(), nil, GenerateNetworkPolicyInput{PodName: ""})
+	if !res.IsError {
+		t.Fatalf("expected IsError for empty pod_name")
+	}
+}
+
+func TestGenerateNetworkPolicy_AdvisorErrorSurfaced(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadGateway)
+		_, _ = w.Write([]byte(`{"error":"no traffic data found for pod web-1"}`))
+	}))
+	defer srv.Close()
+
+	h := GenerateNetworkPolicyHandler{advisor: NewAdvisorClient(srv.URL)}
+	res, _, _ := h.Call(context.Background(), nil, GenerateNetworkPolicyInput{PodName: "web-1"})
+
+	if !res.IsError {
+		t.Fatalf("expected IsError on advisor 502")
+	}
+	if !strings.Contains(textOf(t, res), "no traffic data found") {
+		t.Errorf("expected advisor error message surfaced; got: %s", textOf(t, res))
+	}
+}
+
+func TestGenerateSeccompProfile_ReturnsJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/generate/seccomp" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"defaultAction":"SCMP_ACT_ERRNO","syscalls":[{"names":["read"],"action":"SCMP_ACT_ALLOW"}]}`))
+	}))
+	defer srv.Close()
+
+	h := GenerateSeccompProfileHandler{advisor: NewAdvisorClient(srv.URL)}
+	res, _, _ := h.Call(context.Background(), nil, GenerateSeccompProfileInput{PodName: "web-1"})
+
+	if res.IsError {
+		t.Fatalf("unexpected error: %s", textOf(t, res))
+	}
+	if !strings.Contains(textOf(t, res), "SCMP_ACT_ERRNO") {
+		t.Errorf("expected seccomp JSON passed through; got: %s", textOf(t, res))
+	}
+}
+
+func TestNewAdvisorClient_PrecedenceAndTrim(t *testing.T) {
+	// Explicit arg wins and trailing slash is stripped.
+	c := NewAdvisorClient("  http://example:8082/  ")
+	if c.baseURL != "http://example:8082" {
+		t.Errorf("baseURL: want http://example:8082, got %q", c.baseURL)
+	}
+	// Empty arg + no env -> in-cluster default.
+	t.Setenv("ADVISOR_URL", "")
+	if d := NewAdvisorClient("").baseURL; d != defaultAdvisorURL {
+		t.Errorf("default baseURL: want %s, got %s", defaultAdvisorURL, d)
+	}
+	// Env override.
+	t.Setenv("ADVISOR_URL", "http://from-env:9000")
+	if e := NewAdvisorClient("").baseURL; e != "http://from-env:9000" {
+		t.Errorf("env baseURL: want http://from-env:9000, got %s", e)
+	}
+}

--- a/mcp-server/tools/pod_by_name.go
+++ b/mcp-server/tools/pod_by_name.go
@@ -1,0 +1,82 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/kguardian-dev/kguardian/mcp-server/logger"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/sirupsen/logrus"
+)
+
+// PodByNameInput defines the input parameters for the pod-by-name tool
+type PodByNameInput struct {
+	PodName string `json:"pod_name" jsonschema:"The name of the pod to look up"`
+}
+
+// PodByNameOutput defines the output structure
+type PodByNameOutput struct {
+	Data string `json:"data" jsonschema:"Pod details in JSON format"`
+}
+
+// PodByNameHandler handles the get_pod_details_by_name tool
+type PodByNameHandler struct {
+	client *BrokerClient
+}
+
+// Call implements the tool handler
+func (h PodByNameHandler) Call(
+	ctx context.Context,
+	req *mcp.CallToolRequest,
+	input PodByNameInput,
+) (*mcp.CallToolResult, PodByNameOutput, error) {
+	startTime := time.Now()
+	logger.Log.WithField("pod_name", input.PodName).Debug("Received get_pod_details_by_name request")
+
+	if input.PodName == "" {
+		logger.Log.Error("pod_name is required but not provided")
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{&mcp.TextContent{Text: "pod_name is required"}},
+			IsError: true,
+		}, PodByNameOutput{}, nil
+	}
+
+	data, err := h.client.GetPodByName(ctx, input.PodName)
+	if err != nil {
+		logger.Log.WithFields(logrus.Fields{
+			"pod_name":       input.PodName,
+			"error":          err.Error(),
+			"total_duration": time.Since(startTime).String(),
+		}).Error("Error fetching pod details by name")
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{&mcp.TextContent{Text: fmt.Sprintf("error fetching pod details: %v", err)}},
+			IsError: true,
+		}, PodByNameOutput{}, nil
+	}
+
+	// Strip heavyweight fields (pod_obj) the same way get_pod_details
+	// does — the LLM needs identity (name, namespace, IP, node,
+	// workload labels), not the full Kubernetes Pod spec/status.
+	compacted := compactPodsSummary(data)
+
+	jsonData, err := json.Marshal(compacted)
+	if err != nil {
+		logger.Log.WithField("error", err.Error()).Error("Error marshaling response")
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{&mcp.TextContent{Text: fmt.Sprintf("error marshaling response: %v", err)}},
+			IsError: true,
+		}, PodByNameOutput{}, nil
+	}
+
+	logger.Log.WithFields(logrus.Fields{
+		"pod_name":       input.PodName,
+		"response_bytes": len(jsonData),
+		"total_duration": time.Since(startTime).String(),
+	}).Info("Successfully fetched pod details by name")
+
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{&mcp.TextContent{Text: string(jsonData)}},
+	}, PodByNameOutput{}, nil
+}

--- a/mcp-server/tools/pods_on_node.go
+++ b/mcp-server/tools/pods_on_node.go
@@ -1,0 +1,80 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/kguardian-dev/kguardian/mcp-server/logger"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/sirupsen/logrus"
+)
+
+// PodsOnNodeInput defines the input for the node-scoped pod tool.
+type PodsOnNodeInput struct {
+	Node string `json:"node" jsonschema:"The name of the Kubernetes node to list pods for"`
+}
+
+// PodsOnNodeOutput holds the compacted pod records.
+type PodsOnNodeOutput struct {
+	Data string `json:"data" jsonschema:"Pods on the node, in JSON format"`
+}
+
+// PodsOnNodeHandler handles the get_pods_on_node tool.
+type PodsOnNodeHandler struct {
+	client *BrokerClient
+}
+
+// Call implements the tool handler.
+func (h PodsOnNodeHandler) Call(
+	ctx context.Context,
+	_ *mcp.CallToolRequest,
+	input PodsOnNodeInput,
+) (*mcp.CallToolResult, PodsOnNodeOutput, error) {
+	start := time.Now()
+	logger.Log.WithField("node", input.Node).Debug("Received get_pods_on_node request")
+
+	if input.Node == "" {
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{&mcp.TextContent{Text: "node is required"}},
+			IsError: true,
+		}, PodsOnNodeOutput{}, nil
+	}
+
+	data, err := h.client.GetPodsOnNode(ctx, input.Node)
+	if err != nil {
+		logger.Log.WithFields(logrus.Fields{
+			"node":           input.Node,
+			"error":          err.Error(),
+			"total_duration": time.Since(start).String(),
+		}).Error("Error fetching pods on node")
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{&mcp.TextContent{Text: fmt.Sprintf("error fetching pods on node: %v", err)}},
+			IsError: true,
+		}, PodsOnNodeOutput{}, nil
+	}
+
+	// Live pods only, with heavyweight pod_obj stripped — same shape as
+	// get_cluster_pods so the LLM sees a consistent pod record everywhere.
+	compacted := compactPodsSummary(filterAlivePods(data))
+
+	jsonData, err := json.Marshal(compacted)
+	if err != nil {
+		logger.Log.WithField("error", err.Error()).Error("Error marshaling response")
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{&mcp.TextContent{Text: fmt.Sprintf("error marshaling response: %v", err)}},
+			IsError: true,
+		}, PodsOnNodeOutput{}, nil
+	}
+
+	logger.Log.WithFields(logrus.Fields{
+		"node":           input.Node,
+		"response_bytes": len(jsonData),
+		"total_duration": time.Since(start).String(),
+	}).Info("Successfully fetched pods on node")
+
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{&mcp.TextContent{Text: string(jsonData)}},
+	}, PodsOnNodeOutput{}, nil
+}

--- a/mcp-server/tools/tier1_tools_test.go
+++ b/mcp-server/tools/tier1_tools_test.go
@@ -22,7 +22,7 @@ func TestBrokerClient_GetAuditVerdicts_BuildsQueryString(t *testing.T) {
 	defer srv.Close()
 
 	c := NewBrokerClient(srv.URL)
-	_, err := c.GetAuditVerdicts(context.Background(), "web-deny", "prod", "WouldDeny", "Egress", 50)
+	_, err := c.GetAuditVerdicts(context.Background(), "web-deny", "prod", "WouldDeny", "Egress", 50, false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -56,11 +56,39 @@ func TestBrokerClient_GetAuditVerdicts_OmitsEmptyAndZero(t *testing.T) {
 	defer srv.Close()
 
 	c := NewBrokerClient(srv.URL)
-	if _, err := c.GetAuditVerdicts(context.Background(), "", "", "", "", 0); err != nil {
+	if _, err := c.GetAuditVerdicts(context.Background(), "", "", "", "", 0, false); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if rawQuery != "" {
 		t.Errorf("expected no query string, got %q", rawQuery)
+	}
+}
+
+// TestBrokerClient_GetAuditVerdicts_ClusterScoped pins that clusterScoped=true
+// sends namespace= (empty value PRESENT, not absent), which the broker reads as
+// "cluster-scoped policy verdicts only". A bare empty namespace string can't
+// express this — it would be omitted — so the dedicated flag is the only way to
+// reach the broker's cluster-scoped filter.
+func TestBrokerClient_GetAuditVerdicts_ClusterScoped(t *testing.T) {
+	var rawQuery string
+	var gotQuery url.Values
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rawQuery = r.URL.RawQuery
+		gotQuery = r.URL.Query()
+		_, _ = w.Write([]byte("[]"))
+	}))
+	defer srv.Close()
+
+	c := NewBrokerClient(srv.URL)
+	// namespace="prod" is provided but clusterScoped=true must take precedence.
+	if _, err := c.GetAuditVerdicts(context.Background(), "", "prod", "", "", 0, true); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(rawQuery, "namespace=") {
+		t.Errorf("expected namespace= (empty value present) in query, got %q", rawQuery)
+	}
+	if ns, ok := gotQuery["namespace"]; !ok || len(ns) != 1 || ns[0] != "" {
+		t.Errorf("expected namespace present with empty value, got %v", gotQuery["namespace"])
 	}
 }
 

--- a/mcp-server/tools/tier1_tools_test.go
+++ b/mcp-server/tools/tier1_tools_test.go
@@ -1,0 +1,213 @@
+package tools
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+// TestBrokerClient_GetAuditVerdicts_BuildsQueryString pins that every
+// supplied filter is forwarded as a query parameter to /audit/verdicts.
+func TestBrokerClient_GetAuditVerdicts_BuildsQueryString(t *testing.T) {
+	var gotQuery url.Values
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotQuery = r.URL.Query()
+		_, _ = w.Write([]byte("[]"))
+	}))
+	defer srv.Close()
+
+	c := NewBrokerClient(srv.URL)
+	_, err := c.GetAuditVerdicts(context.Background(), "web-deny", "prod", "WouldDeny", "Egress", 50)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotPath != "/audit/verdicts" {
+		t.Errorf("path: want /audit/verdicts, got %s", gotPath)
+	}
+	want := map[string]string{
+		"policy":    "web-deny",
+		"namespace": "prod",
+		"verdict":   "WouldDeny",
+		"direction": "Egress",
+		"limit":     "50",
+	}
+	for k, v := range want {
+		if got := gotQuery.Get(k); got != v {
+			t.Errorf("query %s: want %q, got %q", k, v, got)
+		}
+	}
+}
+
+// TestBrokerClient_GetAuditVerdicts_OmitsEmptyAndZero pins that empty
+// filters and a zero limit are not sent — the broker then applies its
+// documented defaults (no filter, default row cap) rather than seeing
+// empty-valued parameters.
+func TestBrokerClient_GetAuditVerdicts_OmitsEmptyAndZero(t *testing.T) {
+	var rawQuery string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rawQuery = r.URL.RawQuery
+		_, _ = w.Write([]byte("[]"))
+	}))
+	defer srv.Close()
+
+	c := NewBrokerClient(srv.URL)
+	if _, err := c.GetAuditVerdicts(context.Background(), "", "", "", "", 0); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rawQuery != "" {
+		t.Errorf("expected no query string, got %q", rawQuery)
+	}
+}
+
+// TestPodByNameHandler_EmptyPodNameRejected mirrors the other
+// name-required handlers: a blank pod_name short-circuits to IsError
+// without hitting the broker.
+func TestPodByNameHandler_EmptyPodNameRejected(t *testing.T) {
+	h := PodByNameHandler{client: NewBrokerClient("http://unused")}
+	res, _, _ := h.Call(context.Background(), nil, PodByNameInput{PodName: ""})
+	if !res.IsError {
+		t.Fatalf("expected IsError for empty pod_name")
+	}
+}
+
+// TestPodByNameHandler_StripsPodObj pins that get_pod_details_by_name
+// strips the heavyweight pod_obj like get_pod_details does, while
+// keeping identity fields.
+func TestPodByNameHandler_StripsPodObj(t *testing.T) {
+	c, cleanup := newBrokerWithJSON(t, `{
+		"pod_name":"web-1",
+		"pod_namespace":"prod",
+		"pod_ip":"10.0.0.1",
+		"workload_selector_labels":{"app":"web"},
+		"pod_obj":{"spec":{"containers":[{"name":"app","image":"nginx"}]}}
+	}`)
+	defer cleanup()
+	h := PodByNameHandler{client: c}
+	res, _, _ := h.Call(context.Background(), nil, PodByNameInput{PodName: "web-1"})
+	if res.IsError {
+		t.Fatalf("unexpected error: %s", textOf(t, res))
+	}
+	body := textOf(t, res)
+	if strings.Contains(body, "pod_obj") {
+		t.Errorf("pod_obj must be stripped; got: %s", body)
+	}
+	if !strings.Contains(body, "web-1") || !strings.Contains(body, `"app":"web"`) {
+		t.Errorf("identity fields lost: %s", body)
+	}
+}
+
+// TestPodsOnNodeHandler pins node-scoped pod listing: empty-node rejection,
+// and that the result is live-only with pod_obj stripped.
+func TestPodsOnNodeHandler(t *testing.T) {
+	reject := PodsOnNodeHandler{client: NewBrokerClient("http://unused")}
+	if res, _, _ := reject.Call(context.Background(), nil, PodsOnNodeInput{Node: ""}); !res.IsError {
+		t.Fatalf("expected IsError for empty node")
+	}
+
+	c, cleanup := newBrokerWithJSON(t, `[
+		{"pod_name":"web-1","pod_namespace":"prod","node_name":"node-a","is_dead":false,"pod_obj":{"spec":{"containers":[]}}},
+		{"pod_name":"old-1","pod_namespace":"prod","node_name":"node-a","is_dead":true}
+	]`)
+	defer cleanup()
+	res, _, _ := PodsOnNodeHandler{client: c}.Call(context.Background(), nil, PodsOnNodeInput{Node: "node-a"})
+	if res.IsError {
+		t.Fatalf("unexpected error: %s", textOf(t, res))
+	}
+	body := textOf(t, res)
+	if strings.Contains(body, "pod_obj") {
+		t.Errorf("pod_obj must be stripped; got: %s", body)
+	}
+	if !strings.Contains(body, "web-1") || strings.Contains(body, "old-1") {
+		t.Errorf("expected live web-1, dead old-1 filtered; got: %s", body)
+	}
+}
+
+// TestClusterServicesHandler_CompactsAndFiltersNamespace pins that
+// list_services strips the full service_spec down to selector+ports
+// and honours the optional namespace filter.
+func TestClusterServicesHandler_CompactsAndFiltersNamespace(t *testing.T) {
+	c, cleanup := newBrokerWithJSON(t, `[
+		{"svc_name":"web","svc_namespace":"prod","svc_ip":"10.96.0.1","service_spec":{"spec":{"selector":{"app":"web"},"ports":[{"port":80}],"type":"ClusterIP"}}},
+		{"svc_name":"db","svc_namespace":"data","svc_ip":"10.96.0.2","service_spec":{"spec":{"selector":{"app":"db"},"ports":[{"port":5432}]}}}
+	]`)
+	defer cleanup()
+	h := ClusterServicesHandler{client: c}
+	res, _, _ := h.Call(context.Background(), nil, ClusterServicesInput{Namespace: "prod"})
+	if res.IsError {
+		t.Fatalf("unexpected error: %s", textOf(t, res))
+	}
+	body := textOf(t, res)
+	// Namespace filter keeps prod, drops data.
+	if !strings.Contains(body, "web") || strings.Contains(body, `"db"`) {
+		t.Errorf("namespace filter not applied; got: %s", body)
+	}
+	// Compaction: full service_spec wrapper stripped, selector lifted.
+	if strings.Contains(body, "service_spec") || strings.Contains(body, "ClusterIP") {
+		t.Errorf("service_spec must be stripped; got: %s", body)
+	}
+	if !strings.Contains(body, "service_selector") || !strings.Contains(body, "service_ports") {
+		t.Errorf("selector/ports must be lifted; got: %s", body)
+	}
+}
+
+// TestAuditVerdictsHandler_PassesThrough pins that get_audit_verdicts
+// returns the broker's verdict rows unmodified (no compaction).
+func TestAuditVerdictsHandler_PassesThrough(t *testing.T) {
+	c, cleanup := newBrokerWithJSON(t, `[
+		{"policy_name":"web-deny","src_pod":"web-1","dst_pod":"db-1","dst_port":5432,"protocol":"TCP","direction":"Egress","verdict":"WouldDeny","reason":"no rule permits this flow","observed_at":"2026-06-26T10:00:00"}
+	]`)
+	defer cleanup()
+	h := AuditVerdictsHandler{client: c}
+	res, _, _ := h.Call(context.Background(), nil, AuditVerdictsInput{Verdict: "WouldDeny"})
+	if res.IsError {
+		t.Fatalf("unexpected error: %s", textOf(t, res))
+	}
+	body := textOf(t, res)
+	for _, want := range []string{"web-deny", "WouldDeny", "no rule permits this flow", "5432"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("expected %q in response; got: %s", want, body)
+		}
+	}
+}
+
+// TestClusterTrafficHandler_CountsAllowAndDrop pins that the cluster-traffic
+// summary surfaces policy-decision counts (the "what's being dropped" signal),
+// both per-pod and as a cluster-wide total_drop_count.
+func TestClusterTrafficHandler_CountsAllowAndDrop(t *testing.T) {
+	c, cleanup := newBrokerWithJSON(t, `[
+		{"pod_name":"web-1","traffic_type":"EGRESS","traffic_in_out_ip":"8.8.8.8","decision":"ALLOW"},
+		{"pod_name":"web-1","traffic_type":"EGRESS","traffic_in_out_ip":"9.9.9.9","decision":"DROP"},
+		{"pod_name":"web-1","traffic_type":"INGRESS","traffic_in_out_ip":"10.0.0.5","decision":"DROP"}
+	]`)
+	defer cleanup()
+	h := ClusterTrafficHandler{client: c}
+	res, _, _ := h.Call(context.Background(), nil, ClusterTrafficInput{})
+	if res.IsError {
+		t.Fatalf("unexpected error: %s", textOf(t, res))
+	}
+	body := textOf(t, res)
+	for _, want := range []string{`"total_drop_count":2`, `"drop_count":2`, `"allow_count":1`} {
+		if !strings.Contains(body, want) {
+			t.Errorf("expected %s in summary; got: %s", want, body)
+		}
+	}
+}
+
+// TestAuditVerdictsHandler_BrokerErrorBecomesIsError pins that an
+// upstream broker failure surfaces as a tool error, not a panic.
+func TestAuditVerdictsHandler_BrokerErrorBecomesIsError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+	h := AuditVerdictsHandler{client: NewBrokerClient(srv.URL)}
+	res, _, _ := h.Call(context.Background(), nil, AuditVerdictsInput{})
+	if !res.IsError {
+		t.Fatalf("expected IsError on broker 500")
+	}
+}


### PR DESCRIPTION
## Summary

End-to-end uplift of kguardian's AI / MCP integration so the in-cluster assistant can answer the full range of service, network, and Kubernetes-security questions from captured telemetry — plus four architecture-review refactors that harden the data path the assistant stands on.

Everything is validated with real test output (below) and deployable in-cluster (Helm + image CI wired). The only thing not verifiable locally is the actual `docker build` of the advisor image (runs in CI).

## What's in it

**Assistant data coverage (mcp-server)** — new tools: `get_pod_details_by_name`, `list_services`, `get_pods_on_node` (blast radius), `get_audit_verdicts` (Allow/WouldDeny), drop-count signal on `get_cluster_traffic`, plus deterministic `generate_network_policy` / `generate_seccomp_profile` that proxy to the advisor. Heavyweight `pod_obj`/`service_spec` stripped from summaries.

**LLM bridge** — rewritten on the official `@anthropic-ai/sdk` (`claude-opus-4-8`): prompt caching (cache_control on the system block, caches tools+system), adaptive summarized thinking + SSE streaming with client-disconnect abort, typed error + refusal handling. The MCP server is the single source of truth for tools — the static fallback is gone and discovery failure fails clearly instead of answering ungrounded.

**Frontend** — streaming assistant: incremental text + thinking, live tool activity, copy-able code blocks, AbortController cancel on unmount/close/resend.

**Advisor** — `advisor serve` HTTP mode (`/generate/networkpolicy`, `/generate/seccomp`, `/healthz`, graceful shutdown), a hardened broker client (PathEscape, LimitReader, timeout, bearer auth), and dependency-injected `BrokerData` so the policy generators no longer reach package globals.

**Deploy** — advisor chart templates (gated on `advisor.enabled`), mcp-server `ADVISOR_URL`, broker NetworkPolicy ingress for the advisor, and `advisor-image-release.yaml` building/pushing the advisor image on `advisor/v*` tags.

## Architecture-review refactors

- **#5** advisor generators + `PolicyService` take an injected `network.BrokerData` (peer resolution decoupled from package globals; default bridges to the api accessors, tests/CLI unchanged).
- **#6** broker compacts `pod_obj`/`service_spec` at **write** time (keep labels / spec), so the bulk never reaches storage; no migration, no semantic change.
- **#7** broker ingest uses a **bounded** audit queue + dispatcher with load-shedding (`broker_audit_dropped_total`) instead of spawning a task per flow — bounded memory, capture never back-pressured.
- **#10** llm-bridge has no static tool fallback; the MCP server is the single source of truth.

## Validation (run on this branch)

| Component | Result |
|---|---|
| broker (Rust) | build OK · **87/87** tests (serial) · clippy 0 issues |
| advisor (Go) | build + vet OK · all pkgs pass |
| mcp-server (Go) | build + vet OK · tools pass |
| llm-bridge (TS) | **59/59** tests · lint · build |
| frontend (TS) | lint · build |
| helm | lint 0 failed · template (advisor + netpol) OK |

Broker tests are run with `--test-threads=1`: the parallel run trips a **pre-existing** `conn::tests` env-race on `DATABASE_URL` in code this PR doesn't touch.

## Known follow-ups (non-blocking)

- Time-range (`since`/`until`) filters on `get_audit_verdicts` / traffic need a broker `/audit/verdicts` change (currently `limit`-only).
- `advisor.enabled` defaults to **false**; the advisor image publishes on the next `advisor/v*` release (or workflow_dispatch on the existing tag).
