### PR TITLE
docs: repo-wide accuracy pass — remove obsolete, untrue, and misleading content

### DIFF
--- a/AI-MCP-INTEGRATION-GOAL.md
+++ b/AI-MCP-INTEGRATION-GOAL.md
@@ -43,7 +43,7 @@ frontend/AIAssistant.tsx
 llm-bridge (TS/Express, @anthropic-ai/sdk, claude-opus-4-8, prompt caching)
    │  MCP tool calls
    ▼
-mcp-server (Go, 11 tools) ──HTTP──► broker (Rust/actix, Postgres)   [pod/traffic, pod/info, audit/verdicts, …]
+mcp-server (Go, 12 tools) ──HTTP──► broker (Rust/actix, Postgres)   [pod/traffic, pod/info, audit/verdicts, …]
                           └─HTTP──► advisor (Go, serve mode)        [generate networkpolicy / seccomp]
 ```
 
@@ -70,7 +70,7 @@ drift-guard between mcp-server tool set and llm-bridge; golden-answer tests for 
 responses are size-capped end to end.
 **Acceptance:** a CI guard fails the build if a broker read lacks a bound; DB size stays flat
 under steady state; p95/p99 latency targets met under a load test.
-- **[P0] `/pod/traffic` unbounded** — FIXED, PR #1034 (bound + `idx_pod_traffic_time_stamp`). Deploy + verify.
+- **[P0] `/pod/traffic` unbounded** — FIXED, PR #1034 (bound + `idx_pod_traffic_time_stamp`).
 - **[P0] `/pod/traffic/{name}` (`get.rs:368`) unbounded** — hit by the frontend per-pod on every
   view load AND by the advisor. Fix via **dedup (DISTINCT ON the flow tuple)** so the advisor keeps
   complete flows, not a blind LIMIT. Correct tuple = `(pod_ip, pod_port, ip_protocol, traffic_type,
@@ -97,7 +97,7 @@ no single query or pod restart is fatal.
 degrading cleanly; broker survives a burst of concurrent heavy calls.
 - Broker is a **single replica** = SPOF for the entire data path. Decide HA (replicas + readiness)
   or at minimum isolate heavy queries (statement_timeout, separate pool) so one can't wedge the pod.
-- Enforce `statement_timeout` on all broker queries as a backstop.
+- Enforce `statement_timeout` on all broker queries as a backstop — SHIPPED (#1036, 2026-07-19).
 - mcp-server↔broker: confirm sane client timeouts (90s today) + retries; llm-bridge tool-call timeouts.
 
 ### WS4 — Observability
@@ -115,7 +115,7 @@ telemetry alone; alerts fire on error-rate/latency/DB-size breaches.
 every PR; an "unbounded-query" lint/guard; a load-smoke job; zero known-flaky tests.
 - Fix flaky `TestBrokerClient_OversizedBodyTruncated` (deadlocks under parallel load).
 - Add the WS1 contract tests and the WS2 bound-guard.
-- Ensure Rust tests actually gate PRs (historically they didn't).
+- Ensure Rust tests actually gate PRs — DONE (`pr-build.yaml` runs fmt/clippy/test for broker + controller).
 
 ### WS6 — Security & trust
 **Bar:** Broker API authenticated; secrets handled well; the LLM path is hardened against prompt
@@ -156,7 +156,7 @@ is exposed. No component silently depends on a service that isn't deployed.
 ## 4. Sequencing
 
 - **P0 — Stop the bleeding (WS2 + the live deploy):** land #1034; dedup-bound the two sibling
-  endpoints; `pod_traffic` retention; `audit_verdicts` bloat. Add `statement_timeout` backstop (WS3).
+  endpoints; `pod_traffic` retention; `audit_verdicts` bloat. `statement_timeout` backstop (WS3) — SHIPPED (#1036, 2026-07-19).
 - **P1 — Make it stay fixed:** CI bound-guard + contract tests + flaky fix (WS5); observability for
   the golden signals + table-size alerts (WS4); broker SPOF decision (WS3).
 - **P2 — Trust & polish:** UX failure-state mapping (WS7); broker auth + dep alert burndown (WS6);
@@ -191,3 +191,9 @@ wait until §1 targets hold.
   - Task #2 re-scoped by code review: the `ip_protocol` "index bug" is actually a `get_row` (6-col DB
     dedup) vs `traffic_content_key` (7-col in-batch) INGEST inconsistency — separate, riskier, deferred.
     Per-pod growth is churn-driven (new IP per restart), which retention (Task #3) attacks at the root.
+- 2026-07-19 — **llm-bridge streaming hardening shipped (#1039, v1.4.1):** SSE keepalive, abort-aware
+  tool rounds, `is_error` tool results, refusal/max_tokens fallbacks, 429/529 mapping.
+- 2026-07-19 — **advisor ARM seccomp fix shipped (#1042, v1.6.1):** aarch64 arch map + serve-path
+  validation.
+- 2026-07-19/20 — **Anonymous version check-in + `GET /version` shipped (#1098):** broker v1.12.0,
+  chart v1.14.0; version.kguardian.dev live.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thanks for your interest in contributing. This guide explains how to file issues
 
 ## Code of Conduct
 
-This project adopts the [Contributor Covenant 2.1](./CODE_OF_CONDUCT.md). By participating you agree to abide by it. Report unacceptable behaviour to the maintainers as described in that document.
+Be respectful and constructive — critique code and ideas, not people, and keep discussions focused on making the project better. Report unacceptable behaviour privately to the maintainers listed below.
 
 ## Where to file what
 
@@ -62,28 +62,23 @@ All commits must be signed off:
 git commit -s -m "fix(broker): close DB pool on shutdown"
 ```
 
-The `-s` flag adds a `Signed-off-by:` trailer that certifies you have the right to submit the work under the project licence (see the [Developer Certificate of Origin](https://developercertificate.org/)). PRs without sign-off will be rejected by CI.
+The `-s` flag adds a `Signed-off-by:` trailer that certifies you have the right to submit the work under the project licence (see the [Developer Certificate of Origin](https://developercertificate.org/)). Sign-off is expected on all commits; maintainers may ask you to add it during review.
 
 ### PR checklist
 
 Before requesting review:
 
-1. The change is covered by tests (unit, integration, or both — see [`docs/development/testing`](./docs/development/testing.mdx)).
+1. The change is covered by tests (unit, integration, or both).
 2. `task preflight` and the relevant component build (`task <component>:build`) pass locally.
-3. Docs are updated if behaviour, flags, or API contracts changed. See [`docs/contributing.mdx`](./docs/contributing.mdx) for the docs workflow.
+3. Docs are updated if behaviour, flags, or API contracts changed.
 4. Style rules from [`STYLE.md`](./STYLE.md) are honoured (lowercase product name, no banned marketing words, no emoji in headings, no unqualified "real-time").
 5. Commit messages follow Conventional Commits and are signed off.
 
 ## Local development setup
 
-Pointers, not duplicates — the docs site has the canonical guides:
+The monorepo builds via [`Taskfile.yaml`](./Taskfile.yaml) (run `task --list` for all targets) and each component lives in its own source directory: `controller/`, `broker/`, `frontend/`, `advisor/`, `evaluator/`, `mcp-server/`, `llm-bridge/`, `charts/`.
 
-- [Development overview](./docs/development/overview.mdx) — repo layout, monorepo components, dev loop.
-- [Building from source](./docs/development/building-from-source.mdx) — Rust + Go + frontend build via `Taskfile.yaml` and `Tiltfile`.
-- [Testing](./docs/development/testing.mdx) — how to run unit and integration tests per component.
-- Component internals: [Controller](./docs/development/controller.mdx), [Broker](./docs/development/broker.mdx), [CLI](./docs/development/cli.mdx), [UI](./docs/development/ui.mdx).
-
-Quick start for the impatient:
+Quick start:
 
 ```bash
 # clone + enter
@@ -114,7 +109,7 @@ If you are touching docs, read `STYLE.md` end-to-end before writing — it is sh
 
 ## Releases
 
-kguardian uses component-based versioning automated by [release-please](https://github.com/googleapis/release-please). See [`RELEASES.md`](./RELEASES.md) and [`docs/development/releases.mdx`](./docs/development/releases.mdx) for the full release flow. As a contributor, the only thing you usually need to do is write a Conventional Commit message — release-please does the rest.
+kguardian uses component-based versioning automated by [release-please](https://github.com/googleapis/release-please). See [`RELEASES.md`](./RELEASES.md) for the full release flow. As a contributor, the only thing you usually need to do is write a Conventional Commit message — release-please does the rest.
 
 ## Maintainers
 

--- a/README.md
+++ b/README.md
@@ -48,15 +48,15 @@ It's built for platform and security teams who want policy-as-code without writi
 
 ## ✨ Features
 
-- **Network Policy generation** — least-privilege Kubernetes `NetworkPolicy` and Cilium `CiliumNetworkPolicy` / `CiliumClusterwideNetworkPolicy` resources from observed pod-to-pod traffic.
+- **Network Policy generation** — least-privilege Kubernetes `NetworkPolicy` and Cilium `CiliumNetworkPolicy` resources from observed pod-to-pod traffic.
 - **Seccomp profile generation** — per-container syscall allowlists derived from runtime traces.
 - **Policy auditing before enforcement** — the `AuditNetworkPolicy` CRD is byte-identical to an upstream `NetworkPolicy`, but instead of dropping packets the evaluator reports every flow the policy *would* deny. Ship policies with confidence instead of blackholing production.
 - **Flexible targeting** — generate per-pod, per-namespace, or cluster-wide.
-- **Dry-run by default** — YAML is written to `--output-dir` and never applied unless you pass `--dry-run=false`.
+- **Review-first by design** — the CLI writes YAML to `--output-dir` and never applies anything to the cluster; you review and `kubectl apply` the files yourself.
 - **GitOps-friendly output** — plain YAML/JSON files ready for review or a GitOps pipeline.
 - **Optional AI assistant** — query traffic and syscall data in natural language via the LLM bridge and MCP server.
 
-Worked examples of everything the generator produces (nginx, Postgres, kube-dns, Prometheus, Istio sidecar, a Go microservice) live in the [Generated Policy Gallery](docs/policy-gallery/). For a comparison with Inspektor Gadget and Security Profiles Operator, see the [docs site](https://docs.kguardian.dev/#comparison-with-other-tools).
+Example policies for common workloads (nginx, Postgres, kube-dns, Prometheus, Istio sidecar, a Go microservice) live in the [Policy Gallery](docs/policy-gallery/). For a comparison with Inspektor Gadget and Security Profiles Operator, see the [docs site](https://docs.kguardian.dev/#comparison-with-other-tools).
 
 ## 🏗️ Architecture
 
@@ -92,7 +92,7 @@ graph LR
 | **Evaluator** | Go | Deployment | Evaluates live flows against `AuditNetworkPolicy` CRDs and reports would-deny verdicts — without dropping a packet |
 | **CLI** (`kubectl kguardian`) | Go | kubectl plugin | Generates NetworkPolicies and seccomp profiles from the observed baseline |
 | **Web UI** | React + TypeScript | Deployment | Visualizes traffic, policies, and pod behavior |
-| **LLM Bridge / MCP Server** | TypeScript / Go | Optional Deployments | Natural-language assistant over cluster traffic ([docs/ai-assistant](docs/ai-assistant/)) |
+| **LLM Bridge / MCP Server** | TypeScript / Go | Optional Deployments | Natural-language assistant over cluster traffic ([llm-bridge/README.md](llm-bridge/README.md), [mcp-server/README.md](mcp-server/README.md)) |
 
 ## 🚀 Quick Start
 
@@ -119,7 +119,7 @@ kubectl kguardian gen netpol --all -n staging --type cilium --output-dir ./polic
 kubectl kguardian gen seccomp -A --output-dir ./seccomp
 ```
 
-Review the generated YAML, then apply it yourself (`kubectl apply -f ./policies`) or re-run with `--dry-run=false`. Manual download, custom Helm values, Kind setup, verification, upgrades, and uninstall are covered in the [Installation Guide](https://docs.kguardian.dev/installation).
+Review the generated YAML, then apply it yourself (`kubectl apply -f ./policies`). Manual download, custom Helm values, Kind setup, verification, upgrades, and uninstall are covered in the [Installation Guide](https://docs.kguardian.dev/installation).
 
 ## 🛠️ Usage
 
@@ -132,18 +132,18 @@ kubectl kguardian gen <networkpolicy|seccomp> [pod-name] [flags]
 | Flag | Applies to | Description |
 | --- | --- | --- |
 | `-n, --namespace` | both | Namespace scope (defaults to current context namespace) |
-| `-a, --all` | both | All pods in the selected namespace |
+| `--all` | both | All pods in the selected namespace (`-a` shorthand: networkpolicy only) |
 | `-A, --all-namespaces` | both | All pods in all namespaces |
 | `--output-dir` | both | Directory for generated files (`network-policies` / `seccomp-profiles`) |
 | `-t, --type` | networkpolicy | `kubernetes` (default) or `cilium` |
-| `--dry-run` | networkpolicy | `true` (default) writes files only; `false` applies to the cluster |
+| `--dry-run` | networkpolicy | `true` (default). Applying directly is not implemented yet — the CLI always writes files only |
 | `--default-action` | seccomp | Action for unlisted syscalls: `SCMP_ACT_ERRNO` (default), `SCMP_ACT_LOG`, `SCMP_ACT_KILL` |
 
 Full command reference, including audit workflows and advanced flags, is in the [CLI docs](https://docs.kguardian.dev/cli).
 
 ## 🤖 AI Assistant
 
-kguardian ships an optional natural-language assistant: ask questions like *"what has this pod talked to in the last hour?"* or *"generate a seccomp profile for the payments namespace"* from the Web UI. It's powered by an LLM bridge (SSE streaming) and an MCP server exposing the broker's data as tools — bring your own Anthropic API key. Setup and configuration live in [docs/ai-assistant](docs/ai-assistant/).
+kguardian ships an optional natural-language assistant: ask questions like *"what has this pod talked to in the last hour?"* or *"generate a seccomp profile for the payments namespace"* from the Web UI. It's powered by an LLM bridge (SSE streaming) and an MCP server exposing the broker's data as tools — bring your own Anthropic API key. Setup and configuration live in [llm-bridge/README.md](llm-bridge/README.md) and [mcp-server/README.md](mcp-server/README.md).
 
 ## 🧩 Compatibility
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -140,13 +140,13 @@ Once the Release PR is merged, release-please automatically:
 2. Creates GitHub Releases with changelog content
 3. Triggers component-specific build workflows via workflow_dispatch
 4. Publishes artifacts:
-   - **Controller**: Docker image to `ghcr.io/kguardian-dev/kguardian/guardian-controller:vX.Y.Z`
-   - **Broker**: Docker image to `ghcr.io/kguardian-dev/kguardian/guardian-broker:vX.Y.Z`
+   - **Controller**: Docker image to `ghcr.io/kguardian-dev/kguardian/controller:vX.Y.Z`
+   - **Broker**: Docker image to `ghcr.io/kguardian-dev/kguardian/broker:vX.Y.Z`
    - **Frontend**: Docker image to `ghcr.io/kguardian-dev/kguardian/frontend:vX.Y.Z`
    - **Evaluator**: Docker image to `ghcr.io/kguardian-dev/kguardian/evaluator:vX.Y.Z`
    - **MCP Server**: Docker image to `ghcr.io/kguardian-dev/kguardian/mcp-server:vX.Y.Z`
    - **LLM Bridge**: Docker image to `ghcr.io/kguardian-dev/kguardian/llm-bridge:vX.Y.Z`
-   - **Advisor**: SLSA3-attested binaries to GitHub Releases (linux/darwin, amd64/arm64)
+   - **Advisor**: Binaries to GitHub Releases (linux/darwin, amd64/arm64) with GitHub build-provenance attestations — verify with `gh attestation verify advisor-<os>-<arch> --repo kguardian-dev/kguardian` — plus a Docker image to `ghcr.io/kguardian-dev/kguardian/advisor` via `advisor-image-release.yaml`
    - **Chart**: Helm package to `oci://ghcr.io/kguardian-dev/charts/kguardian:X.Y.Z`
 5. Tags Docker images with `latest`
 
@@ -178,17 +178,20 @@ git commit -m "feat(chart): add support for custom annotations"
 # → Creates PR: chart 1.0.0 → 1.1.0
 ```
 
-The chart can reference specific component versions via `values.yaml`:
+The chart can reference specific component versions via `values.yaml`. Image tags are bare semver — no `v` prefix (only advisor binary releases use `v`-prefixed versions, e.g. `v1.6.1`):
 ```yaml
 controller:
   image:
-    tag: "v1.2.0"  # Pin to specific controller version
+    tag: "1.9.1"  # Pin to specific controller version
 broker:
   image:
-    tag: "v1.3.1"  # Pin to specific broker version
+    tag: "1.12.0"  # Pin to specific broker version
 frontend:
   image:
-    tag: "v2.0.0"  # Pin to specific frontend version
+    tag: "1.9.1"  # Pin to specific frontend version
+llmBridge:
+  image:
+    tag: "1.4.1"  # Pin to specific LLM Bridge version
 ```
 
 ### Manual Override (Emergency Use Only)
@@ -328,18 +331,18 @@ These are automatically updated by release-please based on conventional commits.
 - `.github/workflows/controller-release.yaml` - Triggered by `controller/v*` tags or workflow_dispatch
 - `.github/workflows/broker-release.yaml` - Triggered by `broker/v*` tags or workflow_dispatch
 - `.github/workflows/frontend-release.yaml` - Triggered by `frontend/v*` tags or workflow_dispatch
-- `.github/workflows/advisor-release.yml` - Triggered by `advisor/v*` tags or workflow_dispatch
+- `.github/workflows/advisor-release.yml` - Triggered by workflow_dispatch only (release-please dispatches it with tag + sha inputs); uses a draft-release flow — the draft GitHub release is published once the binaries are attached
 - `.github/workflows/evaluator-release.yaml` - Triggered by `evaluator/v*` tags or workflow_dispatch
 - `.github/workflows/mcp-server-release.yaml` - Triggered by `mcp-server/v*` tags or workflow_dispatch
 - `.github/workflows/llm-bridge-release.yaml` - Triggered by `llm-bridge/v*` tags or workflow_dispatch
-- `.github/workflows/charts-release.yaml` - Triggered by `chart/v*` tags or chart file changes
+- `.github/workflows/charts-release.yaml` - Triggered by `chart/v*` tags or workflow_dispatch
 
 ## Querying Versions
 
 ### Current Installed Versions
 
 The chart sets `app.kubernetes.io/name` on each workload's pod template
-(values: `kguardian` for the controller daemonset, `kguardian-broker`,
+(values: `kguardian` for the controller daemonset, `kbroker`,
 `kguardian-frontend`, `kguardian-evaluator`, etc). Examples:
 
 ```bash
@@ -347,7 +350,7 @@ The chart sets `app.kubernetes.io/name` on each workload's pod template
 kubectl get pods -n kguardian -l app.kubernetes.io/name=kguardian -o jsonpath='{.items[0].spec.containers[0].image}'
 
 # Broker version (from pod)
-kubectl get pods -n kguardian -l app.kubernetes.io/name=kguardian-broker -o jsonpath='{.items[0].spec.containers[0].image}'
+kubectl get pods -n kguardian -l app.kubernetes.io/name=kbroker -o jsonpath='{.items[0].spec.containers[0].image}'
 
 # Frontend version (from pod)
 kubectl get pods -n kguardian -l app.kubernetes.io/name=kguardian-frontend -o jsonpath='{.items[0].spec.containers[0].image}'
@@ -366,12 +369,13 @@ helm list -n kguardian
 
 ```bash
 # Docker images
-docker pull ghcr.io/kguardian-dev/kguardian/guardian-controller
-docker pull ghcr.io/kguardian-dev/kguardian/guardian-broker
+docker pull ghcr.io/kguardian-dev/kguardian/controller
+docker pull ghcr.io/kguardian-dev/kguardian/broker
 docker pull ghcr.io/kguardian-dev/kguardian/frontend
 
-# Helm chart versions
-helm search repo kguardian --versions
+# Helm chart versions (OCI registry — no classic repo index)
+helm show chart oci://ghcr.io/kguardian-dev/charts/kguardian
+# or browse the GitHub releases page (chart/v* releases)
 
 # Advisor releases
 gh release list --repo kguardian-dev/kguardian
@@ -408,7 +412,7 @@ gh release list --repo kguardian-dev/kguardian
 
 6. **Pin component versions** in Helm values for production
    - Don't use `latest` in production
-   - Use specific version tags: `v1.2.3`
+   - Use specific version tags: `1.2.3`
 
 7. **Coordinate breaking changes**
    - Document breaking changes clearly in commit body
@@ -422,35 +426,7 @@ gh release list --repo kguardian-dev/kguardian
 
 ## Migration from Previous Versioning
 
-Previously, the project used a single `v*` tag for all components. With release-please:
-
-1. ✅ All workflows updated to use component-specific tags (component/v*)
-2. ✅ VERSION files created for each component at v1.0.0
-3. ✅ Helm chart updated to support component-specific versions
-4. ✅ Release-please configured for automated releases
-5. ✅ CHANGELOG.md files created for each component
-6. 🔄 Next step: Push to main and let release-please create the first Release PR
-7. 📋 Legacy `v*` tags remain for backward compatibility but are deprecated
-
-**Important:** With release-please, you no longer manually create tags. The automation handles all versioning, tagging, and changelog generation.
-
-## Validation and Testing
-
-Before using release-please in production, validate your configuration:
-
-```bash
-# Run the validation script
-./.github/scripts/validate-release-config.sh
-```
-
-This validates:
-- JSON syntax and structure
-- Component consistency
-- Version file existence and consistency
-- Workflow configuration
-- Conventional commit parsing
-
-For comprehensive testing including dry-runs, mock commits, and using the release-please CLI, see [.github/TESTING_RELEASES.md](.github/TESTING_RELEASES.md).
+The project migrated from a single `v*` tag to component-based versioning in 2025; legacy `v*` tags remain for backward compatibility but are deprecated.
 
 ## Examples
 
@@ -561,7 +537,7 @@ git push origin main
 
 # Release-please will:
 # 1. Create Release PR bumping chart from 1.0.0 -> 1.1.0
-# 2. Update charts/kguardian/Chart.yaml version and appVersion
+# 2. Update charts/kguardian/Chart.yaml version
 # 3. When merged, creates chart/v1.1.0 and publishes to OCI registry
 ```
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -43,22 +43,13 @@ We will not pursue legal action against researchers who follow this policy in go
 
 Security fixes are backported to currently supported releases only. Older releases receive fixes on a best-effort basis.
 
-| Component  | Version     | Supported          |
-|------------|-------------|--------------------|
-| Controller | latest minor | ✅ security fixes  |
-| Controller | older        | ❌ best-effort     |
-| Broker     | latest minor | ✅ security fixes  |
-| Broker     | older        | ❌ best-effort     |
-| Advisor    | latest minor | ✅ security fixes  |
-| Advisor    | older        | ❌ best-effort     |
-| UI         | latest minor | ✅ security fixes  |
-| Helm chart | latest minor | ✅ security fixes  |
+This applies uniformly to every independently versioned component — Controller, Broker, UI, Advisor CLI, Evaluator, MCP Server, LLM Bridge, and the Helm chart: the latest minor release of each receives security fixes; older releases get fixes on a best-effort basis only.
 
 "latest minor" means the most recent `MAJOR.MINOR.x` release line for each component. See [`RELEASES.md`](./RELEASES.md) for the per-component versioning model.
 
 ## Threat Model and Architecture Notes
 
-For security-relevant architecture details (Controller capabilities, Broker auth posture, data sensitivity, trust boundaries) see [`docs/security-model.mdx`](./docs/security-model.mdx). That page is the canonical source for "what does kguardian assume about its environment?" — please read it before reporting issues that depend on those assumptions.
+For security-relevant architecture details (Controller capabilities, Broker auth posture, data sensitivity, trust boundaries) see the docs site at [docs.kguardian.dev](https://docs.kguardian.dev) — please review the architecture and security material there before reporting issues that depend on those assumptions.
 
 ## Style
 

--- a/STYLE.md
+++ b/STYLE.md
@@ -12,11 +12,16 @@ Use `kguardian` (the package/system) when speaking about the project as a whole.
 
 ### Component nouns
 
-The system has three named components. When referring to the specific kguardian component, capitalize as proper nouns:
+The system has eight named components. When referring to the specific kguardian component, capitalize as proper nouns:
 
 - **Controller** — the eBPF DaemonSet that captures pod traffic and syscalls.
 - **Broker** — the Rust + Actix-web service that stores observed behavior in PostgreSQL and serves it back over an HTTP API.
 - **UI** — the React + TypeScript frontend that visualises pod-to-pod traffic.
+- **CLI** — the `kubectl kguardian` plugin (the `advisor` source directory) that generates policies from the observed baseline.
+- **Evaluator** — the Go service that checks live flows against `AuditNetworkPolicy` CRDs and reports would-deny verdicts.
+- **MCP Server** — the Go service exposing the Broker's data as MCP tools.
+- **LLM Bridge** — the TypeScript service that streams assistant responses to the UI via the MCP Server.
+- **database** — the PostgreSQL instance behind the Broker (lowercase; it is off-the-shelf, not a kguardian binary).
 
 When the same words appear generically (a controller in another tool, the broker pattern, a ui), keep them lowercase.
 
@@ -36,7 +41,7 @@ Avoid the awkward "kguardian Controller" form — within kguardian's own README 
 ## Tone
 
 - **Specific over fluff.** Prefer concrete numbers, kernel versions, and command examples. A docs sentence with a kernel version, a Helm version, and a kubectl flag in it is almost always stronger than one without.
-- **No emoji in headings.** Emoji is fine in feature-comparison tables, badges, and inline status markers (`✅`, `❌`, `🔜`). Headings stay text-only.
+- **Emoji in headings: root README only.** The root `README.md` uses emoji+badge headings — a deliberate choice from the 2026-07 redesign. Docs-site pages (`docs/*.mdx`) and component READMEs stay emoji-free in headings. Emoji is fine everywhere in feature-comparison tables, badges, and inline status markers (`✅`, `❌`, `🔜`).
 - **Banned marketing words.** The following do not appear in user-facing copy:
   - "made simple"
   - "tailored"
@@ -49,7 +54,7 @@ Avoid the awkward "kguardian Controller" form — within kguardian's own README 
 
 ## Versioning and links
 
-- Pin Helm chart versions in copy-paste install snippets so they do not drift behind newer releases. The Tier-1 baseline is `1.9.1`; bump in lockstep with chart releases.
+- Pin nothing in copy-paste install snippets — install unpinned so snippets never drift behind newer releases. Only show a pinned version when the snippet is specifically demonstrating version pinning.
 - Internal docs links are repo-relative (`/installation`, `/quickstart`, `/architecture`). External links use full URLs.
 - Cross-link rather than duplicate. If the same install snippet, comparison table, or "what is kguardian?" pitch already lives somewhere canonical, link to it instead of copy-pasting.
 
@@ -59,7 +64,7 @@ When the same content would otherwise appear in multiple places, this is the can
 
 | Topic | Canonical source |
 |---|---|
-| "What is kguardian?" pitch | `README.md` lede (line 10) — used verbatim in `docs/index.mdx` and `docs/concepts/overview.mdx` |
+| "What is kguardian?" pitch | `README.md` lede — used verbatim in `docs/index.mdx` and `docs/concepts/overview.mdx` |
 | Feature comparison table | `docs/index.mdx` `## Comparison with Other Tools` |
 | Install snippets (Helm, Krew, manual, Kind, custom values) | `docs/installation.mdx` |
 | Quickstart-flow install (one Helm command + link) | `docs/quickstart.mdx` Step 1 |

--- a/broker/README.md
+++ b/broker/README.md
@@ -1,1 +1,51 @@
-DOCKER_BUILDKIT=1 docker build . -t ghcr.io/kguardian-dev/kguardian/guardian-broker:latest
+# Broker
+
+The Broker is kguardian's API server: a Rust (actix-web) service that stores the telemetry the Controller captures — pod traffic, pod/service specs, syscalls — in PostgreSQL and serves it back to the UI, CLI, evaluator, and MCP server. It runs as a single replica behind the chart's `kguardian-broker` Service.
+
+## Build
+
+```bash
+DOCKER_BUILDKIT=1 docker build . -t ghcr.io/kguardian-dev/kguardian/broker:latest
+```
+
+## Endpoints
+
+Ingest (POST):
+
+- `/pod/traffic` and `/pod/traffic/batch` — traffic rows from the Controller
+- `/pod/spec`, `/pod/syscalls`, `/svc/spec` — pod details, syscalls, service details
+- `/pod/mark_dead` — mark a pod as no longer running
+
+Query (GET):
+
+- `/pod/traffic` (`?limit=`, default 5000, max 20000), `/pod/traffic/{name}`
+- `/pod/info`, `/pod/name/{name}`, `/pod/ip/{ip}`, `/pod/list/{node}`
+- `/pod/syscalls/{name}`
+- `/svc/info`, `/svc/ip/{ip}`
+- `/audit/verdicts`
+- `/version`, `/health`, `/metrics` (Prometheus text format)
+
+When `BROKER_AUTH_TOKEN` is set, all endpoints except `/health` and `/metrics` require a bearer token.
+
+## Configuration
+
+| Env var | Default | Purpose |
+|---|---|---|
+| `LISTEN_ADDR` | `0.0.0.0:9090` | HTTP bind address |
+| `DATABASE_URL` | — (required) | PostgreSQL connection string |
+| `DB_POOL_MAX_SIZE` | `32` | r2d2 pool size (floored to keep headroom over audit permits) |
+| `DB_STATEMENT_TIMEOUT_MS` | `30000` | Per-statement timeout backstop; `0` disables |
+| `DB_MIGRATION_MAX_RETRIES` | `10` | Startup migration retry budget (2s spacing) |
+| `BROKER_AUTH_TOKEN` | unset | Enables bearer-token auth when set |
+| `EVALUATOR_URL` | unset | Enables audit-evaluator forwarding when set |
+| `AUDIT_INFLIGHT_PERMITS` | `16` | Max concurrent evaluator calls |
+| `AUDIT_QUEUE_CAPACITY` | `2048` | Bounded ingest→audit queue size |
+| `AUDIT_EVAL_TIMEOUT_MS` | `500` | Per-call evaluator timeout (min 50) |
+| `AUDIT_VERDICTS_RETENTION_DAYS` | `30` | Verdict retention; `0` disables pruning |
+| `AUDIT_VERDICTS_RETENTION_INTERVAL_SECS` | `3600` | Pruner cadence |
+| `AUDIT_VERDICTS_RETENTION_BATCH_SIZE` | `5000` | Rows deleted per pruning batch |
+| `TELEMETRY_ENABLED` | `true` | Daily anonymous version check-in; `false` disables |
+| `TELEMETRY_ENDPOINT` | `https://version.kguardian.dev/v1/check` | Check-in endpoint override |
+| `TELEMETRY_INTERVAL_SECS` | `86400` | Check-in cadence (min 3600) |
+| `CHART_VERSION` / `KUBE_VERSION` | unset | Reported in the version check-in |
+| `RUST_LOG` | `info` | Log level |

--- a/cloudflare/version-service/README.md
+++ b/cloudflare/version-service/README.md
@@ -5,7 +5,7 @@ the broker's daily anonymous check-in ([docs/telemetry](../../docs/telemetry.mdx
 client: [`broker/src/version_check.rs`](../../broker/src/version_check.rs)).
 
 `GET /v1/check` returns the latest released component versions (GitHub
-Releases, cached 5 min in KV) and records the check-in's metadata in Workers
+Releases, cached 5 min via the Workers Cache API) and records the check-in's metadata in Workers
 Analytics Engine. IPs are not persisted; geo is Cloudflare's country code.
 
 ## Deploy

--- a/cloudflare/version-service/src/index.js
+++ b/cloudflare/version-service/src/index.js
@@ -6,8 +6,9 @@
  * GET /v1/check?install=&broker=&chart=&k8s=&nodes=&arch=
  *   → { "latest": { "chart": "1.13.2", "broker": "1.11.1", ... } }
  *
- * Latest versions come from the GitHub Releases API, cached in KV for
- * CACHE_TTL_SECS so the worker never rate-limits against GitHub and
+ * Latest versions come from the GitHub Releases API, cached via the
+ * Workers Cache API for CACHE_TTL_SECS so the worker never rate-limits
+ * against GitHub and
  * check-ins stay fast. Each request's metadata is written to Workers
  * Analytics Engine (dataset: TELEMETRY) — that dataset is the project's
  * usage telemetry. IP addresses are not persisted; country comes from
@@ -46,7 +47,7 @@ async function fetchLatestFromGitHub(env) {
       headers: {
         "User-Agent": "kguardian-version-service",
         Accept: "application/vnd.github+json",
-        // Optional: raises the rate limit from 60/h to 5000/h. The KV
+        // Optional: raises the rate limit from 60/h to 5000/h. The
         // cache keeps us far below either, so absence is fine.
         ...(env.GITHUB_TOKEN
           ? { Authorization: `Bearer ${env.GITHUB_TOKEN}` }

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,43 +1,14 @@
-# Mintlify Starter Kit
+# kguardian docs
 
-Use the starter kit to get your docs deployed and ready to customize.
+Source for the kguardian documentation site, published to [docs.kguardian.dev](https://docs.kguardian.dev) via Mintlify on push to `main`.
 
-Click the green **Use this template** button at the top of this repo to copy the Mintlify starter kit. The starter kit contains examples with
+Navigation and site configuration live in `docs.json`; pages are `.mdx` files in this directory.
 
-- Guide pages
-- Navigation
-- Customizations
-- API reference pages
-- Use of popular components
+Preview locally:
 
-**[Follow the full quickstart guide](https://starter.mintlify.com/quickstart)**
-
-## Development
-
-Install the [Mintlify CLI](https://www.npmjs.com/package/mint) to preview your documentation changes locally. To install, use the following command:
-
-```
+```bash
 npm i -g mint
+mint dev   # run from docs/, serves http://localhost:3000
 ```
 
-Run the following command at the root of your documentation, where your `docs.json` is located:
-
-```
-mint dev
-```
-
-View your local preview at `http://localhost:3000`.
-
-## Publishing changes
-
-Install our GitHub app from your [dashboard](https://dashboard.mintlify.com/settings/organization/github-app) to propagate changes from your repo to your deployment. Changes are deployed to production automatically after pushing to the default branch.
-
-## Need help?
-
-### Troubleshooting
-
-- If your dev environment isn't running: Run `mint update` to ensure you have the most recent version of the CLI.
-- If a page loads as a 404: Make sure you are running in a folder with a valid `docs.json`.
-
-### Resources
-- [Mintlify documentation](https://mintlify.com/docs)
+If the preview misbehaves, run `mint update` to get the latest CLI. User-facing copy follows the repo [Style Guide](../STYLE.md).

--- a/docs/advanced/troubleshooting.mdx
+++ b/docs/advanced/troubleshooting.mdx
@@ -36,7 +36,7 @@ kubectl get pods -n kguardian
     kubectl logs -n kguardian daemonset/kguardian-controller
     ```
 
-    Look for errors like: "failed to load BPF programs"
+    Look for errors like: "Failed to load network probe eBPF"
 
     **Solution:** Enable eBPF in cloud provider settings or use privileged security context.
   </Accordion>
@@ -73,22 +73,29 @@ kubectl get pods -n kguardian
     ```
   </Step>
 
-  <Step title="Check controller is sending data">
-    ```bash
-    kubectl logs -n kguardian daemonset/kguardian-controller | grep "Sending traffic"
-    ```
-  </Step>
-
   <Step title="Check broker is receiving data">
     ```bash
     kubectl logs -n kguardian deployment/kguardian-broker | grep POST
     ```
+
+    The controller logs its batch flushes ("Flushing network event
+    batch of N events") only at DEBUG, and the chart pins
+    `RUST_LOG=INFO` — so verify ingest at the broker side, or raise
+    the controller log level (see [Debug Mode](#debug-mode)).
   </Step>
 
-  <Step title="Query database directly">
+  <Step title="Query the broker directly">
     ```bash
     kubectl port-forward -n kguardian svc/kguardian-broker 9090:9090
-    curl http://localhost:9090/pod/traffic/10.244.1.5  # Use actual pod IP
+    curl 'http://localhost:9090/pod/traffic?limit=10'          # Recent rows, any pod
+    curl http://localhost:9090/pod/traffic/my-app-7d9f6b8c4-x5z2w  # Per-pod, by POD NAME
+    ```
+
+    The per-pod path takes a pod **name**, not an IP. If you only
+    have an IP, resolve it first with `GET /pod/ip/{ip}`:
+
+    ```bash
+    curl http://localhost:9090/pod/ip/10.244.1.5
     ```
   </Step>
 </Steps>
@@ -101,18 +108,28 @@ kubectl get pods -n kguardian
 
 **Symptoms:**
 ```
-Error: failed to connect to broker: connection refused
+Port forwarding failed
+Failed to setup port forwarding: ...
 ```
 
 **Solution:**
 
-The CLI auto-discovers the broker via port-forwarding. Ensure you have permissions:
+The CLI creates its own port-forward to the broker service — no
+manual port-forward is needed. Ensure you have permissions:
 
 ```bash
 kubectl auth can-i create pods/portforward -n kguardian
 ```
 
-If not, ask your cluster admin for permissions or manually port-forward:
+If kguardian is installed in a non-default namespace or with a
+renamed broker service, point the CLI at it:
+
+```bash
+kubectl kguardian gen netpol my-app --broker-namespace my-ns --broker-service my-broker
+```
+
+A manual port-forward is only needed when curling the broker API
+directly:
 
 ```bash
 kubectl port-forward -n kguardian svc/kguardian-broker 9090:9090 &
@@ -149,15 +166,16 @@ kubectl port-forward -n kguardian svc/kguardian-broker 9090:9090 &
 Enable debug logging for more details:
 
 ```bash
-# For controller
-helm upgrade kguardian kguardian/kguardian \
-  --namespace kguardian \
-  --set controller.debug=true \
-  --reuse-values
+# For controller — verbosity is the RUST_LOG env var, which the
+# chart's DaemonSet template fixes to INFO. Override it directly:
+kubectl set env daemonset/kguardian-controller RUST_LOG=debug -n kguardian
 
 # For CLI
 kubectl kguardian gen netpol my-app --debug
 ```
+
+The `kubectl set env` override reverts on the next `helm upgrade`,
+which re-renders the DaemonSet with the chart's pinned value.
 
 ---
 

--- a/docs/api-reference/endpoints/audit-verdicts.mdx
+++ b/docs/api-reference/endpoints/audit-verdicts.mdx
@@ -81,7 +81,7 @@ curl 'http://localhost:9090/audit/verdicts?namespace='
 | `src_namespace` / `src_pod` | For `direction=Ingress`: typically `null` (the peer is an external IP). For `direction=Egress`: the subject pod's identity. |
 | `dst_namespace` / `dst_pod` | Mirror of above. |
 | `dst_port` / `protocol` | The flow's destination port + protocol (`"TCP"`/`"UDP"`/`"SCTP"`). |
-| `reason` | Free-text rationale from the matcher when `verdict=WouldDeny`; empty for `Allow`. |
+| `reason` | Free-text rationale from the matcher when `verdict=WouldDeny`; JSON `null` (not an empty string) for `Allow`. |
 | `observed_at` | UTC timestamp the broker stamped when the verdict was inserted (microsecond precision). |
 | `verdict` | `"Allow"` (a rule matched and permitted the flow) or `"WouldDeny"` (no rule matched, or `NotApplicable` results are dropped before insert). |
 

--- a/docs/api-reference/endpoints/pods.mdx
+++ b/docs/api-reference/endpoints/pods.mdx
@@ -65,6 +65,10 @@ filter (and logs a warn for the missing precision). Empty
 Return all pod metadata rows. Ordered by
 `(pod_namespace ASC, pod_name ASC)` for stable display.
 
+The stored/returned `pod_obj` is compacted, not the full manifest:
+only `metadata` (minus `managedFields`) and `spec.hostNetwork` are
+kept — containers, volumes, and status are dropped.
+
 ```bash
 curl http://localhost:9090/pod/info
 ```

--- a/docs/api-reference/endpoints/traffic.mdx
+++ b/docs/api-reference/endpoints/traffic.mdx
@@ -11,10 +11,11 @@ eBPF ring buffers; external integrations rarely need it (prefer
 `POST /pod/traffic/batch` below for bulk).
 
 Duplicate events (same `pod_ip`, `pod_port`, `traffic_type`,
-`traffic_in_out_ip`, `traffic_in_out_port`, `ip_protocol`,
-`decision`) are deduped server-side and reported back as the
-inserted-or-Null result. The audit forwarder (when
-`evaluator.enabled: true`) is fired only for events that were
+`traffic_in_out_ip`, `traffic_in_out_port`, `decision`) are deduped
+server-side; the check is protocol-aware, branching on the event's
+protocol rather than treating `ip_protocol` as a plain key column.
+The result reported back is inserted-or-Null. The audit forwarder
+(when `evaluator.enabled: true`) is fired only for events that were
 genuinely new.
 
 ### Request
@@ -52,21 +53,22 @@ dedup.
 
 ## GET /pod/traffic
 
-Get every observed traffic row. Returns rows ordered
+Get a most-recent-first window of observed traffic rows, ordered
 `(time_stamp DESC, uuid DESC)` — newest first, with the UUID
 primary key as a tiebreak for microsecond-collision rows from a
-single batch ingest.
+single batch ingest. The query is backed by the
+`idx_pod_traffic_time_stamp` index.
 
-<Warning>
-Currently unbounded — no LIMIT, no pagination. On a busy cluster
-with months of retained traffic this can be tens of MB to GB of
-JSON. Prefer the per-pod variant for any interactive use.
-</Warning>
+### Query Parameters
+
+| Parameter | Type    | Default | Description |
+|-----------|---------|---------|-------------|
+| `limit`   | integer | 5000    | Cap rows returned. Clamped to `[1, 20000]`; values outside that range are silently clamped to the nearest bound. Non-numeric input returns 400. |
 
 ### Example
 
 ```bash
-curl http://localhost:9090/pod/traffic
+curl 'http://localhost:9090/pod/traffic?limit=100'
 ```
 
 ### Response

--- a/docs/api-reference/endpoints/version.mdx
+++ b/docs/api-reference/endpoints/version.mdx
@@ -1,0 +1,52 @@
+---
+title: "Version Endpoint"
+description: "Running broker + chart versions and update availability"
+---
+
+## Overview
+
+The broker checks in with the kguardian version service once a day
+(see [telemetry](/telemetry)) to learn the latest released component
+versions. `GET /version` surfaces the useful half of that exchange:
+the versions currently running plus the latest known ones, so the
+frontend can show an update notice and the MCP layer can answer
+"am I up to date?".
+
+When telemetry is disabled the endpoint still works — it reports the
+current versions with `latest` and `checked_at` as `null`.
+
+## GET /version
+
+Requires bearer auth when `BROKER_AUTH_TOKEN` is set — unlike
+`/health` and `/metrics`, it is not on the exempt list.
+
+### Example
+
+```bash
+curl http://localhost:9090/version
+```
+
+### Response
+
+```json
+{
+  "broker": "1.7.0",
+  "chart": "1.13.1",
+  "telemetry_enabled": true,
+  "latest": {
+    "chart": "1.13.2",
+    "broker": "1.7.1"
+  },
+  "checked_at": "2026-07-18T04:12:09.123456",
+  "update_available": true
+}
+```
+
+| Field | Notes |
+|-------|-------|
+| `broker` | Version of the running broker (crate version). |
+| `chart` | Helm chart version, injected by the chart at install time. `"unknown"` when the broker runs outside the chart (dev, docker-compose). |
+| `telemetry_enabled` | Whether the daily check-in loop is active. |
+| `latest` | Component name → latest released version, as reported by the version service. `null` until the first successful check-in — or forever, when telemetry is disabled. |
+| `checked_at` | UTC timestamp of the last successful check-in; `null` when `latest` is `null`. |
+| `update_available` | `true` when the latest chart version differs from the running one. `false` when the chart version is `"unknown"` or no check-in data exists — the broker never nags when it can't compare. |

--- a/docs/api-reference/introduction.mdx
+++ b/docs/api-reference/introduction.mdx
@@ -22,8 +22,17 @@ kubectl port-forward -n kguardian svc/kguardian-broker 9090:9090
 
 ## Authentication
 
+Authentication is **opt-in** bearer-token auth, off by default. Set the
+`BROKER_AUTH_TOKEN` environment variable on the broker and every
+endpoint except `/health` and `/metrics` requires an
+`Authorization: Bearer <token>` header; a missing or invalid token
+returns `401`.
+
 <Warning>
-The broker currently has **no authentication**. The API should only be accessible within the cluster network. For production deployments, consider using NetworkPolicies, service mesh, or an API gateway with authentication.
+Without `BROKER_AUTH_TOKEN` set, the API is unauthenticated and should
+only be reachable within the cluster network. For production
+deployments, enable token auth and/or restrict access with
+NetworkPolicies, a service mesh, or an API gateway.
 </Warning>
 
 For the broker's current released version, see
@@ -49,6 +58,9 @@ For the broker's current released version, see
   <Card title="Audit Verdicts" icon="shield-check" href="/api-reference/endpoints/audit-verdicts">
     Query Would-Deny / Allow verdicts from the audit evaluator
   </Card>
+  <Card title="Version" icon="tag" href="/api-reference/endpoints/version">
+    Running broker + chart versions, latest known releases, and update availability
+  </Card>
 </CardGroup>
 
 ## Response Format
@@ -57,6 +69,7 @@ All responses are JSON with standard HTTP status codes:
 
 - `200 OK` - Success
 - `400 Bad Request` - Invalid parameters
+- `401 Unauthorized` - Missing or invalid bearer token (only when `BROKER_AUTH_TOKEN` is set)
 - `404 Not Found` - Resource not found
 - `500 Internal Server Error` - Server error
 
@@ -64,13 +77,14 @@ All responses are JSON with standard HTTP status codes:
 
 ### Pagination
 
-Most endpoints return all matching rows without paging — fine for
-small / medium clusters but unbounded on busy ones. `/audit/verdicts`
-is the exception: it supports a `limit` query parameter (default 100,
-max 500) and orders by `(observed_at DESC, id DESC)` for stable
-cursor-style traversal. The `/pod/info`, `/svc/info`, `/pod/traffic`
-and `/pod/traffic/{name}` endpoints have stable ordering too — see
-each page for the sort key — but no LIMIT yet.
+The high-volume endpoints support a `limit` query parameter:
+`/pod/traffic` defaults to 5000 rows (clamped to `[1, 20000]`,
+most-recent-first) and `/audit/verdicts` defaults to 100 (clamped to
+`[1, 500]`), both ordered newest-first with the primary key as a
+tiebreak for stable cursor-style traversal. Only
+`/pod/traffic/{name}` remains unbounded. The `/pod/info` and
+`/svc/info` endpoints return all rows but have stable ordering — see
+each page for the sort key.
 
 ### Filtering
 

--- a/docs/architecture.mdx
+++ b/docs/architecture.mdx
@@ -6,7 +6,7 @@ icon: "sitemap"
 
 ## System Architecture
 
-kguardian is designed as a distributed system with four main components that work together to observe, analyze, and secure your Kubernetes workloads.
+kguardian is designed as a distributed system: four core components (Controller, Broker, CLI, UI) plus an audit-mode evaluator (deployed by default) and an optional AI assistant (llm-bridge + mcp-server) work together to observe, analyze, and secure your Kubernetes workloads.
 
 ```mermaid
 graph TB
@@ -26,6 +26,7 @@ graph TB
         Broker[Broker API<br/>Rust + Actix]
         DB[(PostgreSQL<br/>Telemetry Data)]
         UI[Web UI<br/>React + TypeScript]
+        Evaluator[Evaluator<br/>Audit Mode]
     end
 
     subgraph "Developer Machine"
@@ -35,6 +36,8 @@ graph TB
     Controller1 -->|Network Traffic<br/>Syscall Data| Broker
     Controller2 -->|Network Traffic<br/>Syscall Data| Broker
     Broker --> DB
+    Broker -->|flows| Evaluator
+    Evaluator -->|would-deny verdicts| Broker
     CLI -->|Query Traffic<br/>Generate Policies| Broker
     UI -->|Visualize Data| Broker
 
@@ -84,13 +87,25 @@ graph TB
 
     **Purpose:** Visualizes network topology
   </Card>
+
+  <Card title="Evaluator" icon="scale-balanced" iconType="duotone">
+    **Deployment:** Deployment (on by default; disable with `evaluator.enabled=false`)
+
+    **Purpose:** Replays observed flows against policies and records would-deny verdicts
+  </Card>
+
+  <Card title="AI Assistant (Optional)" icon="robot" iconType="duotone">
+    **Deployment:** llm-bridge + mcp-server (opt-in via chart values)
+
+    **Purpose:** Natural-language queries and conversational policy generation
+  </Card>
 </CardGroup>
 
 ## Data Flow
 
 <Steps>
   <Step title="1. eBPF Monitoring" icon="radar">
-    The **Controller** attaches eBPF programs to kernel hooks (`tcp_connect`, `syscall enter/exit`, etc.) on each node. When pods make network connections or execute syscalls, eBPF programs capture:
+    The **Controller** attaches eBPF programs to kernel hooks on each node — fentry probes on `tcp_v4_connect`, `tcp_set_state`, `udp_sendmsg`, and `tcp_retransmit_skb`, a kprobe/kretprobe pair on `inet_csk_accept`, and the `raw_syscalls/sys_enter` tracepoint. When pods make network connections or execute syscalls, eBPF programs capture:
 
     - Source/destination IPs and ports
     - Protocol (TCP/UDP)
@@ -99,14 +114,14 @@ graph TB
     - Timestamp
 
     <Info>
-    eBPF runs in the kernel with minimal overhead (~1-2% CPU), avoiding the need for sidecar proxies or agent injection.
+    eBPF runs in the kernel with low overhead, avoiding the need for sidecar proxies or agent injection.
     </Info>
   </Step>
 
   <Step title="2. Event Enrichment" icon="tags">
     The Controller's userspace component:
 
-    1. Receives events from eBPF via perf buffers
+    1. Receives events from eBPF via BPF ring buffers
     2. Queries **containerd** to map network namespace inodes to container IDs
     3. Matches containers to **Kubernetes pods** via the API server
     4. Enriches events with pod name, namespace, labels, and owner references
@@ -115,9 +130,11 @@ graph TB
   <Step title="3. Data Transmission" icon="paper-plane">
     Enriched events are sent to the **Broker** via HTTP POST:
 
-    - Network traffic → `/pods` and `/pod/spec`
-    - Syscall data → `/pods/syscalls`
+    - Network traffic → `/pod/traffic` (batched via `/pod/traffic/batch`)
+    - Pod metadata → `/pod/spec`
+    - Syscall data → `/pod/syscalls`
     - Service mappings → `/svc/spec`
+    - Pod deletions → `/pod/mark_dead`
 
     The Controller batches events to reduce network overhead.
   </Step>
@@ -170,7 +187,7 @@ graph TB
   <Accordion icon="linux" title="eBPF Programs">
     - Written in C, compiled with `clang -target bpf`
     - Use `libbpf-cargo` to generate Rust skeleton bindings (`.skel.rs`)
-    - Attach to kprobes: `tcp_connect`, `tcp_sendmsg`, etc.
+    - Attach fentry probes to `tcp_v4_connect`, `tcp_set_state`, `udp_sendmsg`, and `tcp_retransmit_skb`; a kprobe/kretprobe pair to `inet_csk_accept`; and the `raw_syscalls/sys_enter` tracepoint
     - Use BPF maps for kernel ↔ userspace communication
   </Accordion>
 
@@ -194,19 +211,20 @@ graph TB
 
   <Accordion icon="database" title="Data Schema">
     Tables:
-    - `pods`: Pod metadata (name, namespace, IP, labels, spec)
-    - `services`: Service metadata (name, namespace, cluster IP, selectors)
+    - `pod_details`: Pod metadata (name, namespace, IP, labels, spec)
+    - `svc_details`: Service metadata (name, namespace, cluster IP, selectors)
     - `pod_traffic`: Network connections (src/dst IP, port, protocol, type)
     - `pod_syscalls`: Syscall observations (pod, syscall names, count, architecture)
+    - `audit_verdicts`: Evaluator would-deny verdicts for observed flows
+    - `install_info`: Installation metadata
 
     Indexes optimize queries by pod IP and name/namespace.
   </Accordion>
 
   <Accordion icon="box-archive" title="Data Retention">
-    Currently, data is retained indefinitely. Future versions will support:
-    - Configurable retention periods
-    - Automatic data aggregation/rollup
-    - Export to external systems (S3, etc.)
+    - `audit_verdicts` are pruned automatically: `broker.audit.retention.days` (default 30), with `intervalSeconds` and `batchSize` controlling the pruning loop.
+    - `pod_traffic` and `pod_syscalls` are retained indefinitely.
+    - The cluster-wide `GET /pod/traffic` endpoint is capped to protect the broker: 5000 rows by default, up to 20000 via `?limit=`.
   </Accordion>
 </AccordionGroup>
 
@@ -222,8 +240,8 @@ graph TB
 
   <Accordion icon="network-wired" title="Policy Generation Logic">
     Network policies:
-    1. Query `/pod/traffic/name/:namespace/:pod` from Broker
-    2. For each unique peer IP, query `/pod/ip/:ip` or `/svc/ip/:ip`
+    1. Query `/pod/traffic/{pod}` from Broker
+    2. For each unique peer IP, query `/pod/ip/{ip}` or `/svc/ip/{ip}`
     3. Build `NetworkPolicyPeer` with `podSelector` + `namespaceSelector`
     4. Group by direction (ingress/egress) and port/protocol
     5. Deduplicate rules via JSON marshaling comparison
@@ -231,7 +249,7 @@ graph TB
   </Accordion>
 
   <Accordion icon="shield-check" title="Seccomp Generation Logic">
-    1. Query `/pod/syscalls/name/:namespace/:pod` from Broker
+    1. Query `/pod/syscalls/{pod}` from Broker
     2. Extract unique syscall names from aggregated data
     3. Group by architecture (x86_64, arm64, etc.)
     4. Generate JSON with `defaultAction: SCMP_ACT_ERRNO`
@@ -285,7 +303,7 @@ kguardian-db-bbbbbb-yyyyy
 # Deployment: Web frontend
 kguardian-frontend-cccccc-xxxxx
 
-# Deployment: Evaluator (when audit mode is enabled)
+# Deployment: Evaluator (on by default; disable with evaluator.enabled=false)
 kguardian-evaluator-dddddd-wwwww
 
 # Deployment: MCP server + LLM bridge (when AI assistant is enabled)
@@ -311,17 +329,16 @@ The Controller **must** run on every node you want to monitor. Use node selector
 <AccordionGroup>
   <Accordion icon="lock" title="Controller Privileges">
     The Controller requires:
-    - **Privileged** container (to load eBPF programs)
-    - **hostNetwork** (to access node network namespace)
-    - **CAP_BPF**, **CAP_PERFMON**, **CAP_SYS_RESOURCE** capabilities
+    - **Privileged** container with **CAP_BPF** added (to load eBPF programs)
+    - **hostNetwork: true** (to access the node network namespace)
 
     These are necessary for eBPF functionality but should be carefully reviewed in your security policy.
   </Accordion>
 
   <Accordion icon="key" title="Data Access">
-    - Broker API currently has **no authentication** (assumes network isolation)
-    - For production, consider:
-      - Network policies to restrict Broker access
+    - The Broker API is **unauthenticated by default**, with opt-in bearer-token auth via `broker.auth` (`BROKER_AUTH_TOKEN`); `/health` and `/metrics` stay exempt
+    - The chart can also manage a **NetworkPolicy** restricting Broker access
+    - For production, additionally consider:
       - Ingress with authentication (OAuth2 proxy, etc.)
       - mTLS between components
   </Accordion>
@@ -338,15 +355,18 @@ The Controller **must** run on every node you want to monitor. Use node selector
 
 ## Performance Characteristics
 
-| Component   | CPU (idle) | CPU (busy) | Memory  | Notes |
-|-------------|-----------|-----------|---------|-------|
-| Controller  | 10-20m    | 50-100m   | 50-100Mi | Per node, depends on pod count |
-| Broker      | 5-10m     | 50-200m   | 100-200Mi | Scales with request rate |
-| PostgreSQL  | 10-20m    | 50-100m   | 256Mi-1Gi | Depends on data volume |
-| UI          | 1-5m      | 10-20m    | 50-100Mi | Static content serving |
+The chart ships with these default resource requests and limits:
+
+| Component   | CPU request | Memory request | Memory limit | Notes |
+|-------------|------------|----------------|--------------|-------|
+| Controller  | 100m       | 256Mi          | 512Mi        | Per node (DaemonSet) |
+| Broker      | 100m       | 256Mi          | 1Gi          | Scales with request rate |
+| PostgreSQL  | 100m       | 256Mi          | 512Mi        | Depends on data volume |
+| UI          | 50m        | 128Mi          | 256Mi        | Static content serving |
+| Evaluator   | 50m        | 64Mi           | 256Mi        | Audit-mode verdicts |
 
 <Info>
-In testing with 100 pods generating moderate traffic, total cluster overhead is ~200-400m CPU and ~500Mi-1Gi memory.
+For measured numbers from a real deployment, see the [reference deployment in the project README](https://github.com/kguardian-dev/kguardian#readme).
 </Info>
 
 ## Scalability
@@ -357,7 +377,7 @@ In testing with 100 pods generating moderate traffic, total cluster overhead is 
 - **CLI**: No scaling concerns (client-side)
 - **UI**: Horizontal scaling behind ingress
 
-Tested up to **1000 pods** across **50 nodes** with acceptable performance. For larger clusters, consider:
+For larger clusters, consider:
 - Sharding data by namespace
 - Time-windowed queries
 - Data aggregation/rollup

--- a/docs/cli/gen-networkpolicy.mdx
+++ b/docs/cli/gen-networkpolicy.mdx
@@ -20,7 +20,7 @@ kubectl kguardian gen netpol [POD_NAME] [flags]  # Alias
 | `-n, --namespace` | string | Namespace of the pod | Current namespace |
 | `-a, --all` | bool | Generate for all pods in namespace | `false` |
 | `-A, --all-namespaces` | bool | Generate for all pods cluster-wide | `false` |
-| `-t, --type` | string | Policy type: `kubernetes` or `cilium` | `kubernetes` |
+| `-t, --type` | string | Policy type: `kubernetes` (alias `k8s`) or `cilium` | `kubernetes` |
 | `--output-dir` | string | Directory to save policies | `network-policies` |
 | `--dry-run` | bool | Generate without applying | `true` |
 

--- a/docs/cli/gen-seccomp.mdx
+++ b/docs/cli/gen-seccomp.mdx
@@ -18,7 +18,7 @@ kubectl kguardian gen secp [POD_NAME] [flags]  # Alias
 | Flag | Type | Description | Default |
 |------|------|-------------|---------|
 | `-n, --namespace` | string | Namespace of the pod | Current namespace |
-| `-a, --all` | bool | Generate for all pods in namespace | `false` |
+| `--all` | bool | Generate for all pods in namespace (no `-a` shorthand) | `false` |
 | `-A, --all-namespaces` | bool | Generate for all pods cluster-wide | `false` |
 | `--output-dir` | string | Directory to save profiles | `seccomp-profiles` |
 | `--default-action` | string | Action for unlisted syscalls | `SCMP_ACT_ERRNO` |

--- a/docs/cli/overview.mdx
+++ b/docs/cli/overview.mdx
@@ -21,7 +21,13 @@ Available for all commands:
 | `--kubeconfig` | Path to kubeconfig file | `$KUBECONFIG` or `~/.kube/config` |
 | `--context` | Kubernetes context to use | Current context |
 | `-n, --namespace` | Namespace scope | Current namespace |
+| `--broker-namespace` | Namespace where the kguardian broker is installed | `kguardian` |
+| `--broker-service` | Name of the kguardian broker service | `broker` |
 | `--debug` | Enable debug logging | `false` |
+
+`--broker-namespace` and `--broker-service` matter when kguardian is
+installed outside the default `kguardian` namespace — the CLI
+port-forwards to the broker and needs to find it.
 
 ## Commands
 
@@ -37,6 +43,12 @@ Available for all commands:
   </Card>
   <Card title="audit promote-cluster" icon="globe" href="/concepts/audit-network-policy#cluster-scoped--kguardian-audit-promote-cluster">
     Convert an AuditClusterNetworkPolicy into one NetworkPolicy per matched namespace (discovery from `namespaceSelector`).
+  </Card>
+  <Card title="serve" icon="server">
+    Run the advisor as an in-cluster HTTP service exposing `/generate/networkpolicy`, `/generate/seccomp`, and `/healthz` — used by the MCP server's chat tools.
+  </Card>
+  <Card title="version" icon="tag">
+    Print client version information. Also available as `-v` / `--version` on the root command.
   </Card>
 </CardGroup>
 

--- a/docs/concepts/audit-network-policy.mdx
+++ b/docs/concepts/audit-network-policy.mdx
@@ -31,14 +31,14 @@ This pattern is directly modelled on Calico's [`StagedKubernetesNetworkPolicy`](
                                   (Postgres)                              │ + Pods + Namespaces
                                           │                               │
                                           ▼                               ▼
-                                 frontend "Would-Deny"             status.evaluation
-                                 view + Prometheus              + would-deny logs / events
+                                 frontend "Would-Deny" view        status.evaluation
+                                                                  + would-deny logs
 ```
 
 1. The controller observes every TCP/UDP connection on each node (no change from before).
 2. The broker forwards each flow to the evaluator's `/evaluate` endpoint.
 3. The evaluator looks up which `AuditNetworkPolicy` resources select either side of the flow, runs the standard NetworkPolicy semantics over the rule set, and returns a verdict per (policy, direction).
-4. `WouldDeny` verdicts are persisted in `audit_verdicts` and surface as logs, Kubernetes Events on the policy, and rolling counts in `.status.evaluation`.
+4. `WouldDeny` verdicts are persisted in `audit_verdicts` and surface as logs and cumulative counts in `.status.evaluation` — counts accumulate from evaluator start and reset when the evaluator restarts. (Kubernetes Events on the policy are planned.) The broker's `/metrics` endpoint exposes audit pipeline health (`broker_audit_dropped_total`, `broker_audit_inflight_available`), not would-deny counts.
 
 ## Example
 
@@ -83,7 +83,7 @@ spec:
           port: 5432
 ```
 
-`kubectl get auditnetworkpolicy payments-isolation -n prod` shows a `WOULD-DENY` column populated by the rolling-window count. `kubectl describe` shows the most frequent offenders.
+`kubectl get auditnetworkpolicy payments-isolation -n prod` shows a `WOULD-DENY` column populated by the cumulative count (since evaluator start; resets on restart). `kubectl describe` shows the most frequent offenders.
 
 ## Promoting to enforced
 
@@ -102,7 +102,7 @@ Your CNI now enforces the policy. The evaluator stops watching it.
 
 ## Tracking evaluator progress — `status.observedGeneration`
 
-After you edit an `AuditNetworkPolicy` (e.g. broaden a `to:` selector) the evaluator has to pick the new spec up, re-evaluate the rolling window of observed traffic, and re-publish the `WOULD-DENY` counts. The CRD exposes `.status.observedGeneration` so you know when that loop has caught up:
+After you edit an `AuditNetworkPolicy` (e.g. broaden a `to:` selector) the evaluator picks the new spec up and starts evaluating *new* flows against it. The CRD exposes `.status.observedGeneration` so you know when that has happened:
 
 ```sh
 kubectl get auditnetworkpolicy payments-isolation -n prod \
@@ -111,7 +111,7 @@ kubectl get auditnetworkpolicy payments-isolation -n prod \
 # e.g.  4 → 3   ← still working through your last edit
 ```
 
-The evaluator stamps `observedGeneration` once it has finished a full reconcile of the current `.metadata.generation`. Don't trust the `WOULD-DENY` count for tuning decisions until the two numbers match.
+The evaluator advances `observedGeneration` once a new flow has been evaluated against the new spec (status is flushed roughly every 30 seconds). It does not re-evaluate historical traffic — with no new traffic, `observedGeneration` never advances. Verdicts recorded before your edit stay in the cumulative totals, so don't trust the `WOULD-DENY` count for tuning decisions until the two numbers match and fresh traffic has flowed under the new spec.
 
 ## Querying verdicts directly
 

--- a/docs/concepts/ebpf-monitoring.mdx
+++ b/docs/concepts/ebpf-monitoring.mdx
@@ -15,9 +15,9 @@ kguardian attaches eBPF programs to kernel hooks to observe pod behavior:
 ### Network Traffic Monitoring
 
 **Hook points:**
-- `tcp_connect` - Outbound TCP connections
-- `tcp_sendmsg` / `tcp_recvmsg` - Data transmission
-- `udp_sendmsg` / `udp_recvmsg` - UDP traffic
+- `fentry/tcp_set_state` - TCP connection lifecycle (both inbound and outbound)
+- `kprobe`/`kretprobe` on `inet_csk_accept` - Inbound TCP connections
+- `fentry/udp_sendmsg` - Outbound UDP traffic
 
 **Captured data:**
 - Source and destination IP addresses
@@ -25,22 +25,25 @@ kguardian attaches eBPF programs to kernel hooks to observe pod behavior:
 - Protocol (TCP/UDP)
 - Network namespace (to map to containers)
 
+<Warning>
+Inbound UDP is not captured — there is no probe for UDP receive. Traffic arriving at a pod over UDP (e.g. DNS queries reaching CoreDNS) will not appear in the flow stream. Egress UDP and all TCP directions are tracked normally.
+</Warning>
+
 ### Syscall Monitoring
 
 **Hook points:**
-- `sys_enter_*` - Entry to any syscall
-- `sys_exit_*` - Exit from syscall
+- `tracepoint/raw_syscalls/sys_enter` - Entry to any syscall
 
 **Captured data:**
-- Syscall name (e.g., `open`, `read`, `socket`)
+- Syscall number, resolved to a name (e.g., `open`, `read`, `socket`) in userspace
 - Process ID and container namespace
-- Architecture (x86_64, arm64, etc.)
+- Node architecture (`x86_64` or `aarch64`)
 
 ## Why eBPF?
 
 <CardGroup cols={2}>
   <Card title="Performance" icon="gauge-high">
-    ~1-2% CPU overhead vs 10-20% for proxy-based solutions
+    In-kernel tracing avoids the per-request cost of proxy-based solutions
   </Card>
   <Card title="Safety" icon="shield-check">
     Verifier ensures programs can't crash the kernel
@@ -49,7 +52,7 @@ kguardian attaches eBPF programs to kernel hooks to observe pod behavior:
     No code changes, sidecars, or pod restarts needed
   </Card>
   <Card title="Kernel-Level Visibility" icon="eye">
-    See everything, including encrypted connections
+    Connection metadata (endpoints, ports, protocol) is visible even for encrypted traffic — payloads are never captured
   </Card>
 </CardGroup>
 
@@ -57,4 +60,3 @@ kguardian attaches eBPF programs to kernel hooks to observe pod behavior:
 
 **Learn more:**
 - [Architecture Overview](/architecture)
-- [Controller Implementation](/development/controller)

--- a/docs/concepts/network-policies.mdx
+++ b/docs/concepts/network-policies.mdx
@@ -42,7 +42,7 @@ spec:
 
 ## How kguardian Generates Policies
 
-1. **Observes traffic** via eBPF for 5+ minutes
+1. **Observes traffic** continuously via eBPF (let several minutes of representative traffic accumulate before generating)
 2. **Identifies peers** by resolving IPs to pods/services
 3. **Groups rules** by protocol and port
 4. **Deduplicates** to create minimal policies
@@ -71,4 +71,4 @@ spec:
 
 **Next steps:**
 - [Generate Network Policies](/guides/generating-network-policies)
-- [Cilium Policies](/advanced/cilium-policies)
+- [Policy Gallery](/policy-gallery/index)

--- a/docs/concepts/overview.mdx
+++ b/docs/concepts/overview.mdx
@@ -21,7 +21,7 @@ kguardian uses eBPF (extended Berkeley Packet Filter) technology to observe kern
 - **Zero code changes**: No sidecars, agents, or instrumentation needed
 
 <Info>
-eBPF runs safely in the kernel with minimal overhead (~1-2% CPU), making it perfect for production observability.
+eBPF runs safely in the kernel with the low overhead typical of eBPF tracing, making it well suited to production observability.
 </Info>
 
 ### Least-Privilege Security

--- a/docs/concepts/seccomp-profiles.mdx
+++ b/docs/concepts/seccomp-profiles.mdx
@@ -41,10 +41,10 @@ Example generated profile:
 - `SCMP_ACT_ALLOW`: Allow the syscall
 - `SCMP_ACT_ERRNO`: Block with error (default for unlisted)
 - `SCMP_ACT_LOG`: Log the syscall but allow it
-- `SCMP_ACT_KILL`: Kill the process (most restrictive)
+- `SCMP_ACT_KILL`: Kill the calling thread
+- `SCMP_ACT_KILL_PROCESS`: Kill the whole process (most restrictive)
 
 ---
 
 **Next steps:**
-- [Generate Seccomp Profiles](/guides/generating-seccomp-profiles)
 - [CLI Reference](/cli/gen-seccomp)

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -90,7 +90,8 @@
               "api-reference/endpoints/traffic",
               "api-reference/endpoints/syscalls",
               "api-reference/endpoints/services",
-              "api-reference/endpoints/audit-verdicts"
+              "api-reference/endpoints/audit-verdicts",
+              "api-reference/endpoints/version"
             ]
           }
         ]

--- a/docs/guides/generating-network-policies.mdx
+++ b/docs/guides/generating-network-policies.mdx
@@ -40,7 +40,7 @@ kubectl kguardian gen networkpolicy my-app -n production \
   </Step>
 
   <Step title="Generates YAML">
-    Creates `production-my-app-networkpolicy.yaml` in the `./policies` directory
+    Creates `production-my-app-standard-networkpolicy.yaml` in the `./policies` directory
   </Step>
 </Steps>
 
@@ -50,11 +50,12 @@ kubectl kguardian gen networkpolicy my-app -n production \
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: my-app
+  name: my-app-standard-policy
   namespace: production
   labels:
-    kguardian.dev/managed-by: kguardian
-    kguardian.dev/version: v1.0.0
+    app.kubernetes.io/name: my-app
+    app.kubernetes.io/component: standard-policy
+    app.kubernetes.io/part-of: kguardian
 spec:
   podSelector:
     matchLabels:
@@ -144,21 +145,20 @@ kubectl kguardian gen networkpolicy my-app -n production \
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
-  name: my-app
+  name: my-app-cilium-policy
   namespace: production
   labels:
-    kguardian.dev/managed-by: kguardian
-    kguardian.dev/version: v1.0.0
+    app.kubernetes.io/name: my-app
+    app.kubernetes.io/component: cilium-policy
+    app.kubernetes.io/part-of: kguardian
 spec:
   endpointSelector:
     matchLabels:
-      app: my-app
+      k8s:app: my-app
   ingress:
     - fromEndpoints:
         - matchLabels:
-            app: api-gateway
-        - matchLabels:
-            io.kubernetes.pod.namespace: production
+            k8s:app: api-gateway
       toPorts:
         - ports:
             - port: "8080"
@@ -166,20 +166,21 @@ spec:
   egress:
     - toEndpoints:
         - matchLabels:
-            app: postgres
-        - matchLabels:
-            io.kubernetes.pod.namespace: production
+            k8s:app: postgres
       toPorts:
         - ports:
             - port: "5432"
               protocol: TCP
-    - toCIDR:
-        - "10.96.0.10/32"  # kube-dns
+    - toEndpoints:
+        - matchLabels:
+            k8s:k8s-app: kube-dns
       toPorts:
         - ports:
             - port: "53"
               protocol: UDP
 ```
+
+Each peer gets a single endpoint selector built from that peer's labels: the Service's selector when the IP resolves to a Service (as with kube-dns above), the pod's labels otherwise. `toCIDR`/`fromCIDR` entries appear only for IPs that can't be resolved to a pod or Service. Label keys in the generated YAML carry Cilium's `k8s:` source prefix.
 
 ### Cilium vs Kubernetes Policies
 
@@ -200,7 +201,7 @@ If you're running Cilium CNI, use `--type cilium` for better security and featur
 
 ---
 
-## Dry Run vs Apply
+## Dry Run and Applying
 
 ### Dry Run (Default)
 
@@ -211,33 +212,27 @@ kubectl kguardian gen netpol my-app -n prod --output-dir ./policies
 
 # Policies are saved but NOT applied
 # Review them first:
-cat ./policies/prod-my-app-networkpolicy.yaml
+cat ./policies/prod-my-app-standard-networkpolicy.yaml
 ```
 
-### Direct Apply
-
-To generate **and immediately apply** policies:
-
-```bash
-kubectl kguardian gen netpol my-app -n prod \
-  --dry-run=false \
-  --output-dir ./policies
-```
-
-<Warning>
-**Use with caution!** Applying network policies can break communication if the observed traffic was incomplete. Always test in non-production first.
-</Warning>
+<Note>
+Applying directly from the CLI is not implemented. Passing `--dry-run=false` currently behaves the same as dry-run — policies are only saved to files — and the CLI logs a warning to that effect. Apply the generated files with `kubectl apply -f`.
+</Note>
 
 ### Recommended Workflow
 
 1. **Generate** policies in dry-run mode
 2. **Review** the generated YAML files
 3. **Test** in a staging environment
-4. **Apply** manually after validation:
+4. **Apply** with kubectl after validation:
 
 ```bash
 kubectl apply -f ./policies/
 ```
+
+<Warning>
+**Use with caution!** Applying network policies can break communication if the observed traffic was incomplete. Always test in non-production first.
+</Warning>
 
 ---
 
@@ -430,7 +425,7 @@ Now your namespace runs default-deny — only explicitly observed communication 
 3. Check broker has data:
    ```bash
    kubectl port-forward -n kguardian svc/kguardian-broker 9090:9090 &
-   curl http://localhost:9090/pod/traffic/name/myns/mypod
+   curl http://localhost:9090/pod/traffic/mypod
    ```
 
 ### Generated Policy Too Permissive
@@ -458,16 +453,13 @@ Now your namespace runs default-deny — only explicitly observed communication 
 ---
 
 <CardGroup cols={2}>
-  <Card title="Generate Seccomp Profiles" icon="shield-check" href="/guides/generating-seccomp-profiles">
+  <Card title="Generate Seccomp Profiles" icon="shield-check" href="/cli/gen-seccomp">
     Restrict syscalls based on observed behavior
-  </Card>
-  <Card title="Cilium Policies Deep Dive" icon="circle-nodes" href="/advanced/cilium-policies">
-    Advanced Cilium NetworkPolicy features
   </Card>
   <Card title="CLI Reference" icon="terminal" href="/cli/gen-networkpolicy">
     Complete flag documentation
   </Card>
-  <Card title="Policy Gallery" icon="images" href="/policy-gallery">
+  <Card title="Policy Gallery" icon="images" href="/policy-gallery/index">
     Worked examples for nginx, Postgres, Prometheus, Istio, and more
   </Card>
 </CardGroup>

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -74,7 +74,7 @@ A Kubernetes runtime-observability tool that turns the network and syscall behav
 
 ## How it Works
 
-kguardian consists of four components working together:
+kguardian is built around four core components, plus an audit-mode evaluator (deployed by default) and an optional AI assistant (llm-bridge + mcp-server):
 
 <Steps>
   <Step title="Controller Monitors">
@@ -91,6 +91,14 @@ kguardian consists of four components working together:
 
   <Step title="UI Visualizes">
     The **UI** (React + TypeScript) provides an interactive graph showing pod communication, making it easy to understand complex network topologies.
+  </Step>
+
+  <Step title="Evaluator Audits">
+    The **Evaluator** (deployed by default) replays observed flows against generated policies and reports would-deny verdicts, so you can validate a policy before enforcing it.
+  </Step>
+
+  <Step title="AI Assistant (Optional)">
+    The optional **AI assistant** (llm-bridge + mcp-server) answers natural-language questions about cluster traffic and generates policies conversationally.
   </Step>
 </Steps>
 
@@ -111,7 +119,7 @@ kubectl kguardian gen networkpolicy my-app -n production \
   --output-dir ./policies
 
 # Review and apply
-kubectl apply -f ./policies/production-my-app-networkpolicy.yaml
+kubectl apply -f ./policies/production-my-app-standard-networkpolicy.yaml
 ```
 
 <Check>

--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -16,7 +16,7 @@ Before installing kguardian, verify your environment meets these requirements:
     - Kubernetes version: **1.19+**
     - Node OS: **Linux**
     - Kernel version: **6.2+** (for eBPF support)
-    - Container runtime: **containerd** (Docker/CRI-O supported with limitations)
+    - Container runtime: **containerd** (required — Docker and CRI-O are not supported)
 
     **Verify kernel version:**
     ```bash
@@ -59,9 +59,8 @@ Before installing kguardian, verify your environment meets these requirements:
     The simplest and recommended method for production deployments.
 
     ```bash
-    # 1. Install kguardian from OCI registry
+    # 1. Install kguardian from OCI registry (latest chart version)
     helm install kguardian oci://ghcr.io/kguardian-dev/charts/kguardian \
-      --version 1.9.1 \
       --namespace kguardian \
       --create-namespace \
       --wait
@@ -71,16 +70,16 @@ Before installing kguardian, verify your environment meets these requirements:
     ```
 
     <Check>
-    All three pods (controller, broker, UI) should be in `Running` state within 2-3 minutes.
+    All pods — controller (one per node), broker, db, frontend, and evaluator — should be in `Running` state within 2-3 minutes.
     </Check>
 
     ### Install Specific Version
 
-    You can specify a particular version:
+    You can pin a particular chart version:
 
     ```bash
     helm install kguardian oci://ghcr.io/kguardian-dev/charts/kguardian \
-      --version 1.9.1 \
+      --version 1.14.0 \
       --namespace kguardian \
       --create-namespace \
       --wait
@@ -92,12 +91,11 @@ Before installing kguardian, verify your environment meets these requirements:
 
     ```bash
     # Pull and extract the chart to view values
-    helm pull oci://ghcr.io/kguardian-dev/charts/kguardian --version 1.9.1 --untar
+    helm pull oci://ghcr.io/kguardian-dev/charts/kguardian --untar
     cat kguardian/values.yaml > my-values.yaml
 
     # Install with custom values
     helm install kguardian oci://ghcr.io/kguardian-dev/charts/kguardian \
-      --version 1.9.1 \
       --namespace kguardian \
       --create-namespace \
       --values my-values.yaml \
@@ -118,18 +116,15 @@ Before installing kguardian, verify your environment meets these requirements:
     git clone https://github.com/kguardian-dev/kguardian.git
     cd kguardian
 
-    # 3. Create Kind cluster and install everything
-    task install
+    # 3. Create a fresh Kind cluster
+    task kind
 
-    # This will:
-    # - Create a Kind cluster with appropriate settings
-    # - Build controller and broker images
-    # - Load images into Kind
-    # - Install via Helm with local tags
+    # 4. Build images, load them into Kind, and install via Helm
+    task install:oci
     ```
 
     <Tip>
-    The `task install` command is perfect for development. It rebuilds images and reloads them automatically.
+    `task install:oci` rebuilds the controller and broker images, loads them into Kind, and runs a production-style Helm install with the local image tags.
     </Tip>
   </Tab>
 </Tabs>
@@ -155,15 +150,15 @@ controller:
       memory: "512Mi"
 
   # Exclude namespaces from monitoring
-  excludedNamespaces: "kube-system,kguardian,monitoring,istio-system"
-
-  # Enable debug logging
-  debug: true
+  excludedNamespaces:
+    - kube-system
+    - kguardian
+    - monitoring
+    - istio-system
 
   # Image configuration
   image:
-    repository: ghcr.io/kguardian-dev/controller
-    tag: "1.0.0"
+    repository: ghcr.io/kguardian-dev/kguardian/controller
     pullPolicy: IfNotPresent
 
 # Broker configuration
@@ -176,9 +171,8 @@ broker:
     limits:
       memory: "1Gi"
 
-# Frontend (UI) — gated by `frontend.enabled`
+# Frontend (UI)
 frontend:
-  enabled: true
   replicaCount: 1
 
 # Bundled PostgreSQL — see "Use External PostgreSQL" below to disable.
@@ -281,19 +275,19 @@ After deploying the controller, install the CLI to generate policies.
   <Tab title="Manual Download">
     ```bash
     # 1. Download binary from GitHub Releases
-    VERSION="v1.0.0"
+    # CLI releases are tagged advisor/vX.Y.Z; assets are named advisor-<os>-<arch>
+    VERSION="advisor/v1.6.1"
     OS="linux"  # or darwin, windows
     ARCH="amd64"  # or arm64
 
-    curl -LO "https://github.com/kguardian-dev/kguardian/releases/download/${VERSION}/kguardian-${OS}-${ARCH}"
+    curl -LO "https://github.com/kguardian-dev/kguardian/releases/download/${VERSION}/advisor-${OS}-${ARCH}"
 
-    # 2. Verify checksum (optional but recommended)
-    curl -LO "https://github.com/kguardian-dev/kguardian/releases/download/${VERSION}/checksums.txt"
-    sha256sum --check --ignore-missing checksums.txt
+    # 2. Verify build provenance (optional but recommended, requires the gh CLI)
+    gh attestation verify advisor-${OS}-${ARCH} --repo kguardian-dev/kguardian
 
     # 3. Install
-    chmod +x kguardian-${OS}-${ARCH}
-    sudo mv kguardian-${OS}-${ARCH} /usr/local/bin/kubectl-kguardian
+    chmod +x advisor-${OS}-${ARCH}
+    sudo mv advisor-${OS}-${ARCH} /usr/local/bin/kubectl-kguardian
 
     # 4. Verify
     kubectl kguardian --version
@@ -330,11 +324,12 @@ After installation, verify all components are working:
 kubectl get pods -n kguardian
 
 # Expected output:
-# NAME                                  READY   STATUS    RESTARTS   AGE
-# kguardian-controller-xxxxx            1/1     Running   0          5m
-# kguardian-broker-xxxxxxxxxx-xxxxx     1/1     Running   0          5m
-# kguardian-db-xxxxxxxxxx-xxxxx         1/1     Running   0          5m
-# kguardian-frontend-xxxxxxxxxx-xxxxx   1/1     Running   0          5m
+# NAME                                   READY   STATUS    RESTARTS   AGE
+# kguardian-controller-xxxxx             1/1     Running   0          5m
+# kguardian-broker-xxxxxxxxxx-xxxxx      1/1     Running   0          5m
+# kguardian-db-xxxxxxxxxx-xxxxx          1/1     Running   0          5m
+# kguardian-evaluator-xxxxxxxxxx-xxxxx   1/1     Running   0          5m
+# kguardian-frontend-xxxxxxxxxx-xxxxx    1/1     Running   0          5m
 ```
 
 ### 2. Check Controller Logs
@@ -343,8 +338,9 @@ kubectl get pods -n kguardian
 kubectl logs -n kguardian daemonset/kguardian-controller --tail=50
 
 # Look for:
-# - "eBPF programs loaded successfully"
-# - "Watching pods on node: <node-name>"
+# - "Network probe eBPF program loaded and attached"
+# - "Syscall probe eBPF program loaded and attached"
+# - "Ignoring namespaces: [...]"
 # - No error messages
 ```
 
@@ -357,13 +353,15 @@ kubectl port-forward -n kguardian svc/kguardian-broker 9090:9090 &
 # Test health endpoint
 curl http://localhost:9090/health
 
-# Expected: {"status":"ok"}
+# Expected: Healthy!
+# A 503 with body "Database unavailable" or "Database schema not up to date"
+# means the broker is up but cannot serve requests yet.
 ```
 
 ### 4. Test CLI Connection
 
 ```bash
-# List some pods (controller auto-forwards to broker)
+# Print the command help (the CLI port-forwards to the broker automatically)
 kubectl kguardian gen networkpolicy --help
 
 # Try generating a policy for a test pod
@@ -388,7 +386,7 @@ To upgrade kguardian to a newer version:
 
 # 2. Upgrade to a specific pinned version (preserves your values.yaml)
 helm upgrade kguardian oci://ghcr.io/kguardian-dev/charts/kguardian \
-  --version 1.9.1 \
+  --version 1.14.0 \
   --namespace kguardian \
   --values values.yaml \
   --wait

--- a/docs/policy-gallery/go-microservice.mdx
+++ b/docs/policy-gallery/go-microservice.mdx
@@ -4,9 +4,9 @@ description: "Generated NetworkPolicy and seccomp profile for a typical Go HTTP 
 icon: "gears"
 ---
 
-<Note>
-**Example output.** Verified against kguardian `X.Y.Z` controller on `[TBD reference cluster]`.
-</Note>
+<Warning>
+**Hand-authored illustration.** The YAML on this page illustrates the shape of the policies kguardian generates for this workload — it is not captured generator output. Exact metadata, rule grouping, and selectors produced by `kubectl kguardian gen` will differ. Regeneration of this gallery from a live cluster is planned.
+</Warning>
 
 ## Workload
 
@@ -74,7 +74,7 @@ spec:
           port: 53
 ```
 
-The Kubernetes-native NetworkPolicy cannot express "egress to `api.stripe.com`" — you'll see traffic to external IPs in the audit log but no rule for it. The Cilium variant below adds the FQDN.
+Kubernetes-native NetworkPolicy cannot express "egress to `api.stripe.com`" by hostname. In real generator output, that traffic appears as a `/32` `ipBlock` egress rule for the observed IP (not shown above) — functional, but brittle for CDN-backed endpoints whose addresses rotate.
 
 ## Generated CiliumNetworkPolicy
 
@@ -100,12 +100,6 @@ spec:
         - ports:
             - port: "8080"
               protocol: TCP
-          rules:
-            http:
-              - method: POST
-                path: "/v1/orders"
-              - method: GET
-                path: "/v1/orders/.*"
     - fromEndpoints:
         - matchLabels:
             app.kubernetes.io/name: prometheus
@@ -114,10 +108,6 @@ spec:
         - ports:
             - port: "9100"
               protocol: TCP
-          rules:
-            http:
-              - method: GET
-                path: "/metrics"
   egress:
     - toEndpoints:
         - matchLabels:
@@ -127,12 +117,6 @@ spec:
         - ports:
             - port: "5432"
               protocol: TCP
-    - toFQDNs:
-        - matchName: "api.stripe.com"
-      toPorts:
-        - ports:
-            - port: "443"
-              protocol: TCP
     - toEndpoints:
         - matchLabels:
             k8s-app: kube-dns
@@ -141,10 +125,6 @@ spec:
         - ports:
             - port: "53"
               protocol: UDP
-          rules:
-            dns:
-              - matchName: "api.stripe.com"
-              - matchPattern: "*.svc.cluster.local"
 ```
 
 ## Generated seccomp profile (excerpt)
@@ -179,4 +159,4 @@ Full profile contains **97 syscall names**. Representative excerpt:
 
 ## What kguardian observed
 
-The Go runtime makes this profile easy to recognise: heavy `futex` (goroutine scheduling), `getrandom` (TLS), `rseq` and `sched_yield` (scheduler hints), and a small file-I/O footprint. Network-wise, the controller saw three distinct egress destinations — Postgres in the `data` namespace, CoreDNS for DNS, and `api.stripe.com` resolved at runtime. Because Kubernetes-native NetworkPolicy can't express egress by hostname, the K8s policy omits the Stripe rule entirely, while the Cilium variant pins it via `toFQDNs` and limits the corresponding DNS lookups to that exact name. The L7 rules on ingress (`POST /v1/orders`, `GET /v1/orders/.*`) reflect the only request shapes captured during the observation window — a workload that exposes more endpoints will get a longer list.
+The Go runtime makes this profile easy to recognise: heavy `futex` (goroutine scheduling), `getrandom` (TLS), `rseq` and `sched_yield` (scheduler hints), and a small file-I/O footprint. Network-wise, the controller saw three distinct egress destinations — Postgres in the `data` namespace, CoreDNS for DNS, and `api.stripe.com` resolved at runtime. The generator does not emit hostname-based rules, so the Stripe traffic is covered by a `/32` `ipBlock` egress rule for the resolved IP. That works, but is brittle for CDN-backed endpoints like Stripe whose addresses rotate — expect to re-generate or hand-maintain that rule.

--- a/docs/policy-gallery/index.mdx
+++ b/docs/policy-gallery/index.mdx
@@ -4,9 +4,9 @@ description: "Examples of NetworkPolicies, CiliumNetworkPolicies, and seccomp pr
 icon: "images"
 ---
 
-<Note>
-**Example output.** Each page below shows YAML that is representative of what the kguardian controller observes and emits for a given workload. Profiles are illustrative — verify against your own runtime before applying. Verified against kguardian `X.Y.Z` controller on `[TBD reference cluster]`.
-</Note>
+<Warning>
+**Hand-authored illustrations.** The YAML in this gallery illustrates the shape of the policies kguardian generates for each workload — it is not captured generator output. Exact metadata, rule grouping, and selectors produced by `kubectl kguardian gen` will differ, and regeneration from a live cluster is planned. Always verify against your own runtime before applying.
+</Warning>
 
 ## Why a gallery?
 
@@ -16,7 +16,7 @@ Each page in this gallery walks through one real workload pattern:
 
 - A 3-line description of the workload and what it talks to.
 - The generated `NetworkPolicy` YAML.
-- The generated `CiliumNetworkPolicy` YAML (where Cilium-specific fields add value, e.g., FQDN egress or L7 HTTP rules).
+- The generated `CiliumNetworkPolicy` YAML (where Cilium-specific fields add value — CIDR-based L4 egress, endpoint selectors, and default-deny semantics).
 - The generated seccomp profile JSON (or a representative excerpt with the full syscall count).
 - A short paragraph on what kguardian observed at runtime that produced each rule.
 
@@ -45,10 +45,10 @@ Each page in this gallery walks through one real workload pattern:
 
 ## How to read each example
 
-The YAML on each page is what `kubectl kguardian gen networkpolicy <pod> --output-dir ./policies` writes after the controller has observed the workload for at least a few minutes. The seccomp JSON is what `kubectl kguardian gen seccomp <pod> --output-dir ./seccomp` produces.
+The YAML on each page follows what `kubectl kguardian gen networkpolicy <pod> --output-dir ./policies` writes after the controller has observed the workload for at least a few minutes (add `--type cilium` for the CiliumNetworkPolicy variant — the default output type is `kubernetes`). The seccomp JSON is what `kubectl kguardian gen seccomp <pod> --output-dir ./seccomp` produces.
 
 If a workload's observed behavior is empty or noisy in your cluster (no traffic captured yet, very short-lived pods, host-network pods), the generator emits a minimal policy and warns. None of the gallery examples reflect that path — see [Troubleshooting](/advanced/troubleshooting) instead.
 
 <Info>
-The seccomp excerpts in this gallery are abbreviated for readability. Production profiles routinely contain 80–200 syscall names. The full count is noted on each page.
+The seccomp excerpts in this gallery are abbreviated for readability — real profiles contain far more syscall names than shown here.
 </Info>

--- a/docs/policy-gallery/istio-sidecar.mdx
+++ b/docs/policy-gallery/istio-sidecar.mdx
@@ -4,8 +4,12 @@ description: "Generated NetworkPolicy and seccomp profile for an Istio sidecar (
 icon: "diagram-project"
 ---
 
+<Warning>
+**Hand-authored illustration.** The YAML on this page illustrates the shape of the policies kguardian generates for this workload — it is not captured generator output. Exact metadata, rule grouping, and selectors produced by `kubectl kguardian gen` will differ. Regeneration of this gallery from a live cluster is planned.
+</Warning>
+
 <Note>
-**Example output.** Verified against kguardian `X.Y.Z` controller on `[TBD reference cluster]`. Sidecar policies are sensitive to mesh configuration — automatic mTLS, ambient mode, and custom `EnvoyFilter` resources can shift the observed traffic pattern. Re-run generation after mesh upgrades.
+Sidecar policies are sensitive to mesh configuration — automatic mTLS, ambient mode, and custom `EnvoyFilter` resources can shift the observed traffic pattern. Re-run generation after mesh upgrades.
 </Note>
 
 ## Workload
@@ -171,4 +175,4 @@ Full profile contains **148 syscall names**. Representative excerpt:
 
 ## What kguardian observed
 
-The sidecar's traffic shape is dominated by mesh control-plane and peer mTLS rather than application traffic — application-layer requests are tunneled inside the mTLS streams that kguardian sees on port 15006, so the policy keeps L4 only and labels peers by `security.istio.io/tlsMode: istio`. The xDS connection to `istiod` is long-lived and easy to capture (TCP/15012 to the `app: istiod` pod in `istio-system`). Prometheus scrapes for Envoy and pilot-agent metrics show up on 15090 and 15020. Envoy's syscall set is heavier than a typical Go binary because of `io_uring`, `socketpair`, and `eventfd2`. **Caveat:** if your mesh uses ambient mode or a non-default sidecar injector, the observed ports and labels will differ — re-generate per environment.
+The sidecar's traffic shape is dominated by mesh control-plane and peer mTLS rather than application traffic — application-layer requests are tunneled inside the mTLS streams that kguardian sees on port 15006, so the policy stays at L4. Selecting mesh peers by the single `security.istio.io/tlsMode: istio` label, as shown above, is a hand-idealization — real generator output emits one rule per observed peer, selecting that peer's full label set together with a namespace selector. The xDS connection to `istiod` is long-lived and easy to capture (TCP/15012 to the `app: istiod` pod in `istio-system`). Prometheus scrapes for Envoy and pilot-agent metrics show up on 15090 and 15020. Envoy's syscall set is heavier than a typical Go binary because of `io_uring`, `socketpair`, and `eventfd2`. **Caveat:** if your mesh uses ambient mode or a non-default sidecar injector, the observed ports and labels will differ — re-generate per environment.

--- a/docs/policy-gallery/kube-dns.mdx
+++ b/docs/policy-gallery/kube-dns.mdx
@@ -4,8 +4,12 @@ description: "Generated NetworkPolicy and seccomp profile for the kube-system Co
 icon: "signs-post"
 ---
 
+<Warning>
+**Hand-authored illustration.** The YAML on this page illustrates the shape of the policies kguardian generates for this workload — it is not captured generator output. Exact metadata, rule grouping, and selectors produced by `kubectl kguardian gen` will differ. Regeneration of this gallery from a live cluster is planned.
+</Warning>
+
 <Note>
-**Example output.** Verified against kguardian `X.Y.Z` controller on `[TBD reference cluster]`. CoreDNS lives in `kube-system`, which is excluded from monitoring by default — to capture this profile you must remove `kube-system` from `controller.excludedNamespaces` in the Helm values, or scope generation manually.
+CoreDNS lives in `kube-system`, which is excluded from monitoring by default — to capture this profile you must remove `kube-system` from `controller.excludedNamespaces` in the Helm values, or scope generation manually.
 </Note>
 
 ## Workload
@@ -136,4 +140,4 @@ Full profile contains **78 syscall names**. Representative excerpt:
 
 ## What kguardian observed
 
-CoreDNS receives requests from every namespace in the cluster, so kguardian collapses ingress sources into a single `namespaceSelector: {}` rule rather than enumerating thousands of pods. Egress splits into two distinct destinations: node-local resolver IP for upstream lookups, and the Kubernetes API service ClusterIP (`10.96.0.1`) for the in-cluster zone plugin. The syscall set is small because CoreDNS is a single-purpose Go binary — heavy `recvmsg`/`sendmsg` for UDP, `epoll` for TCP, and minimal file I/O. Prometheus scrape ingress on TCP/9153 was captured separately because it originated from a single, identifiable pod.
+CoreDNS receives requests from every namespace in the cluster. The single `namespaceSelector: {}` ingress rule shown above is a hand-idealization — the generator emits one rule per observed peer, with pod and namespace selectors for in-cluster sources. Egress splits into two distinct destinations: node-local resolver IP for upstream lookups, and the Kubernetes API service ClusterIP (`10.96.0.1`) for the in-cluster zone plugin. The syscall set is small because CoreDNS is a single-purpose Go binary — heavy `recvmsg`/`sendmsg` for UDP, `epoll` for TCP, and minimal file I/O. Prometheus scrape ingress on TCP/9153 was captured separately because it originated from a single, identifiable pod.

--- a/docs/policy-gallery/nginx.mdx
+++ b/docs/policy-gallery/nginx.mdx
@@ -4,9 +4,9 @@ description: "Generated NetworkPolicy, CiliumNetworkPolicy, and seccomp profile 
 icon: "server"
 ---
 
-<Note>
-**Example output.** Verified against kguardian `X.Y.Z` controller on `[TBD reference cluster]`.
-</Note>
+<Warning>
+**Hand-authored illustration.** The YAML on this page illustrates the shape of the policies kguardian generates for this workload — it is not captured generator output. Exact metadata, rule grouping, and selectors produced by `kubectl kguardian gen` will differ. Regeneration of this gallery from a live cluster is planned.
+</Warning>
 
 ## Workload
 
@@ -80,12 +80,6 @@ spec:
         - ports:
             - port: "80"
               protocol: TCP
-          rules:
-            http:
-              - method: GET
-                path: "/"
-              - method: HEAD
-                path: "/"
   egress:
     - toEndpoints:
         - matchLabels:
@@ -95,9 +89,6 @@ spec:
         - ports:
             - port: "53"
               protocol: ANY
-          rules:
-            dns:
-              - matchPattern: "*"
 ```
 
 ## Generated seccomp profile (excerpt)
@@ -131,4 +122,4 @@ Full profile contains **104 syscall names**. Representative excerpt:
 
 ## What kguardian observed
 
-The controller saw inbound TCP connections to port 80 originating from `curl-pod` in the same namespace, outbound UDP/53 (and a small number of fallback TCP/53) to the kube-system CoreDNS pods, and the typical syscall mix for an nginx worker process: socket setup, `epoll`-based event loop, `sendfile` for static responses, and read/write on the listening sockets. No outbound traffic to upstream HTTP services was seen, so no egress allow-rules for upstream hosts were generated. The Cilium variant adds L7 HTTP method/path rules for `GET /` and `HEAD /` because those were the only request shapes captured.
+The controller saw inbound TCP connections to port 80 originating from `curl-pod` in the same namespace, outbound UDP/53 (and a small number of fallback TCP/53) to the kube-system CoreDNS pods, and the typical syscall mix for an nginx worker process: socket setup, `epoll`-based event loop, `sendfile` for static responses, and read/write on the listening sockets. No outbound traffic to upstream HTTP services was seen, so no egress allow-rules for upstream hosts were generated. The generator emits one rule per observed peer — pod plus namespace selectors for in-cluster peers — so each source appears as its own rule.

--- a/docs/policy-gallery/postgres.mdx
+++ b/docs/policy-gallery/postgres.mdx
@@ -4,9 +4,9 @@ description: "Generated NetworkPolicy and seccomp profile for a Postgres pod acc
 icon: "database"
 ---
 
-<Note>
-**Example output.** Verified against kguardian `X.Y.Z` controller on `[TBD reference cluster]`.
-</Note>
+<Warning>
+**Hand-authored illustration.** The YAML on this page illustrates the shape of the policies kguardian generates for this workload — it is not captured generator output. Exact metadata, rule grouping, and selectors produced by `kubectl kguardian gen` will differ. Regeneration of this gallery from a live cluster is planned.
+</Warning>
 
 ## Workload
 
@@ -96,10 +96,6 @@ spec:
         - ports:
             - port: "53"
               protocol: UDP
-          rules:
-            dns:
-              - matchPattern: "*.svc.cluster.local"
-              - matchPattern: "*.cluster.local"
 ```
 
 ## Generated seccomp profile (excerpt)
@@ -135,4 +131,4 @@ Full profile contains **162 syscall names**. Representative excerpt:
 
 ## What kguardian observed
 
-Two distinct ingress sources connected to TCP/5432: `order-api` and `billing-worker`, both in the `app` namespace. Egress was limited to UDP/53 lookups during connection establishment (Postgres resolves `pg_hba`-related hostnames at startup). The syscall set is heavier than nginx because Postgres performs heavy I/O: file extension/truncation (`ftruncate`, `pwrite64`, `fdatasync`), directory enumeration (`getdents64`), and process management (`clone`, `wait4`) for its background worker model. The Cilium policy adds an FQDN matchPattern for `*.svc.cluster.local` because that's the only DNS query shape observed.
+Two distinct ingress sources connected to TCP/5432: `order-api` and `billing-worker`, both in the `app` namespace. Egress was limited to UDP/53 lookups during connection establishment (Postgres resolves `pg_hba`-related hostnames at startup). The syscall set is heavier than nginx because Postgres performs heavy I/O: file extension/truncation (`ftruncate`, `pwrite64`, `fdatasync`), directory enumeration (`getdents64`), and process management (`clone`, `wait4`) for its background worker model.

--- a/docs/policy-gallery/prometheus.mdx
+++ b/docs/policy-gallery/prometheus.mdx
@@ -4,9 +4,9 @@ description: "Generated NetworkPolicy and seccomp profile for a Prometheus pod s
 icon: "chart-line"
 ---
 
-<Note>
-**Example output.** Verified against kguardian `X.Y.Z` controller on `[TBD reference cluster]`.
-</Note>
+<Warning>
+**Hand-authored illustration.** The YAML on this page illustrates the shape of the policies kguardian generates for this workload — it is not captured generator output. Exact metadata, rule grouping, and selectors produced by `kubectl kguardian gen` will differ. Regeneration of this gallery from a live cluster is planned.
+</Warning>
 
 ## Workload
 
@@ -91,12 +91,6 @@ spec:
         - ports:
             - port: "9090"
               protocol: TCP
-          rules:
-            http:
-              - method: GET
-                path: "/api/v1/query.*"
-              - method: POST
-                path: "/api/v1/query_range"
   egress:
     - toEndpoints:
         - {}
@@ -110,10 +104,6 @@ spec:
               protocol: TCP
             - port: "10250"
               protocol: TCP
-          rules:
-            http:
-              - method: GET
-                path: "/metrics"
     - toEntities:
         - kube-apiserver
       toPorts:
@@ -154,4 +144,4 @@ Full profile contains **131 syscall names**. Representative excerpt:
 
 ## What kguardian observed
 
-Prometheus's egress is the most interesting piece: scrape requests fanned out to every namespace on a small, well-known set of metrics ports (`8080`, `9100`, `9153`, `10250`), so kguardian emitted a single `namespaceSelector: {}` egress rule rather than per-pod selectors. The Cilium variant pins those scrapes to `GET /metrics` at L7. Ingress was a single source — Grafana — querying the Prometheus API on TCP/9090. Egress to the Kubernetes API service ClusterIP was captured for service-discovery `LIST/WATCH` calls. The syscall profile picks up `pwrite64`/`fdatasync` because Prometheus persists samples to disk via its WAL.
+Prometheus's egress is the most interesting piece: scrape requests fan out to every namespace on a small, well-known set of metrics ports (`8080`, `9100`, `9153`, `10250`). The single `namespaceSelector: {}` egress rule shown above is a hand-idealization — the generator emits one rule per observed peer, with pod and namespace selectors for in-cluster targets. Ingress was a single source — Grafana — querying the Prometheus API on TCP/9090. Egress to the Kubernetes API service ClusterIP was captured for service-discovery `LIST/WATCH` calls. The syscall profile picks up `pwrite64`/`fdatasync` because Prometheus persists samples to disk via its WAL.

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -43,13 +43,12 @@ Before you begin, ensure you have:
 **Kernel Version Check:** kguardian requires Linux kernel 6.2+ for eBPF functionality. Run `uname -r` on your nodes to verify.
 </Warning>
 
-## Step 1: Install the Controller
+## Step 1: Install kguardian
 
-The Controller runs as a DaemonSet and uses eBPF to observe your workloads.
+A single Helm install deploys the full stack: the Controller DaemonSet (eBPF observation), Broker, database, frontend, and evaluator.
 
 ```bash
 helm install kguardian oci://ghcr.io/kguardian-dev/charts/kguardian \
-  --version 1.9.1 \
   --namespace kguardian \
   --create-namespace \
   --wait
@@ -64,13 +63,15 @@ Check that all components are running:
 ```bash
 kubectl get pods -n kguardian
 
-# Expected output (one controller pod per node; broker + db + frontend
-# as Deployments; evaluator / mcp-server / llm-bridge appear only when
-# the corresponding chart values enable them):
+# Expected output (one controller pod per node; broker + db + frontend +
+# evaluator as Deployments; the evaluator is on by default and can be
+# disabled with evaluator.enabled=false; mcp-server / llm-bridge appear
+# only when the corresponding chart values enable them):
 # NAME                                   READY   STATUS    RESTARTS   AGE
 # kguardian-controller-xxxxx             1/1     Running   0          2m
 # kguardian-broker-xxxxxxxxxx-xxxxx      1/1     Running   0          2m
 # kguardian-db-xxxxxxxxxx-xxxxx          1/1     Running   0          2m
+# kguardian-evaluator-xxxxxxxxxx-xxxxx   1/1     Running   0          2m
 # kguardian-frontend-xxxxxxxxxx-xxxxx    1/1     Running   0          2m
 ```
 
@@ -96,16 +97,16 @@ The kguardian CLI is a kubectl plugin for generating policies.
   <Tab title="Manual Download">
     ```bash
     # Download the binary for your platform
-    # Replace {VERSION}, {OS}, and {ARCH} with appropriate values
-    VERSION="v1.0.0"
+    # CLI releases are tagged advisor/vX.Y.Z; assets are named advisor-<os>-<arch>
+    VERSION="advisor/v1.6.1"
     OS="linux"  # or darwin, windows
     ARCH="amd64"  # or arm64
 
-    curl -LO "https://github.com/kguardian-dev/kguardian/releases/download/${VERSION}/kguardian-${OS}-${ARCH}"
+    curl -LO "https://github.com/kguardian-dev/kguardian/releases/download/${VERSION}/advisor-${OS}-${ARCH}"
 
     # Make it executable and move to PATH
-    chmod +x kguardian-${OS}-${ARCH}
-    sudo mv kguardian-${OS}-${ARCH} /usr/local/bin/kubectl-kguardian
+    chmod +x advisor-${OS}-${ARCH}
+    sudo mv advisor-${OS}-${ARCH} /usr/local/bin/kubectl-kguardian
 
     # Verify installation
     kubectl kguardian --version
@@ -139,7 +140,7 @@ kguardian learns from actual runtime behavior, so let your applications run norm
     kubectl port-forward -n kguardian svc/kguardian-broker 9090:9090 &
 
     # Check for traffic data (replace 'nginx' with your pod name)
-    curl http://localhost:9090/pod/traffic/name/default/nginx
+    curl http://localhost:9090/pod/traffic/nginx
     ```
 
     <Tip>
@@ -158,7 +159,7 @@ kubectl kguardian gen networkpolicy nginx -n default \
   --output-dir ./policies
 
 # View the generated policy
-cat ./policies/default-nginx-networkpolicy.yaml
+cat ./policies/default-nginx-standard-networkpolicy.yaml
 ```
 
 To apply directly during generation instead of writing files for review, pass `--dry-run=false`. See [`gen networkpolicy`](/cli/gen-networkpolicy) for the full flag reference.
@@ -219,8 +220,8 @@ kubectl kguardian gen networkpolicy nginx -n default \
   --output-dir ./policies --dry-run=false
 
 # Option B: apply the saved YAML yourself
-kubectl apply --dry-run=client -f ./policies/default-nginx-networkpolicy.yaml  # validate
-kubectl apply -f ./policies/default-nginx-networkpolicy.yaml                   # apply
+kubectl apply --dry-run=client -f ./policies/default-nginx-standard-networkpolicy.yaml  # validate
+kubectl apply -f ./policies/default-nginx-standard-networkpolicy.yaml                   # apply
 
 # Verify it's created
 kubectl get networkpolicies -n default
@@ -236,7 +237,7 @@ kubectl kguardian gen seccomp nginx -n default \
   --output-dir ./seccomp
 
 # View the generated profile
-cat ./seccomp/default-nginx-seccomp.json
+cat ./seccomp/nginx-seccomp.json
 ```
 
 <CodeGroup>

--- a/docs/roadmap/future-resources.mdx
+++ b/docs/roadmap/future-resources.mdx
@@ -4,7 +4,7 @@ description: "Planned security resources and features coming to kguardian"
 icon: "map"
 ---
 
-##  Roadmap Overview
+## Roadmap Overview
 
 kguardian is continuously evolving to support more Kubernetes security resources. This page outlines our plans for future capabilities.
 
@@ -20,7 +20,6 @@ kguardian is continuously evolving to support more Kubernetes security resources
 
     - Kubernetes NetworkPolicy
     - Cilium NetworkPolicy
-    - Cilium ClusterwideNetworkPolicy
   </Card>
 
   <Card title="✅ Audit Mode Policies" icon="check-circle" color="#16A34A">

--- a/docs/roadmap/planned-features.mdx
+++ b/docs/roadmap/planned-features.mdx
@@ -49,7 +49,7 @@ narrative; for the current versions of each component, see
 
     **Still planned:**
     - L7 policy hints for Cilium (HTTP, gRPC)
-    - Policy validation and dry-run testing
+    - CiliumClusterwideNetworkPolicy generation
     - Multi-cluster support (federated broker)
   </Step>
 
@@ -114,35 +114,7 @@ narrative; for the current versions of each component, see
 
 ## Feature Requests
 
-### Top Community Requests
-
-Vote on features you want most by starring issues on GitHub:
-
-<CardGroup cols={2}>
-  <Card title="Istio/Service Mesh Policies" icon="diagram-project">
-    **Votes:** 🔥🔥🔥
-
-    Generate AuthorizationPolicies for Istio and Linkerd based on observed L7 traffic.
-  </Card>
-
-  <Card title="Falco Rules Generation" icon="bell">
-    **Votes:** 🔥🔥
-
-    Create runtime threat detection rules from normal behavior baselines.
-  </Card>
-
-  <Card title="OPA/Gatekeeper Policies" icon="gavel">
-    **Votes:** 🔥🔥
-
-    Generate admission control policies to enforce observed patterns.
-  </Card>
-
-  <Card title="RBAC Analyzer" icon="users-gear">
-    **Votes:** 🔥
-
-    Suggest least-privilege RBAC roles based on actual API usage.
-  </Card>
-</CardGroup>
+Ideas under discussion include service-mesh AuthorizationPolicies (Istio/Linkerd), Falco rule generation, OPA/Gatekeeper admission policies, and an RBAC least-privilege analyzer. Want one of these — or something else? Open or upvote an issue on [GitHub](https://github.com/kguardian-dev/kguardian/issues).
 
 ---
 
@@ -225,19 +197,6 @@ For commercial licensees:
     Enterprise customers get priority feature requests. Contact us for licensing options.
   </Step>
 </Steps>
-
----
-
-## Release Schedule
-
-- **Major releases** (x.0.0): Quarterly
-- **Minor releases** (x.x.0): Monthly (features)
-- **Patch releases** (x.x.x): As needed (bug fixes)
-
-All releases follow [Semantic Versioning](https://semver.org/) and include:
-- Detailed changelog
-- Migration guide (if breaking changes)
-- Upgrade instructions
 
 ---
 

--- a/docs/telemetry.mdx
+++ b/docs/telemetry.mdx
@@ -21,8 +21,8 @@ these six query parameters — nothing else, ever:
 | Field | Example | What it is |
 | --- | --- | --- |
 | `install` | `4f7c…-…` | Random UUID generated once at first startup. Contains no cluster or user information — it only lets repeated check-ins from the same install be counted once. |
-| `broker` | `1.11.1` | Broker version. |
-| `chart` | `1.13.2` | Helm chart version (`unknown` outside the chart). |
+| `broker` | `1.12.0` | Broker version. |
+| `chart` | `1.14.0` | Helm chart version (`unknown` outside the chart). |
 | `k8s` | `v1.33.1` | Kubernetes version, captured by the chart at install/upgrade time. |
 | `nodes` | `3` | Count of distinct live nodes the controller has observed — a coarse size signal, not an inventory. |
 | `arch` | `x86_64` | Broker CPU architecture. |
@@ -44,10 +44,10 @@ surfaces it at `GET /version`:
 
 ```json
 {
-  "broker": "1.11.1",
-  "chart": "1.13.2",
+  "broker": "1.12.0",
+  "chart": "1.14.0",
   "telemetry_enabled": true,
-  "latest": { "chart": "1.13.2", "broker": "1.11.1" },
+  "latest": { "chart": "1.14.0", "broker": "1.12.0" },
   "checked_at": "2026-07-19T12:00:00",
   "update_available": false
 }

--- a/llm-bridge/README.md
+++ b/llm-bridge/README.md
@@ -1,96 +1,51 @@
 # kguardian LLM Bridge
 
-A dedicated microservice that bridges the kguardian frontend with multiple LLM providers (OpenAI, Anthropic, Gemini, GitHub Copilot).
+A microservice that connects the kguardian frontend to LLM providers (OpenAI, Anthropic, Gemini, GitHub Copilot) and gives the model access to cluster data through the MCP server.
 
 ## Architecture
 
 ```
 ┌─────────────┐      ┌─────────────┐      ┌──────────────────┐
 │   Frontend  │─────▶│ LLM Bridge  │─────▶│  LLM Provider    │
-│   (React)   │      │(TypeScript) │      │  (OpenAI/Claude/ │
+│   (React)   │ SSE  │(TypeScript) │      │  (OpenAI/Claude/ │
 │             │      │             │      │  Gemini/Copilot) │
 └─────────────┘      └─────────────┘      └──────────────────┘
-                            │                      │
-                            │                      │
-                            ▼                      ▼
-                     ┌─────────────┐      ┌──────────────┐
-                     │ MCP Server  │      │  Tool Calls  │
-                     │    (Go)     │      │ (6 MCP Tools)│
-                     │             │      │              │
-                     └─────────────┘      └──────────────┘
-                            │                      │
-                            ▼                      │
-                     ┌─────────────┐               │
-                     │   Broker    │◀──────────────┘
-                     │   (Rust)    │
-                     └─────────────┘
                             │
                             ▼
-                     ┌─────────────┐
-                     │ PostgreSQL  │
-                     │   (Data)    │
-                     └─────────────┘
+                     ┌─────────────┐      ┌─────────────┐      ┌─────────────┐
+                     │ MCP Server  │─────▶│   Broker    │─────▶│ PostgreSQL  │
+                     │    (Go)     │      │   (Rust)    │      │             │
+                     └─────────────┘      └─────────────┘      └─────────────┘
 ```
 
-## Why a Separate Service?
+The bridge exists so LLM API keys stay isolated from the Broker, the AI workload can scale independently, and the Broker stays focused on telemetry. It selects the first provider with a configured API key, exposes streaming chat over SSE, and lets the model call the MCP server's 12 tools for live (polled) cluster data. See [mcp-server/README.md](../mcp-server/README.md#available-tools) for the full tool list.
 
-**Security**: API keys isolated from main broker
-**Separation of Concerns**: Broker stays focused on telemetry data
-**Scalability**: Scale AI workload independently
-**Flexibility**: Easy to swap/update LLM logic
-**Frontend Direct Connection**: Simpler architecture
-
-## Features
-
-- ✅ **Multi-Provider Support**: OpenAI, Anthropic, Gemini, GitHub Copilot
-- ✅ **MCP Integration**: Uses Model Context Protocol (MCP) to access cluster data via MCP server
-- ✅ **Function Calling**: LLMs can call 6 MCP tools for real-time cluster data
-- ✅ **Automatic Provider Selection**: Uses first available API key
-- ✅ **Health Checks**: Monitor service and provider availability
-- ✅ **Error Handling**: Comprehensive error messages with graceful fallbacks
-- ✅ **TypeScript**: Full type safety with MCP SDK integration
+Its only upstream is the MCP server (`MCP_SERVER_URL`) — the bridge never talks to the Broker directly.
 
 ## Supported LLM Providers
 
 ### OpenAI (GPT-4, GPT-4o)
 - **Env Var**: `OPENAI_API_KEY`
 - **Default Model**: `gpt-4o`
-- **Best For**: Fast, general-purpose queries
 
 ### Anthropic Claude
 - **Env Var**: `ANTHROPIC_API_KEY`
 - **Default Model**: `claude-opus-4-8`
-- **Best For**: Complex security analysis, best reasoning
 
 ### Google Gemini
 - **Env Var**: `GOOGLE_API_KEY`
 - **Default Model**: `gemini-2.0-flash-exp`
-- **Best For**: Cost-effective, free tier available
 
 ### GitHub Copilot
 - **Env Var**: `GITHUB_TOKEN`
 - **Default Model**: `gpt-4o`
-- **Best For**: If you already have Copilot subscription
-
-## Available Tools
-
-The bridge connects to the MCP server which provides 6 comprehensive tools that LLMs can call:
-
-1. **get_pod_network_traffic** - Query network connections for a specific pod
-2. **get_pod_syscalls** - Get system calls made by a specific pod
-3. **get_pod_details** - Get detailed pod information by IP address
-4. **get_service_details** - Get Kubernetes service information by cluster IP
-5. **get_cluster_traffic** - Get all network traffic across the entire cluster
-6. **get_cluster_pods** - Get detailed information about all pods in the cluster
-
-For detailed tool specifications, parameters, and use cases, see the [MCP Server documentation](../mcp-server/README.md#available-tools).
 
 ## Development
 
 ### Prerequisites
 - Node.js 20+
 - npm
-- Access to kguardian broker
+- A reachable MCP server
 
 ### Install Dependencies
 ```bash
@@ -122,18 +77,20 @@ npm start
 
 ### Build Image
 ```bash
-docker build -t kguardian-llm-bridge .
+docker build -t ghcr.io/kguardian-dev/kguardian/llm-bridge .
 ```
 
 ### Run Container
 ```bash
 docker run -p 8080:8080 \
-  -e BROKER_URL=http://broker:9090 \
-  -e OPENAI_API_KEY=sk-... \
-  kguardian-llm-bridge
+  -e MCP_SERVER_URL=http://kguardian-mcp-server:8081 \
+  -e ANTHROPIC_API_KEY=sk-ant-... \
+  ghcr.io/kguardian-dev/kguardian/llm-bridge
 ```
 
 ## API Endpoints
+
+Both chat endpoints are rate-limited to **20 requests per minute** per client.
 
 ### GET /health
 
@@ -143,15 +100,17 @@ Health check endpoint.
 ```json
 {
   "status": "healthy",
-  "brokerUrl": "http://broker:9090",
-  "availableProviders": ["openai", "anthropic"],
   "hasProvider": true
 }
 ```
 
+### POST /api/chat/stream
+
+Streaming chat over Server-Sent Events — this is what the frontend uses. Same request body as `/api/chat`; the response is an SSE stream of incremental message events, including tool-call rounds, with keepalives while the model works.
+
 ### POST /api/chat
 
-Send a chat message to the AI assistant.
+Non-streaming chat; returns the full response as one JSON object.
 
 **Request:**
 ```json
@@ -182,13 +141,16 @@ Send a chat message to the AI assistant.
 }
 ```
 
+Upstream provider rate limits and overloads are surfaced as `429`/`503` so clients can back off.
+
 ## Environment Variables
 
 | Variable | Required | Description |
 |----------|----------|-------------|
 | `PORT` | No | Server port (default: 8080) |
-| `BROKER_URL` | Yes | kguardian broker URL |
-| `MCP_SERVER_URL` | No | MCP server URL (default: http://kguardian-mcp-server.kguardian.svc.cluster.local:8081) |
+| `MCP_SERVER_URL` | No | MCP server URL (default: `http://kguardian-mcp-server.kguardian.svc.cluster.local:8081`) |
+| `ALLOWED_ORIGIN` | No | CORS allowed origin (default: `*`) |
+| `LOG_LEVEL` | No | Log level (default: `info`) |
 | `OPENAI_API_KEY` | No* | OpenAI API key |
 | `ANTHROPIC_API_KEY` | No* | Anthropic API key |
 | `GOOGLE_API_KEY` | No* | Google Gemini API key |
@@ -204,16 +166,14 @@ The service is deployed as part of the kguardian Helm chart:
 llmBridge:
   enabled: true
   image:
-    repository: ghcr.io/kguardian-dev/llm-bridge
-    tag: latest
+    repository: ghcr.io/kguardian-dev/kguardian/llm-bridge
+    tag: "1.4.1"
   env:
-    - name: BROKER_URL
-      value: "http://broker.kguardian.svc.cluster.local:9090"
-    - name: OPENAI_API_KEY
+    - name: ANTHROPIC_API_KEY
       valueFrom:
         secretKeyRef:
           name: kguardian-secrets
-          key: openai-api-key
+          key: anthropic-api-key
           optional: true
 ```
 
@@ -241,12 +201,7 @@ curl http://localhost:8080/health
 
 ### No providers available
 - Ensure at least one API key environment variable is set
-- Check the `/health` endpoint to see which providers are configured
-
-### Connection to broker fails
-- Verify `BROKER_URL` is correct
-- Ensure broker service is running
-- Check network policies allow egress from llm-bridge to broker
+- Check the `/health` endpoint (`hasProvider` should be `true`)
 
 ### Connection to MCP server fails
 - Verify `MCP_SERVER_URL` is correct
@@ -256,10 +211,9 @@ curl http://localhost:8080/health
 - Look for MCP connection messages in llm-bridge startup logs
 
 ### Tools not working / LLM can't access data
-- Check that MCP server successfully connected (look for "✓ Connected to MCP server" in logs)
-- Verify MCP server can reach broker
-- Test tool calls manually using the MCP Inspector (if using kmcp)
-- Check that all 6 tools are registered: Review MCP server logs for tool registration messages
+- Check that MCP server successfully connected (look for "Connected to MCP server" in logs)
+- Verify MCP server can reach the Broker
+- Check that all 12 tools are registered: review MCP server logs for tool registration messages
 
 ### LLM API errors
 - Verify API keys are valid and have credits
@@ -268,18 +222,9 @@ curl http://localhost:8080/health
 
 ## Security
 
-- API keys are stored as Kubernetes Secrets
+- API keys are stored as Kubernetes Secrets and never exposed to the frontend
 - Service runs as non-root user
-- CORS enabled for frontend access
-- All communication over HTTPS in production
-- API keys never exposed to frontend
-
-## Performance
-
-- Typical response time: 2-5 seconds
-- Function calling adds ~1-2 seconds per tool call
-- Concurrent request handling with Express
-- Health checks every 30 seconds
+- CORS restricted via `ALLOWED_ORIGIN`
 
 ## License
 

--- a/mcp-server/DEPLOYMENT.md
+++ b/mcp-server/DEPLOYMENT.md
@@ -1,199 +1,19 @@
-# kguardian MCP Server Deployment Guide
+# kguardian MCP Server Deployment
 
-This guide covers deployment options for the kguardian MCP server using both traditional Kubernetes manifests and the kmcp controller.
+The MCP server is deployed through the kguardian Helm chart — there is no standalone manifest.
 
-## Table of Contents
-
-- [Prerequisites](#prerequisites)
-- [Deployment Methods](#deployment-methods)
-  - [Method 1: Using kmcp Controller (Recommended)](#method-1-using-kmcp-controller-recommended)
-  - [Method 2: Using Helm Chart](#method-2-using-helm-chart)
-  - [Method 3: Using Kustomize](#method-3-using-kustomize)
-- [Configuration](#configuration)
-- [Transport Options](#transport-options)
-- [Monitoring and Observability](#monitoring-and-observability)
-- [Troubleshooting](#troubleshooting)
-
----
-
-## Prerequisites
-
-### Required
-- Kubernetes cluster (v1.24+)
-- `kubectl` configured
-- kguardian broker deployed and accessible
-
-### Optional (for kmcp)
-- kmcp CLI installed
-- kmcp controller installed in cluster
-
----
-
-## Deployment Methods
-
-### Method 1: Using kmcp Controller (Recommended)
-
-kmcp provides the best developer experience with transport flexibility and native Kubernetes integration.
-
-#### Install kmcp Controller
-
-```bash
-# Install kmcp controller to your cluster
-kmcp install
-
-# Verify installation
-kubectl get pods -n kmcp-system
-```
-
-#### Deploy MCP Server
-
-```bash
-# Deploy using MCPServer CRD
-kubectl apply -f deploy/mcpserver.yaml
-
-# Verify deployment
-kubectl get mcpserver -n kguardian
-kubectl get pods -l app.kubernetes.io/name=kguardian-mcp-server -n kguardian
-```
-
-#### Check Status
-
-```bash
-# Get MCP server status
-kubectl describe mcpserver kguardian-mcp-server -n kguardian
-
-# View logs
-kubectl logs -l app.kubernetes.io/name=kguardian-mcp-server -n kguardian -f
-```
-
-#### Test the Server
-
-```bash
-# Port-forward to access locally
-kubectl port-forward svc/kguardian-mcp-server 8081:8081 -n kguardian
-
-# In another terminal, test with curl
-curl http://localhost:8081
-
-# Or open MCP Inspector
-kmcp run --remote http://localhost:8081
-```
-
----
-
-### Method 2: Using Helm Chart
-
-The Helm chart supports both standard deployments and kmcp-managed deployments.
-
-#### Standard Deployment (without kmcp)
-
-```bash
-# Install with standard Kubernetes Deployment
-helm upgrade --install kguardian oci://ghcr.io/kguardian-dev/charts/kguardian \
-  --namespace kguardian \
-  --create-namespace \
-  --set mcpServer.enabled=true \
-  --set mcpServer.useKmcp=false
-```
-
-#### kmcp-Managed Deployment
-
-```bash
-# First, install kmcp controller
-kmcp install
-
-# Then install with MCPServer CRD
-helm upgrade --install kguardian oci://ghcr.io/kguardian-dev/charts/kguardian \
-  --namespace kguardian \
-  --create-namespace \
-  --set mcpServer.enabled=true \
-  --set mcpServer.useKmcp=true \
-  --set mcpServer.kmcp.transport.type=streamable-http
-```
-
-#### With Multiple Transports
+## Deploy
 
 ```bash
 helm upgrade --install kguardian oci://ghcr.io/kguardian-dev/charts/kguardian \
   --namespace kguardian \
   --create-namespace \
-  --set mcpServer.enabled=true \
-  --set mcpServer.useKmcp=true \
-  --set mcpServer.kmcp.transport.type=streamable-http \
-  --set-json mcpServer.kmcp.transport.alternativeTransports='[{"type":"sse","path":"/sse"}]'
+  --set mcpServer.enabled=true
 ```
 
----
-
-### Method 3: Using Kustomize
-
-Kustomize overlays provide environment-specific configurations.
-
-#### Development Environment
-
-```bash
-# Deploy to dev environment
-kubectl apply -k deploy/overlays/dev
-
-# Verify
-kubectl get mcpserver -n kguardian-dev
-```
-
-#### Production Environment
-
-```bash
-# Deploy to production
-kubectl apply -k deploy/overlays/production
-
-# Verify with autoscaling
-kubectl get mcpserver -n kguardian
-kubectl get hpa -n kguardian
-```
-
-#### Custom Environment
-
-Create your own overlay:
-
-```bash
-# Create custom overlay
-mkdir -p deploy/overlays/staging
-cat > deploy/overlays/staging/kustomization.yaml <<EOF
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-
-resources:
-  - ../../
-
-namespace: kguardian-staging
-
-images:
-  - name: ghcr.io/kguardian-dev/kguardian/mcp-server
-    newTag: v1.2.0
-
-patchesStrategicMerge:
-  - |-
-    apiVersion: kagent.dev/v1alpha1
-    kind: MCPServer
-    metadata:
-      name: kguardian-mcp-server
-    spec:
-      replicas: 2
-      transport:
-        type: streamable-http
-      env:
-        - name: LOG_LEVEL
-          value: info
-EOF
-
-# Apply
-kubectl apply -k deploy/overlays/staging
-```
-
----
+This creates a Deployment and a `kguardian-mcp-server` Service on port 8081.
 
 ## Configuration
-
-### Environment Variables
 
 | Variable | Description | Default |
 |----------|-------------|---------|
@@ -201,147 +21,29 @@ kubectl apply -k deploy/overlays/staging
 | `PORT` | HTTP server port | `8081` |
 | `LOG_LEVEL` | Log verbosity (debug, info, warn, error) | `info` |
 
-### Using Secrets
+## Health Check
 
 ```bash
-# Create secret for broker authentication
-kubectl create secret generic kguardian-mcp-secrets \
-  --from-literal=BROKER_API_KEY=your-api-key \
-  -n kguardian
-
-# Reference in MCPServer
-kubectl patch mcpserver kguardian-mcp-server -n kguardian --type=merge -p '
-spec:
-  envFrom:
-    - secretRef:
-        name: kguardian-mcp-secrets
-'
+kubectl exec -it deployment/kguardian-mcp-server -n kguardian -- \
+  curl localhost:8081/healthz
 ```
 
----
-
-## Transport Options
-
-kmcp allows changing transport without code changes. The MCP server supports:
-
-### 1. StreamableHTTP (Default)
-Best for web clients and HTTP-based integrations.
-
-```yaml
-spec:
-  transport:
-    type: streamable-http
-    port: 8081
-```
-
-### 2. Server-Sent Events (SSE)
-For long-lived streaming connections.
-
-```yaml
-spec:
-  transport:
-    type: sse
-    port: 8081
-    path: /sse
-```
-
-### 3. stdio
-For local CLI tools and desktop applications.
-
-```yaml
-spec:
-  transport:
-    type: stdio
-```
-
-### 4. Multiple Transports Simultaneously
-
-```yaml
-spec:
-  transport:
-    type: streamable-http
-    port: 8081
-  alternativeTransports:
-    - type: stdio
-    - type: sse
-      path: /sse
-```
-
-### Switching Transports
-
-```bash
-# Switch to SSE without redeploying code
-kubectl patch mcpserver kguardian-mcp-server -n kguardian --type=merge -p '
-spec:
-  transport:
-    type: sse
-    port: 8081
-'
-
-# kmcp controller handles the transition automatically
-kubectl rollout status deployment/kguardian-mcp-server -n kguardian
-```
-
----
-
-## Monitoring and Observability
-
-### Health Checks
-
-```bash
-# Check liveness
-kubectl exec -it deployment/kguardian-mcp-server -n kguardian -- curl localhost:8081/
-
-# Check readiness
-kubectl get pods -l app.kubernetes.io/name=kguardian-mcp-server -n kguardian
-```
-
-### Logs
-
-```bash
-# View logs
-kubectl logs -l app.kubernetes.io/name=kguardian-mcp-server -n kguardian -f
-
-# Set debug logging
-kubectl patch mcpserver kguardian-mcp-server -n kguardian --type=merge -p '
-spec:
-  env:
-    - name: LOG_LEVEL
-      value: debug
-'
-```
-
-### Metrics (if enabled)
-
-```bash
-# Port-forward metrics endpoint
-kubectl port-forward svc/kguardian-mcp-server 9090:9090 -n kguardian
-
-# Scrape metrics
-curl http://localhost:9090/metrics
-```
-
----
+The health endpoint is `GET /healthz` (not `/`).
 
 ## Troubleshooting
 
-### Pod Not Starting
+### Pod not starting
 
 ```bash
-# Check pod status
 kubectl get pods -l app.kubernetes.io/name=kguardian-mcp-server -n kguardian
-
-# Describe pod for events
 kubectl describe pod -l app.kubernetes.io/name=kguardian-mcp-server -n kguardian
-
-# Check logs
 kubectl logs -l app.kubernetes.io/name=kguardian-mcp-server -n kguardian --previous
 ```
 
-### Connection to Broker Failing
+### Connection to broker failing
 
 ```bash
-# Test broker connectivity from MCP server pod
+# Test broker connectivity from the MCP server pod
 kubectl exec -it deployment/kguardian-mcp-server -n kguardian -- \
   curl -v http://kguardian-broker.kguardian.svc.cluster.local:9090/health
 
@@ -349,123 +51,17 @@ kubectl exec -it deployment/kguardian-mcp-server -n kguardian -- \
 kubectl get networkpolicies -n kguardian
 ```
 
-### Tools Not Registering
+### Tools not registering
 
 ```bash
-# Check MCP server startup logs for panic
+# Check startup logs for a panic
 kubectl logs -l app.kubernetes.io/name=kguardian-mcp-server -n kguardian | grep panic
 
-# Verify tool registration
-kubectl logs -l app.kubernetes.io/name=kguardian-mcp-server -n kguardian | grep "RegisterTools"
+# Verify tool registration (tools are wired in RegisterAllTools)
+kubectl logs -l app.kubernetes.io/name=kguardian-mcp-server -n kguardian | grep -i register
 ```
-
-### kmcp Controller Issues
-
-```bash
-# Check kmcp controller status
-kubectl get pods -n kmcp-system
-
-# Check kmcp controller logs
-kubectl logs -n kmcp-system -l app=kmcp-controller -f
-
-# Verify CRD installation
-kubectl get crd mcpservers.mcp.kagent.dev
-```
-
----
-
-## Advanced Topics
-
-### Multi-Tenant Deployment
-
-Deploy separate MCP servers per tenant:
-
-```bash
-# Tenant A
-kubectl create namespace tenant-a
-kubectl apply -f - <<EOF
-apiVersion: kagent.dev/v1alpha1
-kind: MCPServer
-metadata:
-  name: kguardian-mcp-server
-  namespace: tenant-a
-spec:
-  image:
-    repository: ghcr.io/kguardian-dev/kguardian/mcp-server
-    tag: v1.0.0
-  env:
-    - name: BROKER_URL
-      value: http://kguardian-broker.tenant-a.svc.cluster.local:9090
-EOF
-
-# Tenant B
-kubectl create namespace tenant-b
-kubectl apply -f - <<EOF
-apiVersion: kagent.dev/v1alpha1
-kind: MCPServer
-metadata:
-  name: kguardian-mcp-server
-  namespace: tenant-b
-spec:
-  image:
-    repository: ghcr.io/kguardian-dev/kguardian/mcp-server
-    tag: v1.0.0
-  env:
-    - name: BROKER_URL
-      value: http://kguardian-broker.tenant-b.svc.cluster.local:9090
-EOF
-```
-
-### GitOps with Flux/ArgoCD
-
-Create a GitOps-friendly structure:
-
-```yaml
-# apps/kguardian-mcp/kustomization.yaml
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-
-resources:
-  - https://github.com/kguardian-dev/kguardian//mcp-server/deploy?ref=v1.0.0
-
-patches:
-  - target:
-      kind: MCPServer
-      name: kguardian-mcp-server
-    patch: |-
-      - op: replace
-        path: /spec/image/tag
-        value: v1.0.0
-```
-
----
-
-## Migration from Standard Deployment to kmcp
-
-If you're currently using standard Kubernetes Deployment:
-
-```bash
-# 1. Install kmcp controller
-kmcp install
-
-# 2. Update Helm values
-helm upgrade kguardian oci://ghcr.io/kguardian-dev/charts/kguardian \
-  --namespace kguardian \
-  --reuse-values \
-  --set mcpServer.useKmcp=true
-
-# 3. Verify migration
-kubectl get mcpserver -n kguardian
-kubectl get deployment kguardian-mcp-server -n kguardian  # Should not exist
-
-# 4. Test connectivity
-kubectl port-forward svc/kguardian-mcp-server 8081:8081 -n kguardian
-```
-
----
 
 ## Support
 
-- **Documentation**: https://kguardian.dev/docs
+- **Documentation**: https://docs.kguardian.dev
 - **Issues**: https://github.com/kguardian-dev/kguardian/issues
-- **kmcp Docs**: https://kagent.dev/docs/kmcp

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -161,6 +161,18 @@ List Kubernetes services across the cluster with compact metadata. Returns the s
 - Service inventory and discovery
 - Map cluster IPs to services when interpreting egress traffic
 
+### `get_pods_on_node`
+List the pods recorded on a specific Kubernetes node (compact metadata: name, namespace, IP, node, workload labels; live pods only).
+
+**Parameters:**
+- `node` (string, required): The node name to list pods for.
+
+**Returns:** JSON array of compacted pod records, same shape as `get_cluster_pods`.
+
+**Use Cases:**
+- Blast-radius analysis ("what runs on node X?")
+- Identify workloads sharing a node
+
 ### `get_audit_verdicts`
 Get network-policy evaluation verdicts produced by the audit pipeline — observed flows scored as `Allow` or `WouldDeny` against `AuditNetworkPolicy` / `AuditClusterNetworkPolicy` resources. Rows are returned newest-first. This is the primary tool for security questions about what traffic a policy would block.
 
@@ -202,7 +214,7 @@ Generate a least-privilege seccomp profile (JSON) for a pod from its observed sy
 ## Development
 
 ### Prerequisites
-- Go 1.23+
+- Go 1.25+
 - kmcp CLI (recommended) - Install from https://kagent.dev/docs/kmcp
 - Docker (for building images)
 - Kubernetes cluster (for deployment)
@@ -236,7 +248,7 @@ go build -o bin/kguardian-mcp .
 
 Set the broker URL and port via environment variables:
 ```bash
-export BROKER_URL=http://broker.kguardian.svc.cluster.local:9090
+export BROKER_URL=http://kguardian-broker.kguardian.svc.cluster.local:9090
 export PORT=8081
 export LOG_LEVEL=debug  # Optional: debug, info, warn, error
 ```
@@ -272,43 +284,13 @@ docker run -e BROKER_URL=http://broker:9090 kguardian-mcp-server
 
 ## Deployment
 
-The MCP server supports multiple deployment methods. See [DEPLOYMENT.md](./DEPLOYMENT.md) for comprehensive deployment guides.
-
-### Quick Deploy with kmcp
+The MCP server is deployed via the kguardian Helm chart. See [DEPLOYMENT.md](./DEPLOYMENT.md) for details.
 
 ```bash
-# Install kmcp controller
-kmcp install
-
-# Deploy MCP server
-kubectl apply -f deploy/mcpserver.yaml
-
-# Verify
-kubectl get mcpserver -n kguardian
-```
-
-### Deploy with Helm
-
-```bash
-# Standard deployment
 helm install kguardian oci://ghcr.io/kguardian-dev/charts/kguardian \
   --set mcpServer.enabled=true \
   --namespace kguardian --create-namespace
-
-# With kmcp controller (recommended)
-helm install kguardian oci://ghcr.io/kguardian-dev/charts/kguardian \
-  --set mcpServer.enabled=true \
-  --set mcpServer.useKmcp=true \
-  --namespace kguardian --create-namespace
 ```
-
-### Benefits of kmcp Deployment
-
-- ✅ **Transport Flexibility**: Switch between HTTP, SSE, stdio, WebSocket without code changes
-- ✅ **Better DX**: Built-in testing with MCP Inspector
-- ✅ **Kubernetes-Native**: MCPServer CRD managed by controller
-- ✅ **Easy Scaling**: Autoscaling and multi-tenant support
-- ✅ **Observability**: Built-in metrics and tracing integration
 
 ## Integration with LLM Bridge
 
@@ -362,7 +344,7 @@ With the LLM bridge, you can ask natural language questions like:
 
 The LLM bridge automatically discovers and uses all MCP tools. No additional configuration needed beyond:
 
-1. Deploy MCP server with kmcp or Helm
+1. Deploy the MCP server via the Helm chart (`mcpServer.enabled=true`)
 2. Configure LLM bridge with MCP server URL
 3. Start asking questions!
 


### PR DESCRIPTION
Five parallel reviewers fact-checked every docs page, README, and component doc against source; fixes verified against code before applying. Highlights:

- CLI/API reference: documented nonexistent -a seccomp shorthand removed; stale 'no authentication' warning replaced with the real opt-in bearer auth; /pod/traffic limit param documented; NEW /version endpoint page; troubleshooting no longer greps log lines that never existed
- Core pages: chart install unpinned (was pinned to the controller's 1.9.1), manual-download URLs fixed (advisor/vX.Y.Z tags + advisor-<os>-<arch> assets; checksums step replaced with gh attestation verify), containerd-only requirement stated, real controller log lines, /health body corrected
- Architecture: real eBPF hooks (fentry tcp_set_state/tcp_v4_connect/udp_sendmsg, kprobe inet_csk_accept, raw_syscalls/sys_enter), ring buffers not perf buffers, real table names, evaluator added, invented benchmark figures deleted
- Concepts/guides: --dry-run=false documented as not-implemented (code TODO), audit counts described as cumulative not rolling, Kubernetes Events claim removed (post-MVP), real generated filenames/labels, Cilium example now matches real k8s:-prefixed generator output (verified by running the marshaling path)
- Policy gallery: all 'Verified against X.Y.Z [TBD]' placeholders removed, fabricated L7/FQDN/DNS rule blocks and narratives cut, honest hand-authored-illustration warnings added pending regeneration from a live cluster
- Roadmap: shipped items no longer listed as planned; fabricated vote decorations removed; ClusterwideNetworkPolicy moved from GA to planned (no generation code exists)
- Root/component docs: guardian-* image names fixed, RELEASES.md matches the real release-please/draft-advisor flow, mcp-server DEPLOYMENT.md cut from 460 lines of fictional kmcp/Kustomize infra to the real Helm path, llm-bridge README rewritten (12 tools, MCP_SERVER_URL not BROKER_URL, SSE endpoint + rate limit), broker README now documents all 19 real endpoints + env vars, docs/README no longer Mintlify starter boilerplate, dead links removed (docs/development/*, docs/ai-assistant, CODE_OF_CONDUCT, security-model), STYLE.md reconciled with the README emoji-heading redesign

Follow-up (out of scope here): regenerate the policy gallery from a live cluster so examples are captured generator output with real syscall counts.

https://claude.ai/code/session_01NGEYMBjENoxEcbcLBeUhKG