### PR TITLE
feat(chart): ai.enabled umbrella toggle for the assistant path

### DIFF
--- a/charts/kguardian/README.md
+++ b/charts/kguardian/README.md
@@ -98,6 +98,7 @@ The following table lists the configurable parameters of the kguardian chart and
 | advisor.serviceAccount.name | string | `""` | The name of the service account to use |
 | advisor.tolerations | list | `[]` | Tolerations for advisor pods |
 | advisor.topologySpreadConstraints | list | `[]` | Topology spread constraints for advisor pods |
+| ai.enabled | bool | `false` | Enable the full AI assistant path (llm-bridge + mcp-server + advisor) with one toggle |
 | broker.affinity | object | `{}` | Affinity rules for broker pod assignment |
 | broker.audit.evalTimeoutMs | int | `500` | Per-call timeout (in milliseconds) on the broker's POST to the evaluator's /evaluate endpoint. 500ms is plenty for an in-cluster evaluator (matcher is in-memory, sub-ms) but operators running the evaluator across cells / regions / VPNs may need more. Clamped to a minimum 50ms broker-side. |
 | broker.audit.inflightPermits | int | `16` | Maximum concurrent in-flight /evaluate calls to the audit evaluator. Bound prevents an ingest spike from creating unbounded concurrent reqwest futures + connection-pool waiters. The broker's /metrics exposes broker_audit_inflight_available so operators can spot saturation. The metrics doc suggests bumping this value when the gauge sits at 0 (under sustained load you'll see "evaluator round-trips queueing"). In-broker default is 16 if unset; minimum is 1. |
@@ -319,7 +320,7 @@ The following table lists the configurable parameters of the kguardian chart and
 | llmBridge.autoscaling.minReplicas | int | `2` | Minimum number of llm-bridge replicas |
 | llmBridge.autoscaling.targetCPUUtilizationPercentage | int | `80` | Target CPU utilization percentage for autoscaling |
 | llmBridge.container.port | int | `8080` | LLM Bridge container port |
-| llmBridge.enabled | bool | `false` | Enable LLM Bridge service for AI assistant |
+| llmBridge.enabled | bool | `false` | Enable LLM Bridge service for AI assistant (or use ai.enabled to turn on the whole path) |
 | llmBridge.env | list | `[]` | Additional environment variables for llm-bridge |
 | llmBridge.fullnameOverride | string | `""` | Override the full name of the llm-bridge resources |
 | llmBridge.image.pullPolicy | string | `"IfNotPresent"` | LLM Bridge image pull policy |

--- a/charts/kguardian/templates/NOTES.txt
+++ b/charts/kguardian/templates/NOTES.txt
@@ -76,6 +76,18 @@ audit's results, promote it to an enforced policy:
 For cluster-scoped policies (AuditClusterNetworkPolicy):
   kguardian audit promote-cluster <name> | kubectl apply -f -
 {{- end }}
+{{- if include "kguardian.llmBridgeEnabled" . }}
+
+AI assistant: ENABLED (llm-bridge{{ if include "kguardian.mcpServerEnabled" . }} + mcp-server{{ end }}{{ if include "kguardian.advisorEnabled" . }} + advisor{{ end }}).
+Provide an LLM provider API key as a Secret (see llmBridge.secrets in
+values) or the assistant will start without a provider. Enabling
+everything at once next time: --set ai.enabled=true
+{{- else }}
+
+AI assistant: disabled. Enable the whole path (llm-bridge, mcp-server,
+advisor) with one value plus a provider secret:
+  --set ai.enabled=true
+{{- end }}
 {{- if .Values.telemetry.enabled }}
 
 Telemetry: the broker performs a daily anonymous version check-in

--- a/charts/kguardian/templates/_helpers.tpl
+++ b/charts/kguardian/templates/_helpers.tpl
@@ -140,3 +140,23 @@ Usage: {{- include "kguardian.brokerAuthEnv" . | nindent 12 }}
       key: {{ .Values.broker.auth.secretKey }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+AI-path component gates (SIMPLIFICATION-GOAL.md WS-D). ai.enabled=true turns
+on the whole assistant chain — llm-bridge, mcp-server, and the advisor
+service — with one value. The per-component `enabled` flags still work and
+remain the way to switch a single component on; these helpers OR the two so
+existing values files render identically. Truthy = non-empty string.
+Usage: {{- if include "kguardian.llmBridgeEnabled" . }}
+*/}}
+{{- define "kguardian.llmBridgeEnabled" -}}
+{{- if or .Values.ai.enabled .Values.llmBridge.enabled }}true{{- end -}}
+{{- end -}}
+
+{{- define "kguardian.mcpServerEnabled" -}}
+{{- if or .Values.ai.enabled .Values.mcpServer.enabled }}true{{- end -}}
+{{- end -}}
+
+{{- define "kguardian.advisorEnabled" -}}
+{{- if or .Values.ai.enabled .Values.advisor.enabled }}true{{- end -}}
+{{- end -}}

