### PR TITLE
fix(advisor): seccomp generation on ARM nodes (architectures was null)

### DIFF
--- a/advisor/cmd/serve.go
+++ b/advisor/cmd/serve.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"os"
 	"os/signal"
@@ -162,6 +163,15 @@ func handleSeccompGenerate(w http.ResponseWriter, r *http.Request) {
 	}
 
 	profile := k8s.BuildSeccompProfile(syscalls.Syscalls, syscalls.Arch, "SCMP_ACT_ERRNO")
+	// Never hand back a structurally-invalid profile. An unrecognised arch
+	// yields empty Architectures ("architectures": null), which is unusable —
+	// the CLI's file-writing path validates, so the serve path must too, or the
+	// MCP generate_seccomp_profile tool silently returns a broken profile.
+	if err := k8s.ValidateProfile(profile); err != nil {
+		log.Warn().Err(err).Str("arch", syscalls.Arch).Msgf("serve: invalid seccomp profile for pod %s", pod)
+		writeJSONError(w, http.StatusUnprocessableEntity, fmt.Sprintf("generated seccomp profile is invalid: %v", err))
+		return
+	}
 	body, err := json.MarshalIndent(profile, "", "    ")
 	if err != nil {
 		writeJSONError(w, http.StatusInternalServerError, "failed to marshal seccomp profile")

--- a/advisor/pkg/k8s/seccomp.go
+++ b/advisor/pkg/k8s/seccomp.go
@@ -40,9 +40,14 @@ var ValidSeccompActions = []string{"SCMP_ACT_ERRNO", "SCMP_ACT_KILL", "SCMP_ACT_
 // controller) to the seccomp arch tokens. Exported so callers that build a
 // profile outside the file-writing GenerateSeccompProfile path (e.g. the
 // `serve` HTTP API) reuse the same mapping rather than duplicating it.
+// Keys MUST match the arch string the controller records, which is Rust's
+// std::env::consts::ARCH (controller/src/syscall.rs) — i.e. "x86_64" or
+// "aarch64". The previous "ARM64" key never matched anything the controller
+// writes, so on ARM/aarch64 nodes the lookup missed and the generated profile
+// had "architectures": null — a structurally invalid, unusable seccomp profile.
 var SeccompArchitectures = map[string][]string{
-	"x86_64": {"SCMP_ARCH_X86_64"},
-	"ARM64":  {"SCMP_ARCH_ARM64"},
+	"x86_64":  {"SCMP_ARCH_X86_64"},
+	"aarch64": {"SCMP_ARCH_ARM64"},
 }
 
 // BuildSeccompProfile constructs a SeccompProfile that allow-lists exactly the

--- a/advisor/pkg/k8s/seccomp_test.go
+++ b/advisor/pkg/k8s/seccomp_test.go
@@ -111,6 +111,23 @@ func TestValidateProfile_EmptyArchitectureSlice(t *testing.T) {
 	assert.Error(t, err)
 }
 
+// BuildSeccompProfile must map the arch strings the controller actually
+// records — Rust's std::env::consts::ARCH: "x86_64" / "aarch64"
+// (controller/src/syscall.rs). A regression here reintroduces the bug where
+// the map keyed on the never-written "ARM64", so ARM nodes got a profile with
+// "architectures": null that ValidateProfile rejects.
+func TestBuildSeccompProfile_MapsControllerArchStrings(t *testing.T) {
+	cases := map[string]string{
+		"x86_64":  "SCMP_ARCH_X86_64",
+		"aarch64": "SCMP_ARCH_ARM64",
+	}
+	for arch, want := range cases {
+		profile := BuildSeccompProfile([]string{"read", "write"}, arch, "SCMP_ACT_ERRNO")
+		assert.Equal(t, []string{want}, profile.Architectures, "arch %q should map to %q", arch, want)
+		assert.NoError(t, ValidateProfile(profile), "arch %q should produce a valid profile", arch)
+	}
+}
+
 // MergeSyscalls deduplicates the union of multiple syscall lists.
 // Order of the output is map-iteration-order (non-deterministic), so
 // tests compare against sorted slices.


### PR DESCRIPTION
Found by the AI + MCP integration audit (the `generate_seccomp_profile` MCP tool).

## Bug
`SeccompArchitectures` keyed on `"ARM64"`, but the controller records the arch as Rust's `std::env::consts::ARCH` (`controller/src/syscall.rs:115`) — `"x86_64"` or **`"aarch64"`**, never `"ARM64"`. So on ARM/aarch64 nodes the map lookup missed → `Architectures: nil` → the profile serialized `"architectures": null`, which is structurally invalid and unusable. `x86_64` worked only by luck. Realistic on ARM homelab / Raspberry Pi clusters.

Compounding it: `serve.go handleSeccompGenerate` (the path the MCP tool proxies to) never called `ValidateProfile`, so the broken profile was returned silently — the CLI's file-writing path *does* validate.

## Fix
- Key the arch map on `"aarch64"` (what the controller actually writes).
- `serve.go` now calls `ValidateProfile` before returning — an unrecognised arch yields a clear `422` instead of a silently-broken profile.
- Regression test pinning both `x86_64` and `aarch64` → non-empty, valid profile.

## Validation
`gofmt`, `go build ./...`, `go vet`, full advisor test suite — all green (incl. the new `TestBuildSeccompProfile_MapsControllerArchStrings`).

## Related audit follow-ups (separate PRs)
- mcp-server: `structuredContent` permanently empty on all 12 tools (MCP spec compliance).
- broker 404 → tool `IsError` for legitimately-empty lookups (both mcp-server + advisor reviewers).
- Empty-syscalls `[""]` guard; distinguish broker 5xx from 404 in policy-gen.