### PR TITLE
fix(broker): ignore semver build metadata in version check comparisons

### DIFF
--- a/broker/src/audit.rs
+++ b/broker/src/audit.rs
@@ -488,6 +488,8 @@ mod tests {
     /// restores between iterations, which is fine — each iteration
     /// sets up its own state fresh).
     fn with_env<F: FnOnce()>(key: &str, value: Option<&str>, f: F) {
+        // Crate-wide env lock — std::env is process-global (see test_support).
+        let _guard = crate::test_support::env_lock();
         let prev = std::env::var(key).ok();
         match value {
             Some(v) => std::env::set_var(key, v),

--- a/broker/src/conn.rs
+++ b/broker/src/conn.rs
@@ -79,6 +79,9 @@ mod tests {
     }
 
     impl EnvGuard {
+        /// NOTE: callers must hold `crate::test_support::env_lock()` for
+        /// the guard's lifetime — EnvGuard restores values but does not
+        /// provide cross-test exclusion.
         fn set(key: &str, value: Option<&str>) -> Self {
             let prev = env::var(key).ok();
             match value {
@@ -108,6 +111,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "DATABASE_URL must be set")]
     fn panics_when_database_url_unset() {
+        let _lock = crate::test_support::env_lock();
         let _g = EnvGuard::set("DATABASE_URL", None);
         // _g drops on the panic-unwind path, restoring env. #[should_panic]
         // still sees the panic.
@@ -120,6 +124,7 @@ mod tests {
         // construction — that happens in r2d2 Pool::build. So a fake
         // URL is sufficient to prove the function returned without
         // panicking.
+        let _lock = crate::test_support::env_lock();
         let _g = EnvGuard::set("DATABASE_URL", Some("postgres://x:y@example.invalid/db"));
         let _mgr = establish_connection();
     }
@@ -132,6 +137,7 @@ mod tests {
         // It hits the empty-after-trim filter and triggers the
         // same "not set" panic — clearer signal at startup than
         // a downstream postgres parse error.
+        let _lock = crate::test_support::env_lock();
         let _g = EnvGuard::set("DATABASE_URL", Some("  \n"));
         establish_connection();
     }
@@ -141,6 +147,7 @@ mod tests {
         // A pasted URL with trailing newline (typical) round-trips
         // clean. Construction succeeds and the connection-manager
         // gets the trimmed URL.
+        let _lock = crate::test_support::env_lock();
         let _g = EnvGuard::set(
             "DATABASE_URL",
             Some("  postgres://x:y@example.invalid/db\n"),

--- a/broker/src/lib.rs
+++ b/broker/src/lib.rs
@@ -23,3 +23,24 @@ pub use get::{
     get_pod_traffic, get_pod_traffic_name, get_pods_by_node, get_svc_by_ip, get_svc_details,
 };
 pub use schema::{pod_details, pod_traffic};
+
+#[cfg(test)]
+pub(crate) mod test_support {
+    use std::sync::{Mutex, MutexGuard};
+
+    /// Process-wide lock for tests that mutate environment variables.
+    /// `std::env` is process-global: parallel tests mutating even
+    /// *different* keys race on libc's `environ` (and one module's
+    /// remove_var can crash another's concurrent var()). Every
+    /// env-mutating test helper in this crate must hold this lock —
+    /// per-module locks give no cross-module exclusion (the flaky
+    /// conn::returns_connection_manager_when_url_set failure).
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    /// Acquire the env lock, tolerating poison: #[should_panic] tests
+    /// legitimately panic while holding it, and the next test must not
+    /// fail on the poisoned mutex.
+    pub fn env_lock() -> MutexGuard<'static, ()> {
+        ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner())
+    }
+}

--- a/broker/src/retention.rs
+++ b/broker/src/retention.rs
@@ -353,6 +353,8 @@ mod tests {
     // each other's mutations. The std test runner runs tests in
     // parallel by default.
     fn with_env<F: FnOnce()>(key: &str, value: Option<&str>, f: F) {
+        // Crate-wide env lock — std::env is process-global (see test_support).
+        let _guard = crate::test_support::env_lock();
         let prev = std::env::var(key).ok();
         match value {
             Some(v) => std::env::set_var(key, v),

--- a/broker/src/version_check.rs
+++ b/broker/src/version_check.rs
@@ -89,15 +89,26 @@ pub(crate) fn telemetry_interval() -> Duration {
     Duration::from_secs(secs)
 }
 
-/// Chart version as injected by the Helm chart. Absent when the broker
-/// runs outside the chart (dev, docker-compose) — sent as "unknown"
-/// rather than omitted so the service can count non-chart installs.
+/// Chart version as injected by the Helm chart, normalized to the base
+/// semver. Flux-installed charts report `.Chart.Version` with build
+/// metadata appended (e.g. "1.14.1+a1f714b25358"); semver defines the
+/// `+meta` suffix as ignorable for comparison, and keeping it would both
+/// fragment the telemetry's version-spread grouping and false-positive
+/// `update_available` against the service's bare "1.14.1". Absent when
+/// the broker runs outside the chart (dev, docker-compose) — sent as
+/// "unknown" rather than omitted so the service can count non-chart
+/// installs.
 fn chart_version() -> String {
     std::env::var("CHART_VERSION")
         .ok()
-        .map(|v| v.trim().to_string())
+        .map(|v| strip_build_metadata(v.trim()).to_string())
         .filter(|v| !v.is_empty())
         .unwrap_or_else(|| "unknown".to_string())
+}
+
+/// Drop a semver build-metadata suffix ("1.14.1+a1f714b" → "1.14.1").
+fn strip_build_metadata(version: &str) -> &str {
+    version.split('+').next().unwrap_or(version)
 }
 
 fn kube_version() -> String {
@@ -160,9 +171,14 @@ pub(crate) fn update_available(
     if current_chart == "unknown" {
         return false;
     }
+    // Compare base versions: build metadata is defined by semver as
+    // ignorable, and callers may pass a raw Flux-style "1.14.1+<sha>"
+    // (chart_version() already normalizes, but stay safe on both sides).
     latest
         .and_then(|l| l.get("chart"))
-        .map(|latest_chart| latest_chart != current_chart)
+        .map(|latest_chart| {
+            strip_build_metadata(latest_chart) != strip_build_metadata(current_chart)
+        })
         .unwrap_or(false)
 }
 
@@ -327,13 +343,11 @@ pub fn spawn(pool: DbPool, state: web::Data<VersionCheckState>) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::Mutex;
-
-    // Env-mutating tests share this lock (std::env is process-global).
-    static ENV_LOCK: Mutex<()> = Mutex::new(());
 
     fn with_env<F: FnOnce()>(key: &str, value: Option<&str>, f: F) {
-        let _guard = ENV_LOCK.lock().unwrap();
+        // Crate-wide lock: std::env is process-global, so exclusion must
+        // span every test module, not just this one.
+        let _guard = crate::test_support::env_lock();
         let saved = std::env::var(key).ok();
         match value {
             Some(v) => std::env::set_var(key, v),
@@ -452,6 +466,37 @@ mod tests {
                 .status()
         });
         assert!(status.is_success(), "unexpected status {status}");
+    }
+
+    #[test]
+    fn chart_version_strips_build_metadata() {
+        // Flux reports .Chart.Version with build metadata; the base
+        // version must be what we send and compare (the raw form caused
+        // a permanent update_available=true false positive in 1.12.1).
+        with_env("CHART_VERSION", Some("1.14.1+a1f714b25358"), || {
+            assert_eq!(chart_version(), "1.14.1");
+        });
+        with_env("CHART_VERSION", Some("1.14.1"), || {
+            assert_eq!(chart_version(), "1.14.1");
+        });
+        // A degenerate "+meta"-only value strips to empty → unknown.
+        with_env("CHART_VERSION", Some("+abc"), || {
+            assert_eq!(chart_version(), "unknown");
+        });
+    }
+
+    #[test]
+    fn update_available_ignores_build_metadata() {
+        let latest = |v: &str| {
+            let mut m = HashMap::new();
+            m.insert("chart".to_string(), v.to_string());
+            m
+        };
+        // Same base version with metadata on either side → no update.
+        assert!(!update_available("1.14.1+a1f714b", Some(&latest("1.14.1"))));
+        assert!(!update_available("1.14.1", Some(&latest("1.14.1+meta"))));
+        // Genuinely behind, metadata present → still flags.
+        assert!(update_available("1.14.0+a1f714b", Some(&latest("1.14.1"))));
     }
 
     #[test]


### PR DESCRIPTION
Fixes the update_available false positive found validating chart 1.14.1 on cluster-00 (Flux reports "1.14.1+<sha>"; plain string compare flagged it as an update forever). Build metadata now stripped at the source, so the check-in payload, /version display, and comparison all use clean base semver. Also consolidates the crate's env-test locking (the cross-module race that made conn's tests flaky). 106 tests green 5x consecutively; clippy -D warnings clean.

https://claude.ai/code/session_01NGEYMBjENoxEcbcLBeUhKG