### PR TITLE
docs: add missing frontmatter icons to eight pages

### DIFF
--- a/docs/api-reference/endpoints/audit-verdicts.mdx
+++ b/docs/api-reference/endpoints/audit-verdicts.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Audit Verdict Endpoints"
 description: "Query Would-Deny / Allow audit-mode policy verdicts"
+icon: "gavel"
 ---
 
 ## Overview

--- a/docs/api-reference/endpoints/pods.mdx
+++ b/docs/api-reference/endpoints/pods.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Pod Endpoints"
 description: "Submit pod metadata, mark dead, and query"
+icon: "cube"
 ---
 
 ## POST /pod/spec

--- a/docs/api-reference/endpoints/services.mdx
+++ b/docs/api-reference/endpoints/services.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Service Endpoints"
 description: "Submit service metadata and look up by IP"
+icon: "diagram-project"
 ---
 
 ## POST /svc/spec

--- a/docs/api-reference/endpoints/syscalls.mdx
+++ b/docs/api-reference/endpoints/syscalls.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Syscall Endpoints"
 description: "Submit and retrieve syscall observations"
+icon: "terminal"
 ---
 
 ## POST /pod/syscalls

--- a/docs/api-reference/endpoints/traffic.mdx
+++ b/docs/api-reference/endpoints/traffic.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Traffic Endpoints"
 description: "Add observed pod-traffic events and query them"
+icon: "right-left"
 ---
 
 ## POST /pod/traffic

--- a/docs/api-reference/endpoints/version.mdx
+++ b/docs/api-reference/endpoints/version.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Version Endpoint"
 description: "Running broker + chart versions and update availability"
+icon: "tag"
 ---
 
 ## Overview

--- a/docs/concepts/audit-network-policy.mdx
+++ b/docs/concepts/audit-network-policy.mdx
@@ -1,6 +1,7 @@
 ---
 title: "AuditNetworkPolicy"
 description: "Push policies, see what would be blocked — without blocking anything"
+icon: "clipboard-check"
 ---
 
 `AuditNetworkPolicy` is a kguardian CRD that lets you preview the impact of a Kubernetes NetworkPolicy *before* you enforce it. The spec is byte-identical to upstream `networking.k8s.io/v1.NetworkPolicy`. The only thing that changes is what kguardian does with it: the `kguardian-evaluator` watches observed pod traffic and reports flows that the policy *would* deny — but never drops a single packet.

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -1,6 +1,7 @@
 ---
 title: "kguardian"
 description: "kguardian watches pod traffic and syscalls with eBPF, then writes Kubernetes NetworkPolicies, CiliumNetworkPolicies, and seccomp profiles from what it sees — no hand-authored rules."
+icon: "house"
 ---
 
 # kguardian


### PR DESCRIPTION
Fixes the missing icon on concepts/audit-network-policy (spotted by Michael in the docs nav) and the same gap on docs/index and all six api-reference endpoint pages.

https://claude.ai/code/session_01NGEYMBjENoxEcbcLBeUhKG