### PR TITLE
fix(version-service): align worker name with dashboard project and drop KV requirement

### DIFF
--- a/cloudflare/version-service/README.md
+++ b/cloudflare/version-service/README.md
@@ -10,15 +10,19 @@ Analytics Engine. IPs are not persisted; geo is Cloudflare's country code.
 
 ## Deploy
 
-```bash
-cd cloudflare/version-service
-wrangler kv namespace create VERSIONS   # paste the id into wrangler.toml
-wrangler deploy
-wrangler secret put GITHUB_TOKEN        # optional: higher GitHub rate limit
-```
+Deployed via Cloudflare's Git-connected Workers Builds: the dashboard
+project **kguardian** points at this repo with root directory
+`cloudflare/version-service`, and every push to `main` touching this
+directory deploys automatically. No pre-created resources are needed —
+the GitHub-releases cache uses the Workers Cache API and the Analytics
+Engine dataset is provisioned on first deploy.
 
 The `version.kguardian.dev` custom domain is claimed on deploy (the
 `kguardian.dev` zone must be on the deploying account).
+
+Manual deploy (fallback): `npx wrangler deploy` from this directory.
+Optional: `wrangler secret put GITHUB_TOKEN` raises the GitHub API rate
+limit; the cache keeps traffic minimal without it.
 
 ## Query the telemetry
 

--- a/cloudflare/version-service/src/index.js
+++ b/cloudflare/version-service/src/index.js
@@ -19,7 +19,9 @@
  */
 
 const REPO = "kguardian-dev/kguardian";
-const CACHE_KEY = "latest-versions";
+// Synthetic cache key for the Workers Cache API (per-colo). Any URL on a
+// zone we control works; this path is never actually routable.
+const CACHE_KEY = "https://version.kguardian.dev/__cache/latest-versions";
 const CACHE_TTL_SECS = 300;
 
 /** Tag prefixes → response keys. Matches release-please's component tags. */
@@ -68,12 +70,20 @@ async function fetchLatestFromGitHub(env) {
 }
 
 async function latestVersions(env) {
-  const cached = await env.VERSIONS.get(CACHE_KEY, { type: "json" });
-  if (cached) return cached;
+  // Workers Cache API instead of KV: per-colo rather than global, which is
+  // fine here — worst case each colo refreshes from GitHub once per TTL,
+  // still far under any rate limit — and it needs no pre-created namespace,
+  // so the Git-connected build deploys with zero manual resources.
+  const cache = caches.default;
+  const hit = await cache.match(CACHE_KEY);
+  if (hit) return hit.json();
   const fresh = await fetchLatestFromGitHub(env);
-  await env.VERSIONS.put(CACHE_KEY, JSON.stringify(fresh), {
-    expirationTtl: CACHE_TTL_SECS,
-  });
+  await cache.put(
+    CACHE_KEY,
+    Response.json(fresh, {
+      headers: { "Cache-Control": `public, max-age=${CACHE_TTL_SECS}` },
+    }),
+  );
   return fresh;
 }
 

--- a/cloudflare/version-service/wrangler.toml
+++ b/cloudflare/version-service/wrangler.toml
@@ -1,4 +1,7 @@
-name = "kguardian-version-service"
+# Name matches the Git-connected Worker created in the Cloudflare dashboard
+# (Workers Builds project "kguardian") — the two must agree or builds warn
+# and auto-PR a rename.
+name = "kguardian"
 main = "src/index.js"
 compatibility_date = "2026-07-01"
 
@@ -8,14 +11,11 @@ routes = [
   { pattern = "version.kguardian.dev", custom_domain = true }
 ]
 
-# Cache of the GitHub Releases lookup (5 min TTL) — create with:
-#   wrangler kv namespace create VERSIONS
-# then paste the returned id below.
-[[kv_namespaces]]
-binding = "VERSIONS"
-id = "REPLACE_WITH_KV_NAMESPACE_ID"
+# The 5-minute GitHub Releases cache uses the Workers Cache API
+# (caches.default) — per-colo, zero pre-created resources. No KV needed.
 
-# Usage telemetry sink. Free tier; query with the Analytics Engine SQL API:
+# Usage telemetry sink. Auto-provisioned on deploy; query with the
+# Analytics Engine SQL API:
 #   SELECT COUNT(DISTINCT index1) AS installs FROM kguardian_telemetry
 #   WHERE timestamp > NOW() - INTERVAL '30' DAY
 [[analytics_engine_datasets]]
@@ -23,5 +23,5 @@ binding = "TELEMETRY"
 dataset = "kguardian_telemetry"
 
 # Optional secret to raise the GitHub API rate limit (not required — the
-# KV cache keeps traffic minimal):
+# cache keeps traffic minimal):
 #   wrangler secret put GITHUB_TOKEN


### PR DESCRIPTION
Aligns wrangler.toml with the dashboard-created Workers Builds project (name: kguardian) and replaces the KV cache with the Workers Cache API so the Git-connected deploy needs zero pre-created resources. Handler re-verified against the live GitHub API with a Cache API stub (cache hit on second call, AE points recorded).

https://claude.ai/code/session_01NGEYMBjENoxEcbcLBeUhKG