--- a/charts/kguardian/templates/advisor/deployment.yaml
+++ b/charts/kguardian/templates/advisor/deployment.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.advisor.enabled }}
+{{- if include "kguardian.advisorEnabled" . }}
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/charts/kguardian/templates/advisor/networkpolicy.yaml
+++ b/charts/kguardian/templates/advisor/networkpolicy.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.advisor.enabled .Values.advisor.networkPolicy.enabled }}
+{{- if and (include "kguardian.advisorEnabled" .) .Values.advisor.networkPolicy.enabled }}
 ---
 # Ingress NetworkPolicy for the advisor service.
 #

--- a/charts/kguardian/templates/advisor/service.yaml
+++ b/charts/kguardian/templates/advisor/service.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.advisor.enabled }}
+{{- if include "kguardian.advisorEnabled" . }}
 ---
 apiVersion: v1
 kind: Service

--- a/charts/kguardian/templates/advisor/serviceaccount.yaml
+++ b/charts/kguardian/templates/advisor/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.advisor.enabled }}
+{{- if include "kguardian.advisorEnabled" . }}
 {{- if .Values.advisor.serviceAccount.create -}}
 ---
 apiVersion: v1

--- a/charts/kguardian/templates/broker/networkpolicy.yaml
+++ b/charts/kguardian/templates/broker/networkpolicy.yaml
@@ -39,7 +39,7 @@ spec:
         - podSelector:
             matchLabels:
               app.kubernetes.io/name: {{ .Values.mcpServer.service.name }}
-        {{- if .Values.advisor.enabled }}
+        {{- if include "kguardian.advisorEnabled" . }}
         # advisor service — reads traffic/syscalls to synthesise policies.
         - podSelector:
             matchLabels:

--- a/charts/kguardian/templates/frontend/deployment.yaml
+++ b/charts/kguardian/templates/frontend/deployment.yaml
@@ -47,7 +47,7 @@ spec:
           env:
             - name: VITE_API_URL
               value: "http://{{ .Values.broker.service.name }}.{{ include "kguardian.namespace" . }}.svc.cluster.local:{{ .Values.broker.container.port }}"
-            {{- if .Values.llmBridge.enabled }}
+            {{- if include "kguardian.llmBridgeEnabled" . }}
             - name: VITE_LLM_BRIDGE_URL
               value: "http://{{ .Values.llmBridge.service.name }}.{{ include "kguardian.namespace" . }}.svc.cluster.local:{{ .Values.llmBridge.service.port }}"
             {{- end }}

--- a/charts/kguardian/templates/llm-bridge/deployment.yaml
+++ b/charts/kguardian/templates/llm-bridge/deployment.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.llmBridge.enabled }}
+{{- if include "kguardian.llmBridgeEnabled" . }}
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/charts/kguardian/templates/llm-bridge/pdb.yaml
+++ b/charts/kguardian/templates/llm-bridge/pdb.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.llmBridge.enabled .Values.llmBridge.podDisruptionBudget.enabled }}
+{{- if and (include "kguardian.llmBridgeEnabled" .) .Values.llmBridge.podDisruptionBudget.enabled }}
 {{- /* PDB-singleton guardrail. See evaluator/pdb.yaml (b964c58d). */ -}}
 {{- $pdb := .Values.llmBridge.podDisruptionBudget -}}
 {{- $replicas := int .Values.llmBridge.replicaCount -}}

--- a/charts/kguardian/templates/llm-bridge/service.yaml
+++ b/charts/kguardian/templates/llm-bridge/service.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.llmBridge.enabled }}
+{{- if include "kguardian.llmBridgeEnabled" . }}
 ---
 apiVersion: v1
 kind: Service

