### PR TITLE
fix(charts): track chart release in appVersion and release on image bumps

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -20,6 +20,17 @@
   "platformAutomerge": true,
   "packageRules": [
     {
+      // Chart image-tag bumps must cut a chart release: release-please hides
+      // chore(deps) commits, so a chart published right before Renovate rolls
+      // the tags (e.g. chart 1.13.1 pinning broker 1.11.0 hours after 1.11.1
+      // shipped) stays stale until an unrelated fix lands. Typing these as
+      // fix(deps) makes every component-image bump produce a chart patch
+      // release automatically.
+      "description": "Chart image tag bumps are user-facing — release the chart",
+      "matchFileNames": ["charts/**"],
+      "semanticCommitType": "fix",
+    },
+    {
       // The SLSA generator's reusable workflows MUST be referenced by a version
       // tag (refs/tags/vX.Y.Z). The builder resolves its own ref to derive the
       // release version for provenance, so a commit SHA makes it fail with

--- a/charts/kguardian/Chart.yaml
+++ b/charts/kguardian/Chart.yaml
@@ -8,10 +8,9 @@ home: https://github.com/kguardian-dev/kguardian
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 version: 1.13.1
 
-# kguardian is multi-component (each image pins its own tag in values.yaml),
-# so appVersion tracks the chart release itself. Kept in sync by release-please
-# via the x-release-please-version annotation — do not edit by hand.
-appVersion: "1.13.1"  # x-release-please-version
+# appVersion is intentionally omitted: kguardian is multi-component and each
+# service pins its own image tag in values.yaml, so no single application
+# version exists. The chart `version` above is the only release identifier.
 kubeVersion: ">= 1.18.0-0"
 
 keywords:

--- a/charts/kguardian/Chart.yaml
+++ b/charts/kguardian/Chart.yaml
@@ -8,11 +8,10 @@ home: https://github.com/kguardian-dev/kguardian
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 version: 1.13.1
 
-# This is the version number of the application being deployed. This version number should be
-# incremented each time you make changes to the application. Versions are not expected to
-# follow Semantic Versioning. They should reflect the version the application is using.
-# It is recommended to use it with quotes.
-appVersion: "1.0.0"
+# kguardian is multi-component (each image pins its own tag in values.yaml),
+# so appVersion tracks the chart release itself. Kept in sync by release-please
+# via the x-release-please-version annotation — do not edit by hand.
+appVersion: "1.13.1" # x-release-please-version
 kubeVersion: ">= 1.18.0-0"
 
 keywords:

--- a/charts/kguardian/Chart.yaml
+++ b/charts/kguardian/Chart.yaml
@@ -11,7 +11,7 @@ version: 1.13.1
 # kguardian is multi-component (each image pins its own tag in values.yaml),
 # so appVersion tracks the chart release itself. Kept in sync by release-please
 # via the x-release-please-version annotation — do not edit by hand.
-appVersion: "1.13.1" # x-release-please-version
+appVersion: "1.13.1"  # x-release-please-version
 kubeVersion: ">= 1.18.0-0"
 
 keywords:

--- a/charts/kguardian/templates/NOTES.txt
+++ b/charts/kguardian/templates/NOTES.txt
@@ -1,4 +1,4 @@
-kguardian {{ .Chart.AppVersion }} installed in namespace "{{ .Release.Namespace }}".
+kguardian chart {{ .Chart.Version }} installed in namespace "{{ .Release.Namespace }}".
 
 {{- if .Values.database.enabled }}
 Database: in-cluster PostgreSQL {{ .Values.database.image.tag }}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -50,10 +50,7 @@
       "release-type": "helm",
       "package-name": "kguardian",
       "changelog-path": "CHANGELOG.md",
-      "include-component-in-tag": true,
-      "extra-files": [
-        "Chart.yaml"
-      ]
+      "include-component-in-tag": true
     },
     "llm-bridge": {
       "component": "llm-bridge",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -50,7 +50,10 @@
       "release-type": "helm",
       "package-name": "kguardian",
       "changelog-path": "CHANGELOG.md",
-      "include-component-in-tag": true
+      "include-component-in-tag": true,
+      "extra-files": [
+        "Chart.yaml"
+      ]
     },
     "llm-bridge": {
       "component": "llm-bridge",


### PR DESCRIPTION
The published chart went stale immediately after the 1.13.1 release: Renovate rolled the component image tags (broker 1.11.1, frontend 1.11.1, llm-bridge 1.4.1, advisor v1.6.1) as chore(deps) commits, which release-please hides, so no new chart release was cut and 1.13.1 still pins the previous versions.

- Renovate rule: bumps under charts/** are now fix(deps), so every component image bump cuts a chart patch release automatically
- Chart.yaml: drop appVersion entirely — kguardian is multi-component (each service pins its own tag in values.yaml), so no single application version exists; the chart version is the only release identifier. NOTES.txt now prints the chart version instead.

Merging this cuts chart 1.13.2 carrying the current image tags.

https://claude.ai/code/session_01NGEYMBjENoxEcbcLBeUhKG