### PR TITLE
feat(broker): anonymous daily version check-in and /version endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ It's built for platform and security teams who want policy-as-code without writi
 - [🤖 AI Assistant](#-ai-assistant)
 - [🧩 Compatibility](#-compatibility)
 - [📊 Performance](#-performance)
+- [📡 Telemetry](#-telemetry)
 - [🤝 Contributing](#-contributing)
 - [📄 License](#-license)
 
@@ -169,6 +170,10 @@ Reference figures from a real-world deployment — a 3-node cluster (18 vCPU / 4
 - **Storage growth is dedup-bounded:** once a workload's flow set is learned, new rows drop to ~0/min in steady state. The database grows with *new* behavior, not with time or traffic volume; `broker.audit.retention.days` caps the audit-verdict history.
 
 This is one measured data point, not a synthetic sweep — treat it as an order-of-magnitude envelope. Expect numbers to scale with flow cardinality, not raw pod count.
+
+## 📡 Telemetry
+
+The broker performs a daily anonymous version check-in that powers the UI's update notice and is the project's only usage signal. Exactly six fields are sent — a random install UUID, broker/chart/Kubernetes versions, node count, and CPU architecture; no cluster names, IPs, or workload data, ever. It's on by default, announced at install time, documented field-by-field in the [telemetry docs](https://docs.kguardian.dev/telemetry), and disabled with `--set telemetry.enabled=false`.
 
 ## 🤝 Contributing
 

--- a/broker/Cargo.lock
+++ b/broker/Cargo.lock
@@ -258,6 +258,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.17.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00bdb5da18dac48ca2cc7cd4a98e533e8635a58e2361d13a1a4ee3888e0d72f1"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.43.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43103168cc76fe62678a375e722fc9cb3a0146159ac5828bc4f0dfd755c2224c"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "pkg-config",
+]
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -366,6 +389,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
+
+[[package]]
 name = "chacha20"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -391,6 +420,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmake"
+version = "0.1.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7caa3f9de89ddbe2c607f4101924c5abec803763ae9534e4f4d7d8f84aa81f0"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -405,6 +453,16 @@ dependencies = [
  "percent-encoding",
  "time",
  "version_check",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -604,6 +662,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -668,6 +732,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
 name = "futures-channel"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -709,6 +779,19 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "wasi",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
@@ -726,11 +809,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi",
  "rand_core",
  "wasip2",
  "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -856,6 +941,21 @@ dependencies = [
  "smallvec",
  "tokio",
  "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http 1.4.0",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
 ]
 
 [[package]]
@@ -1050,6 +1150,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.108",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.108",
+]
+
+[[package]]
 name = "jobserver"
 version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1130,6 +1279,12 @@ name = "log"
 version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "matchers"
@@ -1226,6 +1381,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1318,6 +1479,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2 0.5.10",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
+dependencies = [
+ "aws-lc-rs",
+ "bytes",
+ "getrandom 0.4.1",
+ "lru-slab",
+ "rand",
+ "rand_pcg",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2 0.5.10",
+ "tracing",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1359,6 +1577,15 @@ name = "rand_core"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core",
+]
 
 [[package]]
 name = "redox_syscall"
@@ -1417,15 +1644,22 @@ dependencies = [
  "http-body",
  "http-body-util",
  "hyper",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
+ "serde_urlencoded",
  "sync_wrapper",
  "tokio",
+ "tokio-rustls",
  "tower",
  "tower-http",
  "tower-service",
@@ -1433,6 +1667,110 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
+dependencies = [
+ "aws-lc-rs",
+ "once_cell",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "aws-lc-rs",
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -1448,6 +1786,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "scheduled-thread-pool"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1461,6 +1817,29 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "3.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d17b898a6d6948c3a8ee4372c17cb384f90d2e6e912ef00895b14fd7ab54ec38"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "semver"
@@ -1574,6 +1953,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
 
 [[package]]
+name = "simd_cesu8"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "slab"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1616,6 +2011,12 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -1730,6 +2131,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1755,6 +2171,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.108",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
 ]
 
 [[package]]
@@ -1946,6 +2372,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1992,6 +2424,16 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
 
 [[package]]
 name = "want"
@@ -2126,6 +2568,34 @@ checksum = "3a1f95c0d03a47f4ae1f7a64643a6bb97465d9b740f0fa8f90ea33915c99a9a1"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2418,6 +2888,12 @@ dependencies = [
  "syn 2.0.108",
  "synstructure",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zerotrie"

--- a/broker/Cargo.toml
+++ b/broker/Cargo.toml
@@ -35,7 +35,10 @@ tracing = {version = "0.1.44", features = ['log']}
 chrono = { version = "0.4.43", features = ["serde"] }
 diesel_migrations = "2.1.0"
 tracing-subscriber = { version = "0.3.22", features = ["json", "env-filter"] }
-reqwest = { version = "0.13", default-features = false, features = ["json"] }
+# "rustls" (renamed from 0.12's "rustls-tls") adds the TLS backend for the
+# outbound HTTPS version check-in (version_check.rs); in-cluster calls
+# (evaluator) remain plain http.
+reqwest = { version = "0.13", default-features = false, features = ["json", "query", "rustls"] }
 tokio = { version = "1", features = ["rt", "macros"] }
 
 [dev-dependencies]

--- a/broker/Dockerfile
+++ b/broker/Dockerfile
@@ -17,7 +17,8 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry  cargo build --release
 
 FROM debian:12.15-slim AS app
 
-RUN apt update && apt install libpq5 -y
+# ca-certificates: root store for the outbound HTTPS version check-in.
+RUN apt update && apt install -y libpq5 ca-certificates && rm -rf /var/lib/apt/lists/*
 
 COPY --from=build /app/broker/target/release/broker /broker
 

--- a/broker/db/migrations/2026-07-19-120000_install_info/down.sql
+++ b/broker/db/migrations/2026-07-19-120000_install_info/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS install_info;

--- a/broker/db/migrations/2026-07-19-120000_install_info/up.sql
+++ b/broker/db/migrations/2026-07-19-120000_install_info/up.sql
@@ -1,0 +1,9 @@
+-- Single-row table holding this installation's anonymous identifier for
+-- the version check-in (see broker/src/version_check.rs). The id is a
+-- random UUID generated on first startup — it carries no cluster or user
+-- information and exists only so repeated check-ins from the same install
+-- can be counted once.
+CREATE TABLE IF NOT EXISTS install_info (
+    install_id VARCHAR PRIMARY KEY,
+    created_at TIMESTAMP NOT NULL DEFAULT (timezone('utc', now()))
+);

--- a/broker/src/lib.rs
+++ b/broker/src/lib.rs
@@ -5,6 +5,7 @@ mod get;
 mod retention;
 mod telemetry;
 mod types;
+mod version_check;
 pub use add::{
     add_pod_details, add_pods, add_pods_batch, add_pods_syscalls, add_svc_details, mark_pod_dead,
 };
@@ -13,6 +14,7 @@ pub use error::*;
 pub use retention::spawn as spawn_retention;
 pub use telemetry::*;
 pub use types::*;
+pub use version_check::{get_version, spawn as spawn_version_check, VersionCheckState};
 mod conn;
 pub use conn::*;
 mod schema;

--- a/broker/src/main.rs
+++ b/broker/src/main.rs
@@ -7,8 +7,8 @@ use api::{
     add_pod_details, add_pods, add_pods_batch, add_pods_syscalls, add_svc_details,
     establish_connection, get_audit_verdicts, get_pod_by_ip, get_pod_by_name, get_pod_details,
     get_pod_syscall_name, get_pod_traffic, get_pod_traffic_name, get_pods_by_node, get_svc_by_ip,
-    get_svc_details, mark_pod_dead, set_statement_timeout, spawn_retention, AuditClient,
-    StatementTimeoutCustomizer,
+    get_svc_details, get_version, mark_pod_dead, set_statement_timeout, spawn_retention,
+    spawn_version_check, AuditClient, StatementTimeoutCustomizer, VersionCheckState,
 };
 
 use diesel::r2d2;
@@ -259,6 +259,11 @@ async fn main() -> Result<(), std::io::Error> {
     // chart. Disable by setting AUDIT_VERDICTS_RETENTION_DAYS=0.
     spawn_retention(pool.clone());
 
+    // Daily anonymous version check-in + shared state for GET /version.
+    // Disabled entirely (no task, no requests) with TELEMETRY_ENABLED=false.
+    let version_state = web::Data::new(VersionCheckState::default());
+    spawn_version_check(pool.clone(), version_state.clone());
+
     let listen_addr = listen_addr();
     info!(addr = %listen_addr, "broker HTTP server starting");
     HttpServer::new(move || {
@@ -276,6 +281,7 @@ async fn main() -> Result<(), std::io::Error> {
             .app_data(web::Data::new(pool.clone()))
             .app_data(web::Data::new(audit_client.clone()))
             .app_data(web::Data::new(auth_config.clone()))
+            .app_data(version_state.clone())
             .service(add_pods)
             .service(add_pods_batch)
             .service(add_pod_details)
@@ -292,6 +298,7 @@ async fn main() -> Result<(), std::io::Error> {
             .service(get_pods_by_node)
             .service(get_audit_verdicts)
             .service(mark_pod_dead)
+            .service(get_version)
             .service(health_check)
             .service(metrics)
     })

--- a/broker/src/schema.rs
+++ b/broker/src/schema.rs
@@ -75,6 +75,15 @@ diesel::table! {
     }
 }
 
+diesel::table! {
+    // Single row: this installation's anonymous id for the version
+    // check-in (version_check.rs). Random UUID, no cluster/user data.
+    install_info (install_id) {
+        install_id -> Varchar,
+        created_at -> Timestamp,
+    }
+}
+
 diesel::allow_tables_to_appear_in_same_query!(
     pod_details,
     pod_traffic,

--- a/broker/src/version_check.rs
+++ b/broker/src/version_check.rs
@@ -1,0 +1,473 @@
+//! Anonymous version check-in ("phone home") and the `/version` endpoint.
+//!
+//! Once a day the broker asks the kguardian version service what the
+//! latest released versions are. The request doubles as the project's
+//! usage telemetry: the service's access logs are the only place the
+//! project learns an install exists. The exchange is deliberately
+//! minimal and documented verbatim in docs/telemetry — every field is
+//! listed below, and nothing else is sent:
+//!
+//! - `install`: random UUID generated on first startup (install_info
+//!   table). No cluster or user information — it only deduplicates
+//!   repeated check-ins from the same install.
+//! - `broker`: this broker's crate version.
+//! - `chart`: Helm chart version (CHART_VERSION env, set by the chart).
+//! - `k8s`: Kubernetes version (KUBE_VERSION env, captured by the chart
+//!   at install/upgrade time from `.Capabilities.KubeVersion`).
+//! - `nodes`: count of distinct live nodes observed by the controller —
+//!   a coarse install-size signal, not an inventory.
+//! - `arch`: the broker's CPU architecture (compile-time constant).
+//!
+//! Operators disable it with `telemetry.enabled: false` in the chart
+//! (TELEMETRY_ENABLED=false on the deployment); the loop then never
+//! starts and no request is ever made. Failures are silent-by-design:
+//! air-gapped or egress-restricted clusters just never report, at debug
+//! log level, with no retry storm (next attempt is next interval).
+//!
+//! The useful half of the exchange is surfaced at `GET /version`: the
+//! current versions plus the latest-known ones, so the frontend can show
+//! an update notice and the MCP layer can answer "am I up to date?".
+
+use diesel::pg::PgConnection;
+use diesel::prelude::*;
+use diesel::r2d2::{self, ConnectionManager};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::sync::RwLock;
+use std::time::Duration;
+use tracing::{debug, info, warn};
+
+use actix_web::{get, web, HttpResponse, Responder};
+
+type DbPool = r2d2::Pool<ConnectionManager<PgConnection>>;
+type DbError = Box<dyn std::error::Error + Send + Sync>;
+
+/// Default check-in endpoint. Overridable for testing/self-hosting via
+/// TELEMETRY_ENDPOINT; an unreachable endpoint is harmless (see module
+/// docs — failures are silent and unretried until the next interval).
+const DEFAULT_ENDPOINT: &str = "https://version.kguardian.dev/v1/check";
+/// Default cadence: daily. More often would be needless load on both
+/// sides; less often makes the update notice stale.
+const DEFAULT_INTERVAL_SECS: u64 = 24 * 60 * 60;
+/// Floor for operator-supplied intervals. Anything under an hour is
+/// almost certainly a typo and would hammer the shared service.
+const MIN_INTERVAL_SECS: u64 = 60 * 60;
+/// Warmup before the first check so a crash-looping broker (which never
+/// stays up this long) generates no check-in traffic at all.
+const STARTUP_DELAY_SECS: u64 = 120;
+/// Per-request deadline. The check-in is fire-and-forget; a slow or
+/// blackholed endpoint must never tie up the task past this.
+const REQUEST_TIMEOUT_SECS: u64 = 10;
+
+/// True unless TELEMETRY_ENABLED is explicitly falsy. Default-on is a
+/// deliberate, documented choice (docs/telemetry) — the chart surfaces
+/// the setting and NOTES.txt announces it at install time.
+pub(crate) fn telemetry_enabled() -> bool {
+    match std::env::var("TELEMETRY_ENABLED") {
+        Ok(v) => !matches!(
+            v.trim().to_ascii_lowercase().as_str(),
+            "false" | "0" | "no" | "off"
+        ),
+        Err(_) => true,
+    }
+}
+
+pub(crate) fn telemetry_endpoint() -> String {
+    std::env::var("TELEMETRY_ENDPOINT")
+        .ok()
+        .map(|v| v.trim().to_string())
+        .filter(|v| !v.is_empty())
+        .unwrap_or_else(|| DEFAULT_ENDPOINT.to_string())
+}
+
+pub(crate) fn telemetry_interval() -> Duration {
+    let secs = std::env::var("TELEMETRY_INTERVAL_SECS")
+        .ok()
+        .and_then(|v| v.trim().parse::<u64>().ok())
+        .unwrap_or(DEFAULT_INTERVAL_SECS)
+        .max(MIN_INTERVAL_SECS);
+    Duration::from_secs(secs)
+}
+
+/// Chart version as injected by the Helm chart. Absent when the broker
+/// runs outside the chart (dev, docker-compose) — sent as "unknown"
+/// rather than omitted so the service can count non-chart installs.
+fn chart_version() -> String {
+    std::env::var("CHART_VERSION")
+        .ok()
+        .map(|v| v.trim().to_string())
+        .filter(|v| !v.is_empty())
+        .unwrap_or_else(|| "unknown".to_string())
+}
+
+fn kube_version() -> String {
+    std::env::var("KUBE_VERSION")
+        .ok()
+        .map(|v| v.trim().to_string())
+        .filter(|v| !v.is_empty())
+        .unwrap_or_else(|| "unknown".to_string())
+}
+
+/// Latest-known versions as reported by the version service, plus when
+/// we learned them. None until the first successful check-in.
+#[derive(Clone, Serialize)]
+pub struct CheckOutcome {
+    /// Component name → latest released version (e.g. "chart" → "1.13.2").
+    pub latest: HashMap<String, String>,
+    /// UTC timestamp of the successful check.
+    pub checked_at: chrono::NaiveDateTime,
+}
+
+/// Shared state between the check-in loop and `GET /version`. A plain
+/// std RwLock: writes are ~daily and reads are request-scoped, so
+/// contention is nil and no guard is held across an await point.
+#[derive(Default)]
+pub struct VersionCheckState {
+    outcome: RwLock<Option<CheckOutcome>>,
+}
+
+#[derive(Deserialize)]
+struct CheckResponse {
+    /// The service replies {"latest": {"chart": "...", "broker": "...", ...}}.
+    latest: HashMap<String, String>,
+}
+
+/// Wire shape of `GET /version`.
+#[derive(Serialize)]
+struct VersionInfo {
+    broker: String,
+    chart: String,
+    telemetry_enabled: bool,
+    /// Latest-known versions from the last successful check-in; null
+    /// until one succeeds (or forever, when telemetry is disabled —
+    /// the endpoint still reports current versions).
+    latest: Option<HashMap<String, String>>,
+    checked_at: Option<chrono::NaiveDateTime>,
+    /// True when the latest chart version differs from the running one.
+    /// Plain inequality, not semver ordering: the service only ever
+    /// reports current stable versions, so "different" means "behind"
+    /// in practice, and inequality can't be fooled by pre-release tags.
+    update_available: bool,
+}
+
+/// Compute the update flag from current vs latest chart version.
+/// Extracted for testability. Unknown current version (outside the
+/// chart) or no data yet → false: never nag when we can't compare.
+pub(crate) fn update_available(
+    current_chart: &str,
+    latest: Option<&HashMap<String, String>>,
+) -> bool {
+    if current_chart == "unknown" {
+        return false;
+    }
+    latest
+        .and_then(|l| l.get("chart"))
+        .map(|latest_chart| latest_chart != current_chart)
+        .unwrap_or(false)
+}
+
+#[get("/version")]
+pub async fn get_version(state: web::Data<VersionCheckState>) -> impl Responder {
+    let outcome = state.outcome.read().map(|o| o.clone()).unwrap_or_default();
+    let chart = chart_version();
+    HttpResponse::Ok().json(VersionInfo {
+        update_available: update_available(&chart, outcome.as_ref().map(|o| &o.latest)),
+        broker: env!("CARGO_PKG_VERSION").to_string(),
+        chart,
+        telemetry_enabled: telemetry_enabled(),
+        latest: outcome.as_ref().map(|o| o.latest.clone()),
+        checked_at: outcome.as_ref().map(|o| o.checked_at),
+    })
+}
+
+/// Read the install id, creating it on first run. Runs on the blocking
+/// pool (diesel is sync).
+fn get_or_create_install_id(pool: &DbPool) -> Result<String, DbError> {
+    use crate::schema::install_info::dsl::*;
+    let mut conn = pool.get()?;
+    if let Some(existing) = install_info
+        .select(install_id)
+        .first::<String>(&mut conn)
+        .optional()?
+    {
+        return Ok(existing);
+    }
+    let fresh = uuid::Uuid::new_v4().to_string();
+    // Two brokers racing on first boot both INSERT; the loser's conflict
+    // is ignored and the winner's row is re-read so every replica reports
+    // the same id.
+    diesel::insert_into(install_info)
+        .values(install_id.eq(&fresh))
+        .on_conflict_do_nothing()
+        .execute(&mut conn)?;
+    Ok(install_info.select(install_id).first::<String>(&mut conn)?)
+}
+
+/// Count of distinct live nodes the controller has reported pods on.
+/// Coarse install-size signal for the check-in; 0 when nothing has been
+/// observed yet. sql_query keeps it independent of diesel dsl helpers,
+/// matching the retention module's style.
+fn live_node_count(pool: &DbPool) -> Result<i64, DbError> {
+    use diesel::sql_query;
+    use diesel::sql_types::BigInt;
+
+    #[derive(diesel::QueryableByName)]
+    struct CountRow {
+        #[diesel(sql_type = BigInt)]
+        n: i64,
+    }
+
+    let mut conn = pool.get()?;
+    let row: CountRow =
+        sql_query("SELECT COUNT(DISTINCT node_name) AS n FROM pod_details WHERE is_dead = false")
+            .get_result(&mut conn)?;
+    Ok(row.n)
+}
+
+/// The full query-parameter set for a check-in. Pure so the tests can
+/// pin exactly what leaves the process — this list and docs/telemetry
+/// must stay in lockstep.
+pub(crate) fn check_params(install: &str, nodes: i64) -> Vec<(&'static str, String)> {
+    vec![
+        ("install", install.to_string()),
+        ("broker", env!("CARGO_PKG_VERSION").to_string()),
+        ("chart", chart_version()),
+        ("k8s", kube_version()),
+        ("nodes", nodes.to_string()),
+        ("arch", std::env::consts::ARCH.to_string()),
+    ]
+}
+
+async fn run_check(
+    pool: &DbPool,
+    client: &reqwest::Client,
+    endpoint: &str,
+) -> Result<CheckOutcome, DbError> {
+    let p = pool.clone();
+    let install = tokio::task::spawn_blocking(move || get_or_create_install_id(&p)).await??;
+    let p = pool.clone();
+    let nodes = tokio::task::spawn_blocking(move || live_node_count(&p))
+        .await?
+        .unwrap_or(0);
+
+    let response = client
+        .get(endpoint)
+        .query(&check_params(&install, nodes))
+        .send()
+        .await?
+        .error_for_status()?
+        .json::<CheckResponse>()
+        .await?;
+
+    Ok(CheckOutcome {
+        latest: response.latest,
+        checked_at: chrono::Utc::now().naive_utc(),
+    })
+}
+
+/// Spawn the daily check-in loop. Returns immediately. No task is
+/// spawned at all when telemetry is disabled — disabled means zero
+/// requests, not suppressed ones.
+pub fn spawn(pool: DbPool, state: web::Data<VersionCheckState>) {
+    if !telemetry_enabled() {
+        info!("version check-in disabled (TELEMETRY_ENABLED=false) — no requests will be made");
+        return;
+    }
+    let endpoint = telemetry_endpoint();
+    let interval = telemetry_interval();
+    info!(
+        endpoint,
+        interval_secs = interval.as_secs(),
+        "version check-in scheduled (anonymous; see docs/telemetry — disable with telemetry.enabled=false)"
+    );
+
+    actix_web::rt::spawn(async move {
+        let client = match reqwest::Client::builder()
+            .timeout(Duration::from_secs(REQUEST_TIMEOUT_SECS))
+            .user_agent(concat!("kguardian-broker/", env!("CARGO_PKG_VERSION")))
+            .build()
+        {
+            Ok(c) => c,
+            Err(e) => {
+                // Building a client is config-static; failure here is a
+                // build/packaging bug, not a runtime condition.
+                warn!("version check-in disabled: HTTP client build failed: {e}");
+                return;
+            }
+        };
+        tokio::time::sleep(Duration::from_secs(STARTUP_DELAY_SECS)).await;
+        loop {
+            match run_check(&pool, &client, &endpoint).await {
+                Ok(outcome) => {
+                    let newer = update_available(&chart_version(), Some(&outcome.latest));
+                    if newer {
+                        if let Some(latest_chart) = outcome.latest.get("chart") {
+                            info!(
+                                current = chart_version(),
+                                latest = latest_chart.as_str(),
+                                "a newer kguardian chart release is available"
+                            );
+                        }
+                    }
+                    if let Ok(mut guard) = state.outcome.write() {
+                        *guard = Some(outcome);
+                    }
+                }
+                // Silent-by-design: egress-restricted and air-gapped
+                // clusters land here every interval. debug!, not warn! —
+                // an unreachable telemetry endpoint is a supported
+                // configuration, not a fault.
+                Err(e) => debug!("version check-in skipped: {e}"),
+            }
+            tokio::time::sleep(interval).await;
+        }
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    // Env-mutating tests share this lock (std::env is process-global).
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    fn with_env<F: FnOnce()>(key: &str, value: Option<&str>, f: F) {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let saved = std::env::var(key).ok();
+        match value {
+            Some(v) => std::env::set_var(key, v),
+            None => std::env::remove_var(key),
+        }
+        f();
+        match saved {
+            Some(v) => std::env::set_var(key, v),
+            None => std::env::remove_var(key),
+        }
+    }
+
+    #[test]
+    fn enabled_by_default() {
+        with_env("TELEMETRY_ENABLED", None, || {
+            assert!(telemetry_enabled());
+        });
+    }
+
+    #[test]
+    fn disabled_by_falsy_values() {
+        for v in ["false", "FALSE", " False ", "0", "no", "off"] {
+            with_env("TELEMETRY_ENABLED", Some(v), || {
+                assert!(!telemetry_enabled(), "{v:?} must disable telemetry");
+            });
+        }
+    }
+
+    #[test]
+    fn arbitrary_values_stay_enabled() {
+        // Only explicit falsy values disable; a typo like "flase" keeps
+        // the documented default rather than silently flipping behavior.
+        for v in ["true", "1", "yes", "flase", ""] {
+            with_env("TELEMETRY_ENABLED", Some(v), || {
+                assert!(telemetry_enabled(), "{v:?} must stay enabled");
+            });
+        }
+    }
+
+    #[test]
+    fn endpoint_default_and_override() {
+        with_env("TELEMETRY_ENDPOINT", None, || {
+            assert_eq!(telemetry_endpoint(), DEFAULT_ENDPOINT);
+        });
+        with_env(
+            "TELEMETRY_ENDPOINT",
+            Some("  https://example.test/v1  "),
+            || {
+                assert_eq!(telemetry_endpoint(), "https://example.test/v1");
+            },
+        );
+        // Empty override falls back rather than producing an unusable URL.
+        with_env("TELEMETRY_ENDPOINT", Some("   "), || {
+            assert_eq!(telemetry_endpoint(), DEFAULT_ENDPOINT);
+        });
+    }
+
+    #[test]
+    fn interval_default_and_floor() {
+        with_env("TELEMETRY_INTERVAL_SECS", None, || {
+            assert_eq!(
+                telemetry_interval(),
+                Duration::from_secs(DEFAULT_INTERVAL_SECS)
+            );
+        });
+        with_env("TELEMETRY_INTERVAL_SECS", Some("60"), || {
+            assert_eq!(
+                telemetry_interval(),
+                Duration::from_secs(MIN_INTERVAL_SECS),
+                "sub-hour intervals must clamp to the floor"
+            );
+        });
+        with_env("TELEMETRY_INTERVAL_SECS", Some("garbage"), || {
+            assert_eq!(
+                telemetry_interval(),
+                Duration::from_secs(DEFAULT_INTERVAL_SECS)
+            );
+        });
+    }
+
+    #[test]
+    fn check_params_send_exactly_the_documented_fields() {
+        // This is the wire contract with docs/telemetry: if a field is
+        // added or removed here, the docs page MUST change in the same
+        // commit — this test is the tripwire.
+        with_env("CHART_VERSION", Some("9.9.9"), || {
+            let params = check_params("abc-123", 4);
+            let keys: Vec<&str> = params.iter().map(|(k, _)| *k).collect();
+            assert_eq!(keys, ["install", "broker", "chart", "k8s", "nodes", "arch"]);
+            let map: HashMap<_, _> = params.into_iter().collect();
+            assert_eq!(map["install"], "abc-123");
+            assert_eq!(map["broker"], env!("CARGO_PKG_VERSION"));
+            assert_eq!(map["chart"], "9.9.9");
+            assert_eq!(map["nodes"], "4");
+            assert_eq!(map["arch"], std::env::consts::ARCH);
+        });
+    }
+
+    /// Real-network proof that the reqwest `rustls` feature gives a
+    /// working HTTPS stack (TLS backend + roots). Ignored by default so
+    /// CI and offline runs never depend on the network; run explicitly
+    /// with `cargo test -- --ignored` when touching the TLS setup.
+    #[test]
+    #[ignore = "requires network egress"]
+    fn https_stack_performs_a_real_request() {
+        let status = actix_web::rt::System::new().block_on(async {
+            reqwest::Client::builder()
+                .timeout(Duration::from_secs(10))
+                .build()
+                .expect("client build")
+                .get("https://api.github.com/zen")
+                .header("User-Agent", "kguardian-broker-test")
+                .send()
+                .await
+                .expect("HTTPS request must succeed")
+                .status()
+        });
+        assert!(status.is_success(), "unexpected status {status}");
+    }
+
+    #[test]
+    fn update_available_comparisons() {
+        let latest = |v: &str| {
+            let mut m = HashMap::new();
+            m.insert("chart".to_string(), v.to_string());
+            m
+        };
+        assert!(update_available("1.13.1", Some(&latest("1.13.2"))));
+        assert!(!update_available("1.13.2", Some(&latest("1.13.2"))));
+        // No data yet → never nag.
+        assert!(!update_available("1.13.2", None));
+        // Outside the chart (no CHART_VERSION) → never nag.
+        assert!(!update_available("unknown", Some(&latest("1.13.2"))));
+        // Service response missing the chart key → never nag.
+        assert!(!update_available("1.13.2", Some(&HashMap::new())));
+    }
+}

--- a/charts/kguardian/README.md
+++ b/charts/kguardian/README.md
@@ -407,6 +407,8 @@ The following table lists the configurable parameters of the kguardian chart and
 | namespace.annotations | object | `{}` | Annotations to add to the namespace |
 | namespace.labels | object | `{}` | Labels to add to the namespace |
 | namespace.name | string | `""` | Namespace name. If empty, uses the release namespace |
+| telemetry.enabled | bool | `true` | Enable the daily anonymous version check-in. The broker asks the kguardian version service for the latest released versions (surfacing an update notice in the UI and at GET /version); the request doubles as the project's only usage signal. Exactly six fields are sent — a random install UUID, broker version, chart version, Kubernetes version, live node count, and CPU architecture. No cluster names, no IPs stored, no user data. Documented verbatim at https://docs.kguardian.dev/telemetry. Set to false to disable entirely: no task is spawned and no request is ever made. Air-gapped/egress-restricted clusters can also just leave it on — failures are silent and harmless. |
+| telemetry.endpoint | string | `"https://version.kguardian.dev/v1/check"` | Version service the broker calls once a day. Override to self-host or point at a mock; unreachable endpoints are ignored silently. |
 
 ## Upgrading
 

--- a/charts/kguardian/templates/NOTES.txt
+++ b/charts/kguardian/templates/NOTES.txt
@@ -76,3 +76,17 @@ audit's results, promote it to an enforced policy:
 For cluster-scoped policies (AuditClusterNetworkPolicy):
   kguardian audit promote-cluster <name> | kubectl apply -f -
 {{- end }}
+{{- if .Values.telemetry.enabled }}
+
+Telemetry: the broker performs a daily anonymous version check-in
+(random install UUID, component/chart/Kubernetes versions, node count,
+CPU arch — nothing else). It powers the update notice in the UI and is
+the project's only usage signal. Full field list and privacy details:
+  https://docs.kguardian.dev/telemetry
+Disable it at any time with:
+  --set telemetry.enabled=false
+{{- else }}
+
+Telemetry: DISABLED (telemetry.enabled=false) — no version check-in
+requests will be made. Update notices in the UI are unavailable.
+{{- end }}

--- a/charts/kguardian/templates/broker/deployment.yaml
+++ b/charts/kguardian/templates/broker/deployment.yaml
@@ -117,6 +117,17 @@ spec:
             - name: DB_MIGRATION_MAX_RETRIES
               value: {{ .Values.broker.dbMigrationMaxRetries | quote }}
             {{- end }}
+            # Anonymous version check-in (see docs/telemetry). CHART_VERSION
+            # and KUBE_VERSION are captured at install/upgrade time and ride
+            # the daily check-in; disable with telemetry.enabled=false.
+            - name: TELEMETRY_ENABLED
+              value: {{ .Values.telemetry.enabled | quote }}
+            - name: TELEMETRY_ENDPOINT
+              value: {{ .Values.telemetry.endpoint | quote }}
+            - name: CHART_VERSION
+              value: {{ .Chart.Version | quote }}
+            - name: KUBE_VERSION
+              value: {{ .Capabilities.KubeVersion.Version | quote }}
           {{- with .Values.broker.startupProbe }}
           startupProbe:
             {{- toYaml . | nindent 12 }}

--- a/charts/kguardian/values.yaml
+++ b/charts/kguardian/values.yaml
@@ -10,6 +10,22 @@ global:
   # -- Priority class to be used for the kguardian pods
   priorityClassName: ""
 
+telemetry:
+  # -- Enable the daily anonymous version check-in. The broker asks the
+  # kguardian version service for the latest released versions (surfacing an
+  # update notice in the UI and at GET /version); the request doubles as the
+  # project's only usage signal. Exactly six fields are sent — a random
+  # install UUID, broker version, chart version, Kubernetes version, live
+  # node count, and CPU architecture. No cluster names, no IPs stored, no
+  # user data. Documented verbatim at https://docs.kguardian.dev/telemetry.
+  # Set to false to disable entirely: no task is spawned and no request is
+  # ever made. Air-gapped/egress-restricted clusters can also just leave it
+  # on — failures are silent and harmless.
+  enabled: true
+  # -- Version service the broker calls once a day. Override to self-host
+  # or point at a mock; unreachable endpoints are ignored silently.
+  endpoint: https://version.kguardian.dev/v1/check
+
 namespace:
   # -- Namespace name. If empty, uses the release namespace
   name: ""

--- a/cloudflare/version-service/README.md
+++ b/cloudflare/version-service/README.md
@@ -1,0 +1,41 @@
+# kguardian version service
+
+Cloudflare Worker behind `https://version.kguardian.dev` — the server side of
+the broker's daily anonymous check-in ([docs/telemetry](../../docs/telemetry.mdx),
+client: [`broker/src/version_check.rs`](../../broker/src/version_check.rs)).
+
+`GET /v1/check` returns the latest released component versions (GitHub
+Releases, cached 5 min in KV) and records the check-in's metadata in Workers
+Analytics Engine. IPs are not persisted; geo is Cloudflare's country code.
+
+## Deploy
+
+```bash
+cd cloudflare/version-service
+wrangler kv namespace create VERSIONS   # paste the id into wrangler.toml
+wrangler deploy
+wrangler secret put GITHUB_TOKEN        # optional: higher GitHub rate limit
+```
+
+The `version.kguardian.dev` custom domain is claimed on deploy (the
+`kguardian.dev` zone must be on the deploying account).
+
+## Query the telemetry
+
+Workers Analytics Engine, SQL API — e.g. active installs over 30 days:
+
+```sql
+SELECT COUNT(DISTINCT index1) AS installs
+FROM kguardian_telemetry
+WHERE timestamp > NOW() - INTERVAL '30' DAY
+```
+
+Version spread: `blob2` is the chart version; `blob3` the k8s version;
+`blob5` the country; `double1` the node count.
+
+## Local test
+
+```bash
+wrangler dev
+curl "http://localhost:8787/v1/check?install=test&broker=1.11.1&chart=1.13.2&k8s=v1.33.0&nodes=3&arch=x86_64"
+```

--- a/cloudflare/version-service/src/index.js
+++ b/cloudflare/version-service/src/index.js
@@ -1,0 +1,135 @@
+/**
+ * kguardian version service — the server side of the broker's daily
+ * anonymous check-in (see docs/telemetry.mdx; the client is
+ * broker/src/version_check.rs).
+ *
+ * GET /v1/check?install=&broker=&chart=&k8s=&nodes=&arch=
+ *   → { "latest": { "chart": "1.13.2", "broker": "1.11.1", ... } }
+ *
+ * Latest versions come from the GitHub Releases API, cached in KV for
+ * CACHE_TTL_SECS so the worker never rate-limits against GitHub and
+ * check-ins stay fast. Each request's metadata is written to Workers
+ * Analytics Engine (dataset: TELEMETRY) — that dataset is the project's
+ * usage telemetry. IP addresses are not persisted; country comes from
+ * Cloudflare's edge metadata.
+ *
+ * Privacy contract (must match docs/telemetry.mdx):
+ *   stored per check-in → install UUID, versions, k8s version, node
+ *   count, arch, country. Nothing else.
+ */
+
+const REPO = "kguardian-dev/kguardian";
+const CACHE_KEY = "latest-versions";
+const CACHE_TTL_SECS = 300;
+
+/** Tag prefixes → response keys. Matches release-please's component tags. */
+const COMPONENTS = [
+  "chart",
+  "broker",
+  "controller",
+  "frontend",
+  "advisor",
+  "llm-bridge",
+  "mcp-server",
+  "evaluator",
+];
+
+async function fetchLatestFromGitHub(env) {
+  // One page of most-recent releases covers every component: kguardian
+  // cuts at most a handful of releases per component between cache
+  // expiries, and we only need the newest tag per prefix.
+  const resp = await fetch(
+    `https://api.github.com/repos/${REPO}/releases?per_page=100`,
+    {
+      headers: {
+        "User-Agent": "kguardian-version-service",
+        Accept: "application/vnd.github+json",
+        // Optional: raises the rate limit from 60/h to 5000/h. The KV
+        // cache keeps us far below either, so absence is fine.
+        ...(env.GITHUB_TOKEN
+          ? { Authorization: `Bearer ${env.GITHUB_TOKEN}` }
+          : {}),
+      },
+    },
+  );
+  if (!resp.ok) throw new Error(`GitHub API ${resp.status}`);
+  const releases = await resp.json();
+
+  const latest = {};
+  for (const rel of releases) {
+    if (rel.draft || rel.prerelease) continue;
+    // Tags look like "chart/v1.13.2" or "broker/v1.11.1".
+    const [component, version] = rel.tag_name.split("/");
+    if (!version || !COMPONENTS.includes(component)) continue;
+    // Releases arrive newest-first; keep only the first per component.
+    if (!(component in latest)) latest[component] = version.replace(/^v/, "");
+  }
+  return latest;
+}
+
+async function latestVersions(env) {
+  const cached = await env.VERSIONS.get(CACHE_KEY, { type: "json" });
+  if (cached) return cached;
+  const fresh = await fetchLatestFromGitHub(env);
+  await env.VERSIONS.put(CACHE_KEY, JSON.stringify(fresh), {
+    expirationTtl: CACHE_TTL_SECS,
+  });
+  return fresh;
+}
+
+function recordCheckin(env, request, url) {
+  // Analytics Engine is fire-and-forget and additive-only; a schema of
+  // blobs (strings) + doubles (numbers) + an index. The install UUID is
+  // the index so per-install queries (active installs, version spread)
+  // are cheap.
+  if (!env.TELEMETRY) return; // dataset unbound in local dev
+  const q = url.searchParams;
+  env.TELEMETRY.writeDataPoint({
+    indexes: [q.get("install") ?? "unknown"],
+    blobs: [
+      q.get("broker") ?? "unknown",
+      q.get("chart") ?? "unknown",
+      q.get("k8s") ?? "unknown",
+      q.get("arch") ?? "unknown",
+      request.cf?.country ?? "unknown",
+    ],
+    doubles: [Number(q.get("nodes")) || 0],
+  });
+}
+
+export default {
+  async fetch(request, env) {
+    const url = new URL(request.url);
+
+    if (url.pathname === "/healthz") {
+      return Response.json({ ok: true });
+    }
+
+    if (url.pathname !== "/v1/check" || request.method !== "GET") {
+      return Response.json({ error: "not found" }, { status: 404 });
+    }
+
+    recordCheckin(env, request, url);
+
+    let latest;
+    try {
+      latest = await latestVersions(env);
+    } catch (e) {
+      // GitHub briefly unreachable and cache cold: the check-in was
+      // still recorded; give the client an empty payload rather than an
+      // error it would just discard.
+      console.error("latest-version lookup failed:", e.message);
+      latest = {};
+    }
+
+    return Response.json(
+      { latest },
+      {
+        headers: {
+          // Downstream caches may keep it briefly; clients only call daily.
+          "Cache-Control": `public, max-age=${CACHE_TTL_SECS}`,
+        },
+      },
+    );
+  },
+};

--- a/cloudflare/version-service/wrangler.toml
+++ b/cloudflare/version-service/wrangler.toml
@@ -1,0 +1,27 @@
+name = "kguardian-version-service"
+main = "src/index.js"
+compatibility_date = "2026-07-01"
+
+# Custom domain: version.kguardian.dev (zone kguardian.dev must be on this
+# Cloudflare account; the route is claimed automatically on deploy).
+routes = [
+  { pattern = "version.kguardian.dev", custom_domain = true }
+]
+
+# Cache of the GitHub Releases lookup (5 min TTL) — create with:
+#   wrangler kv namespace create VERSIONS
+# then paste the returned id below.
+[[kv_namespaces]]
+binding = "VERSIONS"
+id = "REPLACE_WITH_KV_NAMESPACE_ID"
+
+# Usage telemetry sink. Free tier; query with the Analytics Engine SQL API:
+#   SELECT COUNT(DISTINCT index1) AS installs FROM kguardian_telemetry
+#   WHERE timestamp > NOW() - INTERVAL '30' DAY
+[[analytics_engine_datasets]]
+binding = "TELEMETRY"
+dataset = "kguardian_telemetry"
+
+# Optional secret to raise the GitHub API rate limit (not required — the
+# KV cache keeps traffic minimal):
+#   wrangler secret put GITHUB_TOKEN

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -61,7 +61,8 @@
           {
             "group": "Advanced",
             "pages": [
-              "advanced/troubleshooting"
+              "advanced/troubleshooting",
+              "telemetry"
             ]
           },
           {
@@ -132,7 +133,7 @@
     ],
     "primary": {
       "type": "button",
-      "label": "Star on GitHub ⭐",
+      "label": "Star on GitHub \u2b50",
       "href": "https://github.com/kguardian-dev/kguardian"
     }
   },

--- a/docs/telemetry.mdx
+++ b/docs/telemetry.mdx
@@ -1,0 +1,85 @@
+---
+title: "Telemetry"
+description: "What the anonymous version check-in sends, why, and how to turn it off"
+icon: "satellite-dish"
+---
+
+kguardian's broker performs a **daily anonymous version check-in**: it asks
+`version.kguardian.dev` for the latest released versions, and that request is
+also how the project learns an installation exists. It powers the update
+notice in the UI (and `GET /version` on the broker), and it is the only
+usage signal the project collects.
+
+It is **enabled by default** and can be disabled at any time — we'd rather
+you know exactly what it does and choose, than never notice it.
+
+## Exactly what is sent
+
+One HTTPS `GET` per day to `https://version.kguardian.dev/v1/check` with
+these six query parameters — nothing else, ever:
+
+| Field | Example | What it is |
+| --- | --- | --- |
+| `install` | `4f7c…-…` | Random UUID generated once at first startup. Contains no cluster or user information — it only lets repeated check-ins from the same install be counted once. |
+| `broker` | `1.11.1` | Broker version. |
+| `chart` | `1.13.2` | Helm chart version (`unknown` outside the chart). |
+| `k8s` | `v1.33.1` | Kubernetes version, captured by the chart at install/upgrade time. |
+| `nodes` | `3` | Count of distinct live nodes the controller has observed — a coarse size signal, not an inventory. |
+| `arch` | `x86_64` | Broker CPU architecture. |
+
+The exact field list is pinned by a unit test in the broker
+(`check_params_send_exactly_the_documented_fields`) — a change to the wire
+contract fails the build unless this page changes with it.
+
+**Not sent:** cluster names, namespaces, pod names, IPs, hostnames, labels,
+traffic data, syscall data, or anything derived from your workloads.
+
+**Server side:** requests are logged with coarse, Cloudflare-provided
+country-level geo. IP addresses are not persisted.
+
+## What you get back
+
+The response lists the latest released component versions. The broker
+surfaces it at `GET /version`:
+
+```json
+{
+  "broker": "1.11.1",
+  "chart": "1.13.2",
+  "telemetry_enabled": true,
+  "latest": { "chart": "1.13.2", "broker": "1.11.1" },
+  "checked_at": "2026-07-19T12:00:00",
+  "update_available": false
+}
+```
+
+The web UI uses this for its update notice, and the AI assistant can answer
+"am I running the latest version?" from the same data.
+
+## Disabling it
+
+```bash
+helm upgrade kguardian oci://ghcr.io/kguardian-dev/charts/kguardian \
+  --reuse-values --set telemetry.enabled=false
+```
+
+Disabled means disabled: the broker spawns no check-in task and makes no
+request at all — not a suppressed or batched one. `GET /version` keeps
+working, but `latest`/`update_available` stay empty.
+
+## Air-gapped and egress-restricted clusters
+
+Nothing to do. Failures are silent by design — if the endpoint is
+unreachable, the broker logs at `debug` level and tries again the next day.
+There is no retry storm, no startup dependency, and no functional impact.
+
+## Self-hosting the endpoint
+
+`telemetry.endpoint` can point at your own service (the reference
+implementation lives in
+[`cloudflare/version-service`](https://github.com/kguardian-dev/kguardian/tree/main/cloudflare/version-service)):
+
+```yaml
+telemetry:
+  endpoint: https://version.internal.example.com/v1/check
+```


### PR DESCRIPTION
Adds the telemetry/version-check feature end to end:

- broker: daily check-in to version.kguardian.dev over HTTPS (reqwest
  rustls — the 0.13 rename of rustls-tls), random install UUID persisted
  in a new install_info table, GET /version surfacing current vs latest
  versions for the UI update notice. Disabled entirely (no task, no
  requests) with TELEMETRY_ENABLED=false; failures are silent debug-level.
- chart: telemetry.enabled (default true) + telemetry.endpoint values,
  broker env wiring incl. CHART_VERSION/.Capabilities KUBE_VERSION,
  NOTES.txt announces telemetry status + opt-out at install time.
- docs: docs/telemetry page listing every field sent verbatim (pinned by
  a unit test on the wire contract); README section.
- cloudflare/version-service: Worker serving /v1/check — GitHub Releases
  cached in KV, check-ins recorded to Workers Analytics Engine, deploy
  instructions in its README. Verified against the live GitHub API.

Exactly six fields leave the cluster: install UUID, broker version,
chart version, k8s version, node count, arch.

https://claude.ai/code/session_01NGEYMBjENoxEcbcLBeUhKG