### PR TITLE
fix(advisor): embed version info via correct ldflag targets

### DIFF
--- a/.github/workflows/advisor-release.yml
+++ b/.github/workflows/advisor-release.yml
@@ -58,12 +58,15 @@ jobs:
         os: [linux, darwin]
         arch: [amd64, arm64]
     env:
+      # Sourced as env (not interpolated into run: scripts) to avoid workflow
+      # injection — these come from the release payload.
       TAG: ${{ github.event.release.tag_name || inputs.tag }}
+      TARGET_REF: ${{ github.event.release.target_commitish || inputs.tag }}
     steps:
       - id: meta
         run: |
           echo "version=${TAG#advisor/v}" >> "$GITHUB_OUTPUT"
-          echo "ref=${{ github.event.release.target_commitish || inputs.tag }}" >> "$GITHUB_OUTPUT"
+          echo "ref=${TARGET_REF}" >> "$GITHUB_OUTPUT"
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ steps.meta.outputs.ref }}
@@ -82,14 +85,12 @@ jobs:
         run: |
           BIN="advisor-${GOOS}-${GOARCH}"
           COMMIT="$(git rev-parse HEAD)"
-          COMMIT_DATE="$(git log --date=iso8601-strict -1 --pretty=%ct)"
-          if git diff --quiet; then TREE_STATE=clean; else TREE_STATE=dirty; fi
+          COMMIT_DATE="$(git log -1 --pretty=%cI)"
           go build -trimpath -tags=netgo \
             -ldflags "-s -w \
-              -X main.Version=${VERSION} \
-              -X main.Commit=${COMMIT} \
-              -X main.CommitDate=${COMMIT_DATE} \
-              -X main.TreeState=${TREE_STATE} \
+              -X github.com/kguardian-dev/kguardian/advisor/cmd.Version=${VERSION} \
+              -X github.com/kguardian-dev/kguardian/advisor/cmd.GitCommit=${COMMIT} \
+              -X github.com/kguardian-dev/kguardian/advisor/cmd.BuildDate=${COMMIT_DATE} \
               -X github.com/kguardian-dev/kguardian/advisor/pkg/k8s.Version=${VERSION}" \
             -o "../${BIN}" .
           echo "binary=${BIN}" >> "$GITHUB_OUTPUT"

--- a/advisor/Dockerfile
+++ b/advisor/Dockerfile
@@ -26,8 +26,8 @@ COPY . .
 
 RUN go build -a -installsuffix cgo \
   -ldflags="-w -extldflags '-static' \
-  -X 'main.ApplicationName=${APPLICATION_NAME}' \
-  -X 'main.Version=${VERSION}' -X 'main.SHA=${SHA}' \
+  -X 'github.com/kguardian-dev/kguardian/advisor/cmd.Version=${VERSION}' \
+  -X 'github.com/kguardian-dev/kguardian/advisor/cmd.GitCommit=${SHA}' \
   -X 'github.com/kguardian-dev/kguardian/advisor/pkg/k8s.Version=${VERSION}'" \
   -o advisor .
 


### PR DESCRIPTION
`advisor version` always reported `development`/`unknown` because the build ldflags targeted non-existent vars (`main.Version`, `main.Commit`, `main.SHA`, `main.ApplicationName`). The version command reads `cmd.Version`/`cmd.GitCommit`/`cmd.BuildDate`. This points the ldflags (image `Dockerfile` + the new binary release workflow) at those real symbols.

Verified locally — a build with the corrected `-X` targets reports the injected version/commit/date instead of the defaults:
```
Client Version:
  Version:    v1.5.1-test
  Git Commit: abc1234
  Build Date: 2026-06-30
```

Also hardens the release workflow: release-payload fields (`tag_name`, `target_commitish`) are now sourced via `env:` rather than interpolated into `run:` scripts.

Doubles as the first real change to cut an advisor patch (v1.5.1) that exercises the new immutable-compatible release flow from #1010.