### PR TITLE
fix(version-service): enable Analytics Engine binding and add stale-cache fallback

### DIFF
--- a/cloudflare/version-service/src/index.js
+++ b/cloudflare/version-service/src/index.js
@@ -23,6 +23,11 @@ const REPO = "kguardian-dev/kguardian";
 // zone we control works; this path is never actually routable.
 const CACHE_KEY = "https://version.kguardian.dev/__cache/latest-versions";
 const CACHE_TTL_SECS = 300;
+// Long-TTL stale copy served when GitHub errors on a cold fresh-cache miss
+// (shared egress IPs can hit GitHub's unauthenticated rate limit). A day-old
+// version map beats an empty one; clients only check daily anyway.
+const STALE_KEY = "https://version.kguardian.dev/__cache/latest-versions-stale";
+const STALE_TTL_SECS = 24 * 60 * 60;
 
 /** Tag prefixes → response keys. Matches release-please's component tags. */
 const COMPONENTS = [
@@ -77,11 +82,29 @@ async function latestVersions(env) {
   const cache = caches.default;
   const hit = await cache.match(CACHE_KEY);
   if (hit) return hit.json();
-  const fresh = await fetchLatestFromGitHub(env);
+  let fresh;
+  try {
+    fresh = await fetchLatestFromGitHub(env);
+  } catch (e) {
+    // GitHub unreachable/rate-limited on a cold fresh-cache miss: serve the
+    // long-TTL stale copy rather than an empty map.
+    const stale = await cache.match(STALE_KEY);
+    if (stale) {
+      console.warn("serving stale latest-versions:", e.message);
+      return stale.json();
+    }
+    throw e;
+  }
   await cache.put(
     CACHE_KEY,
     Response.json(fresh, {
       headers: { "Cache-Control": `public, max-age=${CACHE_TTL_SECS}` },
+    }),
+  );
+  await cache.put(
+    STALE_KEY,
+    Response.json(fresh, {
+      headers: { "Cache-Control": `public, max-age=${STALE_TTL_SECS}` },
     }),
   );
   return fresh;

--- a/cloudflare/version-service/wrangler.toml
+++ b/cloudflare/version-service/wrangler.toml
@@ -14,19 +14,13 @@ routes = [
 # The 5-minute GitHub Releases cache uses the Workers Cache API
 # (caches.default) — per-colo, zero pre-created resources. No KV needed.
 
-# Usage telemetry sink — TEMPORARILY DISABLED (chicken-and-egg on fresh
-# accounts): deploying with this binding fails with error 10089 until
-# Analytics Engine is enabled in the dashboard, but the dashboard's enable
-# CTA (Workers & Pages → Overview → side panel → "Analytics Engine (beta)")
-# only appears once a worker is deployed. So: deploy without the binding
-# first (version checks work; recordCheckin no-ops on the absent binding),
-# enable AE in the dashboard, then uncomment this block. Query with the
-# Analytics Engine SQL API:
+# Usage telemetry sink (Analytics Engine enabled on the account 2026-07-21).
+# Every check-in writes one data point; query with the AE SQL API:
 #   SELECT COUNT(DISTINCT index1) AS installs FROM kguardian_telemetry
 #   WHERE timestamp > NOW() - INTERVAL '30' DAY
-# [[analytics_engine_datasets]]
-# binding = "TELEMETRY"
-# dataset = "kguardian_telemetry"
+[[analytics_engine_datasets]]
+binding = "TELEMETRY"
+dataset = "kguardian_telemetry"
 
 # Optional secret to raise the GitHub API rate limit (not required — the
 # cache keeps traffic minimal):


### PR DESCRIPTION
Enables the Analytics Engine binding (account-level AE enablement completed in the dashboard) — check-ins start recording to kguardian_telemetry on deploy. Adds a 24h stale-cache fallback for GitHub outages/rate limits (all three cache paths unit-verified: fresh, stale-on-outage, cold-outage graceful empty).

https://claude.ai/code/session_01NGEYMBjENoxEcbcLBeUhKG