### PR TITLE
feat(docs): rebrand to the indigo padlock mark used by the UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ _Least-privilege Kubernetes security policies, generated from what your pods act
 
 <div align="center">
 
-[![Docs](https://img.shields.io/badge/docs-docs.kguardian.dev-16A34A?style=for-the-badge&logo=gitbook&logoColor=white)](https://docs.kguardian.dev)&nbsp;&nbsp;
-[![Kubernetes](https://img.shields.io/badge/kubernetes-v1.19%2B-16A34A?style=for-the-badge&logo=kubernetes&logoColor=white)](https://kubernetes.io/)&nbsp;&nbsp;
-[![License](https://img.shields.io/badge/license-BSL%201.1-15803D?style=for-the-badge)](LICENSE)&nbsp;&nbsp;
+[![Docs](https://img.shields.io/badge/docs-docs.kguardian.dev-4E3AD9?style=for-the-badge&logo=gitbook&logoColor=white)](https://docs.kguardian.dev)&nbsp;&nbsp;
+[![Kubernetes](https://img.shields.io/badge/kubernetes-v1.19%2B-4E3AD9?style=for-the-badge&logo=kubernetes&logoColor=white)](https://kubernetes.io/)&nbsp;&nbsp;
+[![License](https://img.shields.io/badge/license-BSL%201.1-3B2BA8?style=for-the-badge)](LICENSE)&nbsp;&nbsp;
 
 </div>
 
@@ -78,11 +78,11 @@ graph LR
     UI --> B
     CLI -->|generate policies| B
 
-    style C fill:#16A34A,color:#fff
-    style B fill:#22C55E,color:#fff
-    style E fill:#22C55E,color:#fff
-    style UI fill:#22C55E,color:#fff
-    style CLI fill:#15803D,color:#fff
+    style C fill:#4E3AD9,color:#fff
+    style B fill:#6D5CE6,color:#fff
+    style E fill:#6D5CE6,color:#fff
+    style UI fill:#6D5CE6,color:#fff
+    style CLI fill:#3B2BA8,color:#fff
 ```
 
 | Component | Language | Runs as | Purpose |

--- a/docs/architecture.mdx
+++ b/docs/architecture.mdx
@@ -46,11 +46,11 @@ graph TB
     Pod3 -.->|Monitors| Controller2
     Pod4 -.->|Monitors| Controller2
 
-    style Controller1 fill:#16A34A
-    style Controller2 fill:#16A34A
-    style Broker fill:#22C55E
-    style CLI fill:#15803D
-    style UI fill:#22C55E
+    style Controller1 fill:#4E3AD9
+    style Controller2 fill:#4E3AD9
+    style Broker fill:#6D5CE6
+    style CLI fill:#3B2BA8
+    style UI fill:#6D5CE6
 ```
 
 ## Components

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -3,9 +3,9 @@
   "theme": "mint",
   "name": "kguardian",
   "colors": {
-    "primary": "#16A34A",
-    "light": "#22C55E",
-    "dark": "#15803D"
+    "primary": "#4E3AD9",
+    "light": "#7C6FF0",
+    "dark": "#3B2BA8"
   },
   "favicon": "/favicon.svg",
   "navigation": {

--- a/docs/favicon.svg
+++ b/docs/favicon.svg
@@ -1,19 +1,10 @@
 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M9.06145 23.1079C5.26816 22.3769 -3.39077 20.6274 1.4173 5.06384C9.6344 6.09939 16.9728 14.0644 9.06145 23.1079Z" fill="url(#paint0_linear_17557_2021)"/>
-<path d="M8.91928 23.0939C5.27642 21.2223 0.78371 4.20891 17.0071 0C20.7569 7.19341 19.6212 16.5452 8.91928 23.0939Z" fill="url(#paint1_linear_17557_2021)"/>
-<path d="M8.91388 23.0788C8.73534 19.8817 10.1585 9.08525 23.5699 13.1107C23.1812 20.1229 18.984 26.4182 8.91388 23.0788Z" fill="url(#paint2_linear_17557_2021)"/>
-<defs>
-<linearGradient id="paint0_linear_17557_2021" x1="3.77557" y1="5.91571" x2="5.23185" y2="21.5589" gradientUnits="userSpaceOnUse">
-<stop stop-color="#18E299"/>
-<stop offset="1" stop-color="#15803D"/>
-</linearGradient>
-<linearGradient id="paint1_linear_17557_2021" x1="12.1711" y1="-0.718425" x2="10.1897" y2="22.9832" gradientUnits="userSpaceOnUse">
-<stop stop-color="#16A34A"/>
-<stop offset="1" stop-color="#4ADE80"/>
-</linearGradient>
-<linearGradient id="paint2_linear_17557_2021" x1="23.1327" y1="15.353" x2="9.33841" y2="18.5196" gradientUnits="userSpaceOnUse">
-<stop stop-color="#4ADE80"/>
-<stop offset="1" stop-color="#0D9373"/>
-</linearGradient>
-</defs>
+  <polygon points="12,1.2 21.4,6.6 21.4,17.4 12,22.8 2.6,17.4 2.6,6.6"
+           fill="#4e3ad9" stroke="#4e3ad9" stroke-width="2" stroke-linejoin="round"/>
+  <path d="M8.6 11.2 V9.2 a3.4 3.4 0 0 1 6.8 0 v2"
+        stroke="#ffffff" stroke-width="2.1" stroke-linecap="round" fill="none"/>
+  <path d="M7.2 12.9 q0 -1.6 1.6 -1.6 h6.4 q1.6 0 1.6 1.6 v3.1 q0 1.3 -1 2.1 l-2.9 2.2 q-0.9 0.7 -1.8 0 l-2.9 -2.2 q-1 -0.8 -1 -2.1 z"
+        fill="#ffffff"/>
+  <circle cx="12" cy="14.9" r="1.15" fill="#4e3ad9"/>
+  <rect x="11.55" y="15.5" width="0.9" height="2.1" rx="0.45" fill="#4e3ad9"/>
 </svg>

--- a/docs/logo/dark.svg
+++ b/docs/logo/dark.svg
@@ -1,28 +1,9 @@
 <svg width="150" height="32" viewBox="0 0 150 32" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <!-- Shield icon -->
-  <g transform="scale(1.2)">
-    <path d="M9.06145 23.1079C5.26816 22.3769 -3.39077 20.6274 1.4173 5.06384C9.6344 6.09939 16.9728 14.0644 9.06145 23.1079Z" fill="url(#paint0_linear_dark)"/>
-    <path d="M8.91928 23.0939C5.27642 21.2223 0.78371 4.20891 17.0071 0C20.7569 7.19341 19.6212 16.5452 8.91928 23.0939Z" fill="url(#paint1_linear_dark)"/>
-    <path d="M8.91388 23.0788C8.73534 19.8817 10.1585 9.08525 23.5699 13.1107C23.1812 20.1229 18.984 26.4182 8.91388 23.0788Z" fill="url(#paint2_linear_dark)"/>
-  </g>
-
-  <!-- Text "kguardian" -->
-  <text x="35" y="21" font-family="Arial, sans-serif" font-size="18" font-weight="600" fill="#FAFAFA">
-    kguardian
-  </text>
-
-  <defs>
-    <linearGradient id="paint0_linear_dark" x1="3.77557" y1="5.91571" x2="5.23185" y2="21.5589" gradientUnits="userSpaceOnUse">
-      <stop stop-color="#18E299"/>
-      <stop offset="1" stop-color="#15803D"/>
-    </linearGradient>
-    <linearGradient id="paint1_linear_dark" x1="12.1711" y1="-0.718425" x2="10.1897" y2="22.9832" gradientUnits="userSpaceOnUse">
-      <stop stop-color="#16A34A"/>
-      <stop offset="1" stop-color="#4ADE80"/>
-    </linearGradient>
-    <linearGradient id="paint2_linear_dark" x1="23.1327" y1="15.353" x2="9.33841" y2="18.5196" gradientUnits="userSpaceOnUse">
-      <stop stop-color="#4ADE80"/>
-      <stop offset="1" stop-color="#0D9373"/>
-    </linearGradient>
-  </defs>
+  <!-- kguardian mark: indigo hexagon + white padlock (matches the UI logo) -->
+  <polygon points="16,1.6 28.5,8.8 28.5,23.2 16,30.4 3.5,23.2 3.5,8.8" fill="#4e3ad9" stroke="#4e3ad9" stroke-width="2.6" stroke-linejoin="round"/>
+  <path d="M11.5 14.9 V12.3 a4.5 4.5 0 0 1 9 0 v2.6" stroke="#ffffff" stroke-width="2.8" stroke-linecap="round" fill="none"/>
+  <path d="M9.6 17.2 q0 -2.1 2.1 -2.1 h8.6 q2.1 0 2.1 2.1 v4.1 q0 1.7 -1.3 2.8 l-3.9 3 q-1.2 0.9 -2.4 0 l-3.9 -3 q-1.3 -1.1 -1.3 -2.8 z" fill="#ffffff"/>
+  <circle cx="16" cy="19.9" r="1.5" fill="#4e3ad9"/>
+  <rect x="15.4" y="20.7" width="1.2" height="2.8" rx="0.6" fill="#4e3ad9"/>
+  <text x="38" y="21.5" font-family="Arial, sans-serif" font-size="18" font-weight="600" fill="#FAFAFA">kguardian</text>
 </svg>

--- a/docs/logo/light.svg
+++ b/docs/logo/light.svg
@@ -1,28 +1,9 @@
 <svg width="150" height="32" viewBox="0 0 150 32" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <!-- Shield icon -->
-  <g transform="scale(1.2)">
-    <path d="M9.06145 23.1079C5.26816 22.3769 -3.39077 20.6274 1.4173 5.06384C9.6344 6.09939 16.9728 14.0644 9.06145 23.1079Z" fill="url(#paint0_linear)"/>
-    <path d="M8.91928 23.0939C5.27642 21.2223 0.78371 4.20891 17.0071 0C20.7569 7.19341 19.6212 16.5452 8.91928 23.0939Z" fill="url(#paint1_linear)"/>
-    <path d="M8.91388 23.0788C8.73534 19.8817 10.1585 9.08525 23.5699 13.1107C23.1812 20.1229 18.984 26.4182 8.91388 23.0788Z" fill="url(#paint2_linear)"/>
-  </g>
-
-  <!-- Text "kguardian" -->
-  <text x="35" y="21" font-family="Arial, sans-serif" font-size="18" font-weight="600" fill="#09090B">
-    kguardian
-  </text>
-
-  <defs>
-    <linearGradient id="paint0_linear" x1="3.77557" y1="5.91571" x2="5.23185" y2="21.5589" gradientUnits="userSpaceOnUse">
-      <stop stop-color="#18E299"/>
-      <stop offset="1" stop-color="#15803D"/>
-    </linearGradient>
-    <linearGradient id="paint1_linear" x1="12.1711" y1="-0.718425" x2="10.1897" y2="22.9832" gradientUnits="userSpaceOnUse">
-      <stop stop-color="#16A34A"/>
-      <stop offset="1" stop-color="#4ADE80"/>
-    </linearGradient>
-    <linearGradient id="paint2_linear" x1="23.1327" y1="15.353" x2="9.33841" y2="18.5196" gradientUnits="userSpaceOnUse">
-      <stop stop-color="#4ADE80"/>
-      <stop offset="1" stop-color="#0D9373"/>
-    </linearGradient>
-  </defs>
+  <!-- kguardian mark: indigo hexagon + white padlock (matches the UI logo) -->
+  <polygon points="16,1.6 28.5,8.8 28.5,23.2 16,30.4 3.5,23.2 3.5,8.8" fill="#4e3ad9" stroke="#4e3ad9" stroke-width="2.6" stroke-linejoin="round"/>
+  <path d="M11.5 14.9 V12.3 a4.5 4.5 0 0 1 9 0 v2.6" stroke="#ffffff" stroke-width="2.8" stroke-linecap="round" fill="none"/>
+  <path d="M9.6 17.2 q0 -2.1 2.1 -2.1 h8.6 q2.1 0 2.1 2.1 v4.1 q0 1.7 -1.3 2.8 l-3.9 3 q-1.2 0.9 -2.4 0 l-3.9 -3 q-1.3 -1.1 -1.3 -2.8 z" fill="#ffffff"/>
+  <circle cx="16" cy="19.9" r="1.5" fill="#4e3ad9"/>
+  <rect x="15.4" y="20.7" width="1.2" height="2.8" rx="0.6" fill="#4e3ad9"/>
+  <text x="38" y="21.5" font-family="Arial, sans-serif" font-size="18" font-weight="600" fill="#09090B">kguardian</text>
 </svg>

--- a/docs/roadmap/future-resources.mdx
+++ b/docs/roadmap/future-resources.mdx
@@ -15,14 +15,14 @@ kguardian is continuously evolving to support more Kubernetes security resources
 ## Planned Resources
 
 <CardGroup cols={2}>
-  <Card title="✅ Network Policies" icon="check-circle" color="#16A34A">
+  <Card title="✅ Network Policies" icon="check-circle" color="#4E3AD9">
     **Status:** Generally Available
 
     - Kubernetes NetworkPolicy
     - Cilium NetworkPolicy
   </Card>
 
-  <Card title="✅ Audit Mode Policies" icon="check-circle" color="#16A34A">
+  <Card title="✅ Audit Mode Policies" icon="check-circle" color="#4E3AD9">
     **Status:** Generally Available
 
     - `AuditNetworkPolicy` + `AuditClusterNetworkPolicy` CRDs
@@ -30,7 +30,7 @@ kguardian is continuously evolving to support more Kubernetes security resources
     - Frontend "Would-Deny" view + CLI `audit promote` helpers
   </Card>
 
-  <Card title="✅ Seccomp Profiles" icon="check-circle" color="#16A34A">
+  <Card title="✅ Seccomp Profiles" icon="check-circle" color="#4E3AD9">
     **Status:** Generally Available
 
     - OCI seccomp JSON format


### PR DESCRIPTION
Standardizes branding on the indigo hexagon padlock (the mark the UI already ships) per Michael's call — replaces the green shield everywhere: README logo+badges+diagram, docs-site logo lockups (light/dark), favicon, docs theme colors. SVGs redrawn from the UI logo's sampled color (#4e3ad9); GitHub's rich diff on docs/logo/*.svg shows the before/after.

https://claude.ai/code/session_01NGEYMBjENoxEcbcLBeUhKG