### PR TITLE
fix(broker): pin builder to rust:1-bookworm to match runtime glibc

### DIFF
--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -322,6 +322,25 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+      # Execute the built image, not just build it. Catches runtime-only
+      # failures like builder/runtime glibc mismatch (broker v1.12.0 shipped
+      # unable to exec: "GLIBC_2.38 not found" — built on a drifted
+      # rust:latest, run on debian 12). Without a DATABASE_URL the binary
+      # must reach its own startup assertion; a loader error means the
+      # image cannot run anywhere.
+      - name: Smoke test image (binary must exec)
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          out=$(docker run --rm "ghcr.io/kguardian-dev/kguardian/broker:pr-${PR_NUMBER}" /broker 2>&1 || true)
+          echo "$out"
+          if echo "$out" | grep -q "DATABASE_URL must be set"; then
+            echo "OK: binary executed to the expected startup assertion"
+          else
+            echo "FAIL: binary did not reach startup (loader/link error above?)"
+            exit 1
+          fi
+
       - name: Update or create PR comment
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:

--- a/broker/Dockerfile
+++ b/broker/Dockerfile
@@ -1,4 +1,11 @@
-FROM rust:latest  AS build
+# Builder MUST target the same Debian release as the runtime stage below:
+# the binary links against the builder's glibc, and a newer builder glibc
+# than the runtime's makes the container fail at exec ("GLIBC_X.YY not
+# found"). rust:latest drifted to a newer Debian base and broke broker
+# v1.12.0 exactly this way (built needing glibc 2.38, ran on bookworm's
+# 2.36). If the runtime moves to debian:13-slim, move this to rust:1-trixie
+# in the same commit.
+FROM rust:1-bookworm AS build
 
 COPY Cargo.lock /app/
 


### PR DESCRIPTION
Fixes the broker v1.12.0 crashloop found deploying chart 1.14.0 to cluster-00: builder/runtime glibc mismatch (rust:latest drifted to a newer Debian base; runtime is debian 12). Builder pinned to rust:1-bookworm + a CI smoke test that executes the built image so this class of failure can never ship silently again. The smoke test in this PR's own CI run is the verification of the fix.

https://claude.ai/code/session_01NGEYMBjENoxEcbcLBeUhKG