### PR TITLE
refactor(broker): remove dead single-row POST /pod/traffic endpoint

### DIFF
--- a/broker/src/add.rs
+++ b/broker/src/add.rs
@@ -153,58 +153,6 @@ fn create_pod_traffic_batch(
     Ok(events_to_insert)
 }
 
-#[post("/pod/traffic")]
-pub async fn add_pods(
-    pool: web::Data<DbPool>,
-    audit: web::Data<AuditClient>,
-    form: web::Json<PodTraffic>,
-) -> Result<HttpResponse, Error> {
-    let pool_for_insert = pool.clone();
-    let inserted = web::block(move || {
-        let mut conn = pool_for_insert.get()?;
-        create_pod_traffic(&mut conn, form)
-    })
-    .await?
-    .map_err(actix_web::error::ErrorInternalServerError)?;
-
-    // Enqueue ONLY new events for best-effort audit eval (deduped flows are
-    // skipped). try_enqueue is non-blocking and sheds load when the evaluator
-    // is backed up — same bounded-queue path as the batch endpoint.
-    if audit.enabled() {
-        if let Some(event) = inserted.clone() {
-            audit.try_enqueue(event);
-        }
-    }
-
-    // Wire format preserved: echo the input form back to the
-    // controller (it ignores the body but a behavior change here
-    // would be observable in API contract tests). When the row was a
-    // duplicate, the input is echoed via the None-path fallback.
-    Ok(HttpResponse::Ok().json(inserted))
-}
-
-fn create_pod_traffic(
-    conn: &mut PgConnection,
-    w: web::Json<PodTraffic>,
-) -> Result<Option<PodTraffic>, DbError> {
-    use schema::pod_traffic::dsl::*;
-    debug!("storing pod_traffic event {:?} (uuid)", w.uuid);
-    if w.get_row(conn)?.is_none() {
-        // debug not info — pod_traffic inserts happen at the rate of
-        // new flows in the cluster (potentially thousands per minute
-        // on a busy cluster). Reserving INFO for the rare events
-        // operators care about (startup, shutdown, config, errors)
-        // keeps the default-info log scannable.
-        debug!("Insert pod {:?}, in pod_traffic table", w.uuid);
-        diesel::insert_into(pod_traffic).values(&*w).execute(conn)?;
-        debug!("Success: pod {:?} inserted in pod_traffic table", w.uuid);
-        Ok(Some(w.0))
-    } else {
-        debug!("Data already exists");
-        Ok(None)
-    }
-}
-
 impl PodTraffic {
     pub fn get_row(&self, conn: &mut PgConnection) -> Result<Option<PodTraffic>, DbError> {
         use schema::pod_traffic::dsl::*;
@@ -313,7 +261,7 @@ pub fn upsert_pod_details(
     // debug not info — every controller pod-watcher event upserts here
     // (creates, updates, status transitions). On a cluster with rolling
     // deployments this fires at high rate; same INFO-reservation
-    // discipline as create_pod_traffic above.
+    // discipline as create_pod_traffic_batch.
     debug!("Success: pod {:?} inserted in pod_details table", w.pod_ip);
     Ok(w.0)
 }

--- a/broker/src/lib.rs
+++ b/broker/src/lib.rs
@@ -6,9 +6,7 @@ mod retention;
 mod telemetry;
 mod types;
 mod version_check;
-pub use add::{
-    add_pod_details, add_pods, add_pods_batch, add_pods_syscalls, add_svc_details, mark_pod_dead,
-};
+pub use add::{add_pod_details, add_pods_batch, add_pods_syscalls, add_svc_details, mark_pod_dead};
 pub use audit::AuditClient;
 pub use error::*;
 pub use retention::spawn as spawn_retention;

--- a/broker/src/main.rs
+++ b/broker/src/main.rs
@@ -4,11 +4,11 @@ use actix_cors::Cors;
 use actix_web::middleware::from_fn;
 use actix_web::{get, web, App, HttpResponse, HttpServer};
 use api::{
-    add_pod_details, add_pods, add_pods_batch, add_pods_syscalls, add_svc_details,
-    establish_connection, get_audit_verdicts, get_pod_by_ip, get_pod_by_name, get_pod_details,
-    get_pod_syscall_name, get_pod_traffic, get_pod_traffic_name, get_pods_by_node, get_svc_by_ip,
-    get_svc_details, get_version, mark_pod_dead, set_statement_timeout, spawn_retention,
-    spawn_version_check, AuditClient, StatementTimeoutCustomizer, VersionCheckState,
+    add_pod_details, add_pods_batch, add_pods_syscalls, add_svc_details, establish_connection,
+    get_audit_verdicts, get_pod_by_ip, get_pod_by_name, get_pod_details, get_pod_syscall_name,
+    get_pod_traffic, get_pod_traffic_name, get_pods_by_node, get_svc_by_ip, get_svc_details,
+    get_version, mark_pod_dead, set_statement_timeout, spawn_retention, spawn_version_check,
+    AuditClient, StatementTimeoutCustomizer, VersionCheckState,
 };
 
 use diesel::r2d2;
@@ -282,7 +282,6 @@ async fn main() -> Result<(), std::io::Error> {
             .app_data(web::Data::new(audit_client.clone()))
             .app_data(web::Data::new(auth_config.clone()))
             .app_data(version_state.clone())
-            .service(add_pods)
             .service(add_pods_batch)
             .service(add_pod_details)
             .service(add_pods_syscalls)


### PR DESCRIPTION
WS-A of SIMPLIFICATION-GOAL.md (#1163). Endpoint has no caller in any component (controller only ever used the batch path). Handler + orphan helper + registration removed; batch path and its dedup untouched. cargo fmt/clippy/test green locally (134 tests).

https://claude.ai/code/session_019iDb3ymyUBM3NZPRd5M39U