--- a/charts/kguardian/templates/llm-bridge/serviceaccount.yaml
+++ b/charts/kguardian/templates/llm-bridge/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.llmBridge.serviceAccount.create -}}
+{{- if and (include "kguardian.llmBridgeEnabled" .) .Values.llmBridge.serviceAccount.create -}}
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/charts/kguardian/templates/llm-bridge/servicemonitor.yaml
+++ b/charts/kguardian/templates/llm-bridge/servicemonitor.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.llmBridge.enabled .Values.llmBridge.metrics.serviceMonitor.enabled }}
+{{- if and (include "kguardian.llmBridgeEnabled" .) .Values.llmBridge.metrics.serviceMonitor.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:

--- a/charts/kguardian/templates/mcp-server/deployment.yaml
+++ b/charts/kguardian/templates/mcp-server/deployment.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.mcpServer.enabled }}
+{{- if include "kguardian.mcpServerEnabled" . }}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -51,7 +51,7 @@ spec:
             {{- include "kguardian.brokerAuthEnv" . | nindent 12 }}
             - name: PORT
               value: "{{ .Values.mcpServer.container.port }}"
-            {{- if .Values.advisor.enabled }}
+            {{- if include "kguardian.advisorEnabled" . }}
             # Policy/seccomp generation tools proxy to the advisor service.
             - name: ADVISOR_URL
               value: "http://{{ .Values.advisor.service.name }}.{{ include "kguardian.namespace" . }}.svc.cluster.local:{{ .Values.advisor.service.port }}"

--- a/charts/kguardian/templates/mcp-server/pdb.yaml
+++ b/charts/kguardian/templates/mcp-server/pdb.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.mcpServer.enabled .Values.mcpServer.podDisruptionBudget.enabled }}
+{{- if and (include "kguardian.mcpServerEnabled" .) .Values.mcpServer.podDisruptionBudget.enabled }}
 {{- /* PDB-singleton guardrail. See evaluator/pdb.yaml (b964c58d). */ -}}
 {{- $pdb := .Values.mcpServer.podDisruptionBudget -}}
 {{- $replicas := int .Values.mcpServer.replicaCount -}}

--- a/charts/kguardian/templates/mcp-server/service.yaml
+++ b/charts/kguardian/templates/mcp-server/service.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.mcpServer.enabled }}
+{{- if include "kguardian.mcpServerEnabled" . }}
 ---
 apiVersion: v1
 kind: Service

--- a/charts/kguardian/templates/mcp-server/serviceaccount.yaml
+++ b/charts/kguardian/templates/mcp-server/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.mcpServer.enabled }}
+{{- if include "kguardian.mcpServerEnabled" . }}
 {{- if .Values.mcpServer.serviceAccount.create -}}
 ---
 apiVersion: v1

--- a/charts/kguardian/templates/mcp-server/servicemonitor.yaml
+++ b/charts/kguardian/templates/mcp-server/servicemonitor.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.mcpServer.enabled .Values.mcpServer.metrics.serviceMonitor.enabled }}
+{{- if and (include "kguardian.mcpServerEnabled" .) .Values.mcpServer.metrics.serviceMonitor.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:

--- a/charts/kguardian/values.yaml
+++ b/charts/kguardian/values.yaml
@@ -780,8 +780,17 @@ frontend:
     #  - secretName: kguardian-tls
     #    hosts:
     #      - kguardian.example.com
+# AI assistant umbrella switch. The assistant needs three components working
+# together (llm-bridge, mcp-server, advisor); this turns them all on with one
+# value so the path can never be half-deployed. Per-component `enabled` flags
+# below still work for enabling components individually. You must also create
+# an LLM provider secret — see llmBridge.secrets.
+ai:
+  # -- Enable the full AI assistant path (llm-bridge + mcp-server + advisor) with one toggle
+  enabled: false
+
 llmBridge:
-  # -- Enable LLM Bridge service for AI assistant
+  # -- Enable LLM Bridge service for AI assistant (or use ai.enabled to turn on the whole path)
   enabled: false
   # -- Number of llm-bridge replicas to deploy
   replicaCount: 2


### PR DESCRIPTION
WS-D of SIMPLIFICATION-GOAL.md (#1163).

- `ai.enabled=true` renders llm-bridge + mcp-server + advisor together (verified: 5 workloads default / 8 with the toggle).
- Legacy `llmBridge.enabled` / `mcpServer.enabled` / `advisor.enabled` render identically to before (verified per-flag).
- Fixes an orphan llm-bridge ServiceAccount rendered on every default install.
- NOTES.txt now states assistant status and the one-line enable command.

https://claude.ai/code/session_019iDb3ymyUBM3NZPRd5M39U