### PR TITLE
chore(broker): use Option::filter to satisfy clippy manual_filter lint

### DIFF
--- a/broker/src/get.rs
+++ b/broker/src/get.rs
@@ -425,7 +425,7 @@ pub(crate) fn clamp_audit_limit(raw: Option<i64>) -> i64 {
 /// `policy_namespace = ''`), so empty-namespace stays as an explicit
 /// filter. See the doc comment on `policy_ns` in the handler.
 pub(crate) fn normalise_empty_to_none(raw: Option<String>) -> Option<String> {
-    raw.and_then(|s| if s.is_empty() { None } else { Some(s) })
+    raw.filter(|s| !s.is_empty())
 }
 
 /// Whitelist of valid verdict values. Anything else is rejected with


### PR DESCRIPTION
Rust 1.97 stabilized the `manual_filter` clippy lint. `normalise_empty_to_none` in `broker/src/get.rs` now trips it, and since CI runs clippy with `-D warnings`, every PR touching broker fails `test-broker` — including the open Renovate lockfile PRs (#1053, #1049).

One-line mechanical fix, behavior identical. Verified locally: `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test --all-features -- --test-threads=1` (113 passed).

https://claude.ai/code/session_011J74RqU1DjfqW3S1vyqKsh