### PR TITLE
fix(llm-bridge): harden AI streaming — resilience + error correctness

### DIFF
--- a/llm-bridge/src/index.ts
+++ b/llm-bridge/src/index.ts
@@ -168,6 +168,19 @@ app.post("/api/chat", chatLimiter, async (req: Request, res: Response<any>) => {
 
     if (error instanceof Error) {
       log.error("Chat error details:", error.message, error.stack);
+      // Surface upstream rate-limit / overload as matching statuses so the
+      // client can back off, instead of an opaque 500 it can't act on.
+      const status = (error as { status?: number }).status;
+      if (status === 429) {
+        return res.status(429).json({
+          error: "The AI provider is rate-limiting requests right now. Please retry in a few seconds.",
+        } as ErrorResponse);
+      }
+      if (status === 529 || status === 503) {
+        return res.status(503).json({
+          error: "The AI provider is temporarily overloaded. Please retry in a few seconds.",
+        } as ErrorResponse);
+      }
       return res.status(500).json({
         error: "An internal error occurred while processing the chat request",
       } as ErrorResponse);
@@ -225,6 +238,15 @@ app.post("/api/chat/stream", chatLimiter, async (req: Request, res: Response) =>
   const abort = new AbortController();
   res.on("close", () => abort.abort());
 
+  // SSE keepalive. During a tool round no events flow for the whole MCP
+  // round-trip; an idle intermediary (nginx ingress default proxy-read-timeout
+  // is 60s) would close the connection and break the stream. A periodic comment
+  // ping keeps it alive — comments (lines starting ":") are ignored by the
+  // EventSource client and don't affect the event data.
+  const heartbeat = setInterval(() => {
+    if (!res.writableEnded) res.write(": ping\n\n");
+  }, 15000);
+
   log.debug(`Processing streaming chat request with provider: ${provider}`);
 
   try {
@@ -238,7 +260,18 @@ app.post("/api/chat/stream", chatLimiter, async (req: Request, res: Response) =>
       emit({ type: "done", model: response.model, conversationId: response.conversationId });
     }
   } catch (error) {
-    const detail = error instanceof Error ? error.message : "An internal error occurred";
+    // Map upstream rate-limit / overload to a clear, actionable message rather
+    // than leaking a raw SDK string. A client disconnect does NOT reach here —
+    // streamAnthropic returns cleanly on abort.
+    const status = (error as { status?: number })?.status;
+    const detail =
+      status === 429
+        ? "The AI provider is rate-limiting requests right now. Please retry in a few seconds."
+        : status === 529 || status === 503
+          ? "The AI provider is temporarily overloaded. Please retry in a few seconds."
+          : error instanceof Error
+            ? error.message
+            : "An internal error occurred";
     log.error("Streaming chat error:", detail);
     // Headers are already sent, so surface the failure over SSE rather than
     // as an HTTP status. Guard the write in case the client already closed.
@@ -246,6 +279,7 @@ app.post("/api/chat/stream", chatLimiter, async (req: Request, res: Response) =>
       emit({ type: "error", error: detail });
     }
   } finally {
+    clearInterval(heartbeat);
     res.end();
   }
 });

--- a/llm-bridge/src/providers/anthropic.ts
+++ b/llm-bridge/src/providers/anthropic.ts
@@ -93,6 +93,33 @@ function toolUsesOf(message: Anthropic.Message): Anthropic.ToolUseBlock[] {
   );
 }
 
+/** Join the text blocks of a completed message into the answer string. */
+function textOf(message: Anthropic.Message): string {
+  return message.content
+    .filter((block): block is Anthropic.TextBlock => block.type === "text")
+    .map((block) => block.text)
+    .join("\n")
+    .trim();
+}
+
+/**
+ * Human-readable stand-in when a completed message carries no usable text.
+ * A `refusal` stop_reason streams empty content (no text_delta), so without
+ * this the user would get a blank answer; `max_tokens` means the answer was
+ * cut off mid-generation. Shared by the streaming and non-streaming paths so
+ * both explain the outcome instead of returning nothing.
+ */
+function fallbackFor(message: Anthropic.Message): string {
+  switch (message.stop_reason) {
+    case "refusal":
+      return "I can't help with that request.";
+    case "max_tokens":
+      return "The response was cut off because it hit the length limit. Please narrow the question or ask for a shorter answer.";
+    default:
+      return "No response from Claude";
+  }
+}
+
 /**
  * Execute the model's tool calls via the broker/MCP client and build the
  * tool_result blocks to feed back. Pushes the assistant turn (verbatim, so
@@ -127,6 +154,11 @@ async function runToolRound(
         type: "tool_result" as const,
         tool_use_id: toolUse.id,
         content: serializeToolResult(result),
+        // Flag failures so the model treats them as errors rather than data.
+        // serializeToolResult renders a failure as plain "Error: ..." text,
+        // which the model can otherwise mistake for a legitimate result and
+        // answer from — set is_error so it knows the call failed.
+        ...(result.error ? { is_error: true } : {}),
       };
     }),
   );
@@ -233,15 +265,30 @@ export async function streamAnthropic(
   };
 
   for (let round = 0; round < MAX_TOOL_ROUNDS; round++) {
+    // Client disconnected between rounds — stop before doing (or paying for)
+    // more model/tool work. Returning cleanly (not throwing) keeps a normal
+    // disconnect out of the transport's error path.
+    if (signal?.aborted) return;
+
     let message: Anthropic.Message;
     try {
       message = await runStream(true);
     } catch (error) {
+      // An abort mid-stream throws from the SDK; that's a normal disconnect,
+      // not a failure to surface to the user.
+      if (signal?.aborted) return;
       throw toCleanError(error);
     }
 
     const toolUses = toolUsesOf(message);
     if (toolUses.length === 0) {
+      // If the model produced no text (a `refusal` streams empty content, so
+      // no text_delta fired), the client would get `done` with a blank answer.
+      // Emit the explanatory fallback so the user always sees something. Text
+      // that WAS produced already streamed incrementally above.
+      if (!textOf(message)) {
+        emit({ type: "text", delta: fallbackFor(message) });
+      }
       emit({ type: "done", model: message.model, conversationId: request.conversationId });
       return;
     }
@@ -249,11 +296,16 @@ export async function streamAnthropic(
   }
 
   // Max rounds reached — final pass without tools.
+  if (signal?.aborted) return;
   let finalMessage: Anthropic.Message;
   try {
     finalMessage = await runStream(false);
   } catch (error) {
+    if (signal?.aborted) return;
     throw toCleanError(error);
+  }
+  if (!textOf(finalMessage)) {
+    emit({ type: "text", delta: fallbackFor(finalMessage) });
   }
   emit({ type: "done", model: finalMessage.model, conversationId: request.conversationId });
 }
@@ -264,31 +316,33 @@ export async function streamAnthropic(
 
 /** Extract the text answer from a completed message into the wire contract. */
 function finalize(message: Anthropic.Message, request: ChatRequest): ChatResponse {
-  const text = message.content
-    .filter((block): block is Anthropic.TextBlock => block.type === "text")
-    .map((block) => block.text)
-    .join("\n")
-    .trim();
-
-  const fallback =
-    message.stop_reason === "refusal"
-      ? "I can't help with that request."
-      : "No response from Claude";
-
   return {
-    message: text || fallback,
+    message: textOf(message) || fallbackFor(message),
     provider: LLMProvider.ANTHROPIC,
     model: message.model,
     conversationId: request.conversationId,
   };
 }
 
+/**
+ * An Error that carries the upstream provider HTTP status so the transport can
+ * map it (429 rate-limit / 529 overload) instead of collapsing everything to a
+ * generic 500. `status` is undefined for non-API (network/other) errors.
+ */
+export interface ProviderError extends Error {
+  status?: number;
+}
+
 /** Normalise SDK/transport errors into a single Error with a clean message. */
-function toCleanError(error: unknown): Error {
+function toCleanError(error: unknown): ProviderError {
   if (error instanceof Anthropic.APIError) {
     const detail = error.message || `status ${error.status}`;
     log.error("Anthropic API Error:", detail);
-    return new Error(`Anthropic API error: ${detail}`, { cause: error });
+    const clean: ProviderError = new Error(`Anthropic API error: ${detail}`, { cause: error });
+    // Preserve the upstream status (429/529/5xx) so the HTTP layer can return a
+    // matching status + retry hint rather than an opaque 500.
+    clean.status = error.status;
+    return clean;
   }
   const detail = error instanceof Error ? error.message : String(error);
   log.error("Anthropic request failed:", detail);


### PR DESCRIPTION
Part of the AI + MCP integration audit. Five verified fixes to how the assistant fails, all no-op on the happy path.

| # | Fix | Failure it removes |
|---|---|---|
| 1 | **SSE heartbeat** (`:ping` while a tool round runs) | A slow MCP call (>~60s) let an idle nginx ingress close the stream → frontend hangs. |
| 2 | **Refusal/empty fallback** on the streaming path | `refusal` streams empty content → client got `done` with a **blank** answer and no explanation. Now mirrors the non-streaming path; also explains `max_tokens` truncation. |
| 3 | **Clean disconnect handling** | Abort was passed to the model stream but not checked between tool rounds; a mid-round disconnect kept doing work and logged the AbortError as a real error. Now returns cleanly. |
| 4 | **`is_error` on failed tool_result** | Tool failures rendered as `"Error: …"` text the model could mistake for data and answer from. Now flagged so the model knows the call failed. |
| 5 | **429/529 mapping** | Provider rate-limit/overload collapsed to an opaque 500; the client couldn't back off. Now maps to 429/503 (+ clear SSE error) with a retry hint. |

### Deferred (noted in the audit, separate PRs)
- Prompt-cache breakpoint split (volatile namespace/pod context is currently baked into the cached block, hurting cache hit-rate) — efficiency, needs cache-metric validation.
- Streaming vs non-streaming thinking asymmetry (likely intentional to avoid the non-streaming timeout).
- Rate-limiter `trust proxy` keying (all users currently share one bucket behind the ingress).

### Validation
`tsc` typecheck, `eslint`, full test suite — **59 pass**.