### PR TITLE
chore(deps): update debian docker tag to v12.15

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -33,6 +33,19 @@
       "pinDigests": false,
     },
   ],
+  "customManagers": [
+    {
+      // Tracks Dockerfile ARGs annotated with "# renovate: datasource=... depName=..."
+      // (e.g. DEBIAN_VERSION in controller/Dockerfile, which the native docker
+      // manager cannot update through the ARG indirection).
+      "customType": "regex",
+      "managerFilePatterns": ["/(^|/)Dockerfile$/"],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>[a-z-]+) depName=(?<depName>\\S+)( versioning=(?<versioning>\\S+))?\\s*\\nARG \\S+=\"(?<currentValue>[^\"]+)\"",
+      ],
+      "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}docker{{/if}}",
+    },
+  ],
   "pre-commit": {
     "enabled": true
   },

--- a/broker/Dockerfile
+++ b/broker/Dockerfile
@@ -15,7 +15,7 @@ COPY db  /app/broker/db
 
 RUN --mount=type=cache,target=/usr/local/cargo/registry  cargo build --release
 
-FROM debian:bookworm-slim AS app
+FROM debian:12.15-slim AS app
 
 RUN apt update && apt install libpq5 -y
 

--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -1,4 +1,5 @@
-ARG DEBIAN_VERSION="12.9"
+# renovate: datasource=docker depName=debian
+ARG DEBIAN_VERSION="12.15"
 
 FROM --platform=$BUILDPLATFORM ubuntu:26.04 AS builder
 


### PR DESCRIPTION
Renovate could not create this update itself: the controller hides the version behind `ARG DEBIAN_VERSION` (its resolved `replaceString` never matches the file), and the broker used the unversioned `bookworm-slim` alias which the docker manager skips. Both were stuck as pending on the Dependency Dashboard.

- controller: `DEBIAN_VERSION` 12.9 → 12.15 (annotated with a `# renovate:` hint)
- broker: `bookworm-slim` → `12.15-slim` (pinned so Renovate can manage it)
- renovate.json5: customManager for annotated Dockerfile ARGs so future debian bumps arrive as normal PRs

The debian v13 (trixie) major is deliberately not included — that stays a manual-review decision.

https://claude.ai/code/session_01NGEYMBjENoxEcbcLBeUhKG