### PR TITLE
fix(ci): trigger advisor binary build from release-please (draft has no tag)

### DIFF
--- a/.github/workflows/advisor-release.yml
+++ b/.github/workflows/advisor-release.yml
@@ -36,6 +36,13 @@ on:
         description: "Release tag to (re)build, e.g. advisor/v1.5.1"
         required: true
         type: string
+      sha:
+        description: "Commit SHA to build (the draft release's target — a draft has no git tag yet)"
+        required: true
+        type: string
+  # Secondary path. Primary trigger is a dispatch from release-please.yaml: a
+  # draft pushes no git tag, and release-please's PAT-created release does not
+  # reliably fire `release` to workflows.
   release:
     types: [created]
 
@@ -61,7 +68,7 @@ jobs:
       # Sourced as env (not interpolated into run: scripts) to avoid workflow
       # injection — these come from the release payload.
       TAG: ${{ github.event.release.tag_name || inputs.tag }}
-      TARGET_REF: ${{ github.event.release.target_commitish || inputs.tag }}
+      TARGET_REF: ${{ github.event.release.target_commitish || inputs.sha }}
     steps:
       - id: meta
         run: |

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -22,3 +22,31 @@ jobs:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
           token: ${{ secrets.KGUARDIAN_PAT }}
+
+  # The advisor release is created as a DRAFT (release-please-config draft:true)
+  # so its binaries + provenance can be attached before it becomes immutable. A
+  # draft pushes no git tag and release-please's PAT-created release does not
+  # reliably fire a `release` event to workflows, so this job is the reliable
+  # trigger: it finds a pending advisor draft (no assets yet) and dispatches the
+  # binary build for its target commit. Idempotent — no-op once assets exist.
+  advisor-binary:
+    needs: release-please
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # view draft releases (drafts need push-level visibility)
+      actions: write # dispatch advisor-release.yml
+    steps:
+      - name: Dispatch advisor binary build for a pending draft release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          tag=$(gh release list --repo "$REPO" --json tagName,isDraft \
+            -q 'map(select(.isDraft and (.tagName|startswith("advisor/"))))|.[0].tagName // ""')
+          if [ -z "$tag" ]; then echo "no pending advisor draft release"; exit 0; fi
+          assets=$(gh release view "$tag" --repo "$REPO" --json assets -q '[.assets[]]|length')
+          if [ "$assets" -gt 0 ]; then echo "$tag already has assets; nothing to do"; exit 0; fi
+          sha=$(gh release view "$tag" --repo "$REPO" --json targetCommitish -q '.targetCommitish')
+          echo "dispatching advisor binary build for $tag @ $sha"
+          gh workflow run advisor-release.yml -f tag="$tag" -f sha="$sha" --repo "$REPO"


### PR DESCRIPTION
Follow-up to #1010. Running the v1.5.1 release surfaced that the binary build never triggered: the advisor release is a **draft** (so assets attach before immutability), but a draft pushes **no git tag**, and release-please's PAT-created release does **not** reliably fire a `release` event to workflows — so v1.5.1 sat as an empty draft.

Fix: `release-please.yaml` now reliably kicks it — after release-please runs, an `advisor-binary` job finds a pending advisor draft (no assets) and dispatches `advisor-release.yml` with the draft's target SHA (a draft has no tag to check out). `advisor-release.yml` gains a `sha` dispatch input. Idempotent — no-op once the release has assets.

Validated by re-running release-please against the existing v1.5.1 draft after merge.