### PR TITLE
feat(version-service): redirect root to the telemetry docs page

### DIFF
--- a/cloudflare/version-service/src/index.js
+++ b/cloudflare/version-service/src/index.js
@@ -115,6 +115,12 @@ export default {
       return Response.json({ ok: true });
     }
 
+    // Humans curious what this endpoint is land on the page that documents
+    // exactly what it collects.
+    if (url.pathname === "/") {
+      return Response.redirect("https://docs.kguardian.dev/telemetry", 302);
+    }
+
     if (url.pathname !== "/v1/check" || request.method !== "GET") {
       return Response.json({ error: "not found" }, { status: 404 });
     }


### PR DESCRIPTION
Root of version.kguardian.dev now 302s to https://docs.kguardian.dev/telemetry — anyone inspecting the endpoint lands on the page documenting exactly what it collects. /healthz and /v1/check unchanged; unknown paths still 404.

https://claude.ai/code/session_01NGEYMBjENoxEcbcLBeUhKG