### PR TITLE
refactor(llm-bridge): retire stale broker naming and dead conversationId

### DIFF
--- a/llm-bridge/.env.example
+++ b/llm-bridge/.env.example
@@ -4,12 +4,6 @@
 PORT=8080
 NODE_ENV=development
 
-# Broker API URL
-BROKER_URL=http://broker.kguardian.svc.cluster.local:9090
-
-# For local development
-# BROKER_URL=http://localhost:9090
-
 # LLM Provider API Keys (configure at least one)
 
 # OpenAI

--- a/llm-bridge/src/availableProviders.test.ts
+++ b/llm-bridge/src/availableProviders.test.ts
@@ -89,7 +89,7 @@ test("availableProvidersFromEnv: ignores unrelated env vars", () => {
   const got = availableProvidersFromEnv({
     PATH: "/usr/bin",
     HOME: "/home/foo",
-    BROKER_URL: "http://x:9090",
+    MCP_SERVER_URL: "http://x:8081",
   });
   assert.deepEqual(got, []);
 });

--- a/llm-bridge/src/index.stream.test.ts
+++ b/llm-bridge/src/index.stream.test.ts
@@ -4,7 +4,7 @@ import http from "node:http";
 import type { AddressInfo } from "node:net";
 
 import { app } from "./index.js";
-import { BrokerClient } from "./brokerClient.js";
+import { McpClient } from "./mcpClient.js";
 
 // Integration test for the SSE /api/chat/stream route: boots the real Express
 // app, points the Anthropic SDK at a mock streaming server, and asserts the
@@ -56,7 +56,7 @@ before(async () => {
   delete process.env.GOOGLE_API_KEY;
   delete process.env.GITHUB_TOKEN;
 
-  (BrokerClient as unknown as { getToolsCached: () => Promise<unknown[]> }).getToolsCached =
+  (McpClient as unknown as { getToolsCached: () => Promise<unknown[]> }).getToolsCached =
     async () => [
       { name: "get_cluster_pods", description: "List pods.", parameters: { type: "object", properties: {}, required: [] } },
     ];

--- a/llm-bridge/src/index.ts
+++ b/llm-bridge/src/index.ts
@@ -6,7 +6,7 @@ import rateLimit from "express-rate-limit";
 import dotenv from "dotenv";
 import { ZodError } from "zod";
 import { ChatRequestSchema, LLMProvider, type ErrorResponse } from "./types/index.js";
-import { BrokerClient } from "./brokerClient.js";
+import { McpClient } from "./mcpClient.js";
 import { log } from "./logger.js";
 import { callOpenAI } from "./providers/openai.js";
 import { callAnthropic, streamAnthropic, type StreamEvent } from "./providers/anthropic.js";
@@ -34,11 +34,11 @@ const allowedOrigin = process.env.ALLOWED_ORIGIN?.trim() || '*';
 app.use(cors({ origin: allowedOrigin }));
 app.use(express.json({ limit: '100kb' }));
 
-// Initialize broker client. Note: the class is named "BrokerClient"
+// Initialize broker client. Note: the class is named "McpClient"
 // for historical reasons; today all tool calls route through the MCP
-// server. The MCP server URL is read inside BrokerClient from
+// server. The MCP server URL is read inside McpClient from
 // MCP_SERVER_URL or its hardcoded default — no constructor arg needed.
-const brokerClient = new BrokerClient();
+const mcpClient = new McpClient();
 
 /**
  * Compute available providers from a key-value env map. Pure — takes
@@ -108,13 +108,13 @@ function resolveProvider(chatRequest: ChatRequest): ProviderResolution {
 function callProvider(provider: LLMProvider, chatRequest: ChatRequest): Promise<ChatResponse> {
   switch (provider) {
     case LLMProvider.OPENAI:
-      return callOpenAI(chatRequest, brokerClient);
+      return callOpenAI(chatRequest, mcpClient);
     case LLMProvider.ANTHROPIC:
-      return callAnthropic(chatRequest, brokerClient);
+      return callAnthropic(chatRequest, mcpClient);
     case LLMProvider.GEMINI:
-      return callGemini(chatRequest, brokerClient);
+      return callGemini(chatRequest, mcpClient);
     case LLMProvider.COPILOT:
-      return callCopilot(chatRequest, brokerClient);
+      return callCopilot(chatRequest, mcpClient);
     default:
       return Promise.reject(new Error(`Unknown provider: ${provider}`));
   }
@@ -251,13 +251,13 @@ app.post("/api/chat/stream", chatLimiter, async (req: Request, res: Response) =>
 
   try {
     if (provider === LLMProvider.ANTHROPIC) {
-      await streamAnthropic(chatRequest, brokerClient, emit, abort.signal);
+      await streamAnthropic(chatRequest, mcpClient, emit, abort.signal);
     } else {
       // Providers without a native streaming path: run to completion and emit
       // the answer as a single text chunk plus the terminal done event.
       const response = await callProvider(provider, chatRequest);
       emit({ type: "text", delta: response.message });
-      emit({ type: "done", model: response.model, conversationId: response.conversationId });
+      emit({ type: "done", model: response.model });
     }
   } catch (error) {
     // Map upstream rate-limit / overload to a clear, actionable message rather
@@ -305,7 +305,7 @@ function startServer() {
 
   // Graceful shutdown
   const shutdown = () => {
-    brokerClient.close();
+    mcpClient.close();
     server.close();
     process.exit(0);
   };

--- a/llm-bridge/src/logger.test.ts
+++ b/llm-bridge/src/logger.test.ts
@@ -68,7 +68,7 @@ test("shouldEmit at error suppresses everything below", () => {
 
 test("shouldEmit at debug keeps info+ but drops trace", () => {
   // LOG_LEVEL=debug is the typical "I'm debugging" setting —
-  // unlocks the per-tool-call hot-path traces from brokerClient.ts
+  // unlocks the per-tool-call hot-path traces from mcpClient.ts
   // (commit 3528d437) but still drops the trace level (currently
   // unused but reserved for future ultra-verbose hooks).
   assert.ok(!shouldEmit("trace", "debug"));

--- a/llm-bridge/src/mcpClient.test.ts
+++ b/llm-bridge/src/mcpClient.test.ts
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { BrokerClient, resolveMcpUrl } from "./brokerClient.js";
+import { McpClient, resolveMcpUrl } from "./mcpClient.js";
 
 const DEFAULT_URL = "http://kguardian-mcp-server.kguardian.svc.cluster.local:8081";
 
@@ -30,7 +30,7 @@ test("resolveMcpUrl treats whitespace-only as empty (falls through)", () => {
   assert.equal(resolveMcpUrl("", ""), DEFAULT_URL);
 });
 
-// BrokerClient.parseContext is the gate that turns the LLM's free-form
+// McpClient.parseContext is the gate that turns the LLM's free-form
 // context blob into a structured filter. A regression here either:
 //   - drops a valid namespace filter (LLM gets cluster-wide data when
 //     the user asked for a single ns), or
@@ -39,27 +39,27 @@ test("resolveMcpUrl treats whitespace-only as empty (falls through)", () => {
 // Use Node 22's built-in test runner (no vitest dep).
 
 test("parseContext returns undefined for empty/missing input", () => {
-  assert.equal(BrokerClient.parseContext(undefined), undefined);
-  assert.equal(BrokerClient.parseContext(""), undefined);
+  assert.equal(McpClient.parseContext(undefined), undefined);
+  assert.equal(McpClient.parseContext(""), undefined);
 });
 
 test("parseContext returns undefined for invalid JSON (no throw)", () => {
-  assert.equal(BrokerClient.parseContext("not-json"), undefined);
-  assert.equal(BrokerClient.parseContext("{open"), undefined);
+  assert.equal(McpClient.parseContext("not-json"), undefined);
+  assert.equal(McpClient.parseContext("{open"), undefined);
 });
 
 test("parseContext extracts namespace string", () => {
-  const got = BrokerClient.parseContext('{"namespace":"prod"}');
+  const got = McpClient.parseContext('{"namespace":"prod"}');
   assert.deepEqual(got, { namespace: "prod", podNames: undefined });
 });
 
 test("parseContext extracts podNames array", () => {
-  const got = BrokerClient.parseContext('{"podNames":["a","b"]}');
+  const got = McpClient.parseContext('{"podNames":["a","b"]}');
   assert.deepEqual(got, { namespace: undefined, podNames: ["a", "b"] });
 });
 
 test("parseContext extracts both fields when present", () => {
-  const got = BrokerClient.parseContext('{"namespace":"prod","podNames":["web-1"]}');
+  const got = McpClient.parseContext('{"namespace":"prod","podNames":["web-1"]}');
   assert.deepEqual(got, { namespace: "prod", podNames: ["web-1"] });
 });
 
@@ -67,22 +67,22 @@ test("parseContext rejects non-string namespace", () => {
   // If the LLM hallucinates {"namespace": 42} we must reject the
   // numeric — passing it downstream would either crash a string
   // comparison or be coerced into a misleading match.
-  const got = BrokerClient.parseContext('{"namespace":42}');
+  const got = McpClient.parseContext('{"namespace":42}');
   assert.equal(got?.namespace, undefined);
 });
 
 test("parseContext rejects non-array podNames", () => {
-  const got = BrokerClient.parseContext('{"podNames":"web-1"}');
+  const got = McpClient.parseContext('{"podNames":"web-1"}');
   assert.equal(got?.podNames, undefined);
 });
 
 test("parseContext ignores unrelated extra fields", () => {
-  const got = BrokerClient.parseContext('{"namespace":"prod","unknown":"value"}');
+  const got = McpClient.parseContext('{"namespace":"prod","unknown":"value"}');
   assert.deepEqual(got, { namespace: "prod", podNames: undefined });
 });
 
 test("parseContext handles pre-empty arrays", () => {
-  const got = BrokerClient.parseContext('{"podNames":[]}');
+  const got = McpClient.parseContext('{"podNames":[]}');
   assert.deepEqual(got, { namespace: undefined, podNames: [] });
 });
 
@@ -91,7 +91,7 @@ test("parseContext handles pre-empty arrays", () => {
 // the request fail clearly, never silently answer the user with zero tools.
 
 test("getToolsCached throws on an empty tool set (no static fallback)", async () => {
-  const C = BrokerClient as unknown as {
+  const C = McpClient as unknown as {
     getToolDefinitionsFromMCP: () => Promise<unknown[]>;
     toolDefsCache: unknown;
   };
@@ -99,7 +99,7 @@ test("getToolsCached throws on an empty tool set (no static fallback)", async ()
   C.toolDefsCache = null;
   C.getToolDefinitionsFromMCP = async () => [];
   try {
-    await assert.rejects(() => BrokerClient.getToolsCached(), /no tools/);
+    await assert.rejects(() => McpClient.getToolsCached(), /no tools/);
   } finally {
     C.getToolDefinitionsFromMCP = orig;
     C.toolDefsCache = null;
@@ -107,7 +107,7 @@ test("getToolsCached throws on an empty tool set (no static fallback)", async ()
 });
 
 test("getToolsCached propagates a discovery failure (no static fallback)", async () => {
-  const C = BrokerClient as unknown as {
+  const C = McpClient as unknown as {
     getToolDefinitionsFromMCP: () => Promise<unknown[]>;
     toolDefsCache: unknown;
   };
@@ -117,7 +117,7 @@ test("getToolsCached propagates a discovery failure (no static fallback)", async
     throw new Error("MCP server unreachable");
   };
   try {
-    await assert.rejects(() => BrokerClient.getToolsCached(), /MCP server unreachable/);
+    await assert.rejects(() => McpClient.getToolsCached(), /MCP server unreachable/);
   } finally {
     C.getToolDefinitionsFromMCP = orig;
     C.toolDefsCache = null;

--- a/llm-bridge/src/mcpClient.ts
+++ b/llm-bridge/src/mcpClient.ts
@@ -17,11 +17,11 @@ export interface ParsedContext {
  * check and surface later as a cryptic `TypeError: Invalid URL` from
  * `new URL(...)` inside the transport — far from the env-var read
  * site. Same defense-in-depth class as the mcp-server's
- * NewBrokerClient TrimSpace and the broker's AuditClient::from_env
+ * NewMcpClient TrimSpace and the broker's AuditClient::from_env
  * trim.
  *
  * Exported as a pure helper so the resolution contract can be unit-
- * tested without instantiating BrokerClient (which would also try to
+ * tested without instantiating McpClient (which would also try to
  * import MCP transports just to test a string resolution).
  */
 export function resolveMcpUrl(arg?: string, envUrl?: string): string {
@@ -30,7 +30,7 @@ export function resolveMcpUrl(arg?: string, envUrl?: string): string {
   return argTrimmed || envTrimmed || "http://kguardian-mcp-server.kguardian.svc.cluster.local:8081";
 }
 
-export class BrokerClient {
+export class McpClient {
   private mcpClient: Client | null = null;
   private mcpUrl: string;
   private mcpInitialized: boolean = false;
@@ -38,7 +38,7 @@ export class BrokerClient {
   private static toolDefsCache: any[] | null = null;
 
   /**
-   * The class is named BrokerClient for historical reasons — before
+   * The class is named McpClient for historical reasons — before
    * the MCP refactor it talked directly to the broker. Today all
    * tool calls route through the MCP server (this.mcpUrl), and the
    * broker is reached via the MCP server's own broker client. So
@@ -220,7 +220,7 @@ export class BrokerClient {
    * This fetches the actual tools from the MCP server dynamically
    */
   static async getToolDefinitionsFromMCP(mcpUrl?: string): Promise<any[]> {
-    const client = new BrokerClient(mcpUrl);
+    const client = new McpClient(mcpUrl);
     try {
       const tools = await client.getAvailableTools();
 
@@ -249,14 +249,14 @@ export class BrokerClient {
    * transient MCP blip is retried on the next request.
    */
   static async getToolsCached(): Promise<any[]> {
-    if (BrokerClient.toolDefsCache) return BrokerClient.toolDefsCache;
-    const tools = await BrokerClient.getToolDefinitionsFromMCP();
+    if (McpClient.toolDefsCache) return McpClient.toolDefsCache;
+    const tools = await McpClient.getToolDefinitionsFromMCP();
     if (!tools.length) {
       throw new Error(
         "MCP server returned no tools — the assistant cannot answer without its data tools. Check that the MCP server is reachable (MCP_SERVER_URL).",
       );
     }
-    BrokerClient.toolDefsCache = tools;
+    McpClient.toolDefsCache = tools;
     return tools;
   }
 

--- a/llm-bridge/src/providers/anthropic.stream.test.ts
+++ b/llm-bridge/src/providers/anthropic.stream.test.ts
@@ -4,7 +4,7 @@ import http from "node:http";
 import type { AddressInfo } from "node:net";
 
 import { streamAnthropic, type StreamEvent } from "./anthropic.js";
-import { BrokerClient } from "../brokerClient.js";
+import { McpClient } from "../mcpClient.js";
 import type { ChatRequest } from "../types/index.js";
 
 // Mock of the Anthropic Messages API streaming endpoint. Each request is
@@ -75,7 +75,7 @@ before(async () => {
 
   process.env.ANTHROPIC_API_KEY = "test-key";
   process.env.ANTHROPIC_BASE_URL = `http://127.0.0.1:${port}`;
-  (BrokerClient as unknown as { getToolsCached: () => Promise<unknown[]> }).getToolsCached =
+  (McpClient as unknown as { getToolsCached: () => Promise<unknown[]> }).getToolsCached =
     async () => [
       { name: "get_cluster_pods", description: "List pods.", parameters: { type: "object", properties: {}, required: [] } },
     ];
@@ -89,18 +89,18 @@ beforeEach(() => {
   responseQueue = [];
 });
 
-function stubBroker(calls: string[]): BrokerClient {
+function stubBroker(calls: string[]): McpClient {
   return {
     executeTool: async (toolCall: { name: string }) => {
       calls.push(toolCall.name);
       return { data: { ok: true } };
     },
-  } as unknown as BrokerClient;
+  } as unknown as McpClient;
 }
 
 const baseRequest: ChatRequest = { message: "hello" } as ChatRequest;
 
-async function collect(req: ChatRequest, broker: BrokerClient): Promise<StreamEvent[]> {
+async function collect(req: ChatRequest, broker: McpClient): Promise<StreamEvent[]> {
   const events: StreamEvent[] = [];
   await streamAnthropic(req, broker, (e) => events.push(e));
   return events;

--- a/llm-bridge/src/providers/anthropic.test.ts
+++ b/llm-bridge/src/providers/anthropic.test.ts
@@ -4,7 +4,7 @@ import http from "node:http";
 import type { AddressInfo } from "node:net";
 
 import { callAnthropic } from "./anthropic.js";
-import { BrokerClient } from "../brokerClient.js";
+import { McpClient } from "../mcpClient.js";
 import type { ChatRequest } from "../types/index.js";
 
 // A scripted mock of the Anthropic Messages API. Each request pops the next
@@ -58,7 +58,7 @@ before(async () => {
   process.env.ANTHROPIC_BASE_URL = baseURL;
   // Stub the MCP-backed tool discovery so the loop has a deterministic,
   // network-free tool set.
-  (BrokerClient as unknown as { getToolsCached: () => Promise<unknown[]> }).getToolsCached =
+  (McpClient as unknown as { getToolsCached: () => Promise<unknown[]> }).getToolsCached =
     async () => [
       {
         name: "get_cluster_pods",
@@ -77,13 +77,13 @@ beforeEach(() => {
   capturedRequests = [];
 });
 
-function stubBroker(calls: string[]): BrokerClient {
+function stubBroker(calls: string[]): McpClient {
   return {
     executeTool: async (toolCall: { name: string }) => {
       calls.push(toolCall.name);
       return { data: { ok: true, tool: toolCall.name } };
     },
-  } as unknown as BrokerClient;
+  } as unknown as McpClient;
 }
 
 const baseRequest: ChatRequest = { message: "hello", provider: undefined } as ChatRequest;

--- a/llm-bridge/src/providers/anthropic.ts
+++ b/llm-bridge/src/providers/anthropic.ts
@@ -200,7 +200,7 @@ export async function callAnthropic(
 
     const toolUses = toolUsesOf(message);
     if (toolUses.length === 0) {
-      return finalize(message, request);
+      return finalize(message);
     }
     await runToolRound(message, toolUses, mcpClient, messages);
   }
@@ -213,7 +213,7 @@ export async function callAnthropic(
   } catch (error) {
     throw toCleanError(error);
   }
-  return finalize(finalMessage, request);
+  return finalize(finalMessage);
 }
 
 // ---------------------------------------------------------------------------
@@ -315,7 +315,7 @@ export async function streamAnthropic(
 // ---------------------------------------------------------------------------
 
 /** Extract the text answer from a completed message into the wire contract. */
-function finalize(message: Anthropic.Message, request: ChatRequest): ChatResponse {
+function finalize(message: Anthropic.Message): ChatResponse {
   return {
     message: textOf(message) || fallbackFor(message),
     provider: LLMProvider.ANTHROPIC,

--- a/llm-bridge/src/providers/anthropic.ts
+++ b/llm-bridge/src/providers/anthropic.ts
@@ -1,7 +1,7 @@
 import Anthropic from "@anthropic-ai/sdk";
 import type { ChatRequest, ChatResponse } from "../types/index.js";
 import { LLMProvider } from "../types/index.js";
-import { BrokerClient } from "../brokerClient.js";
+import { McpClient } from "../mcpClient.js";
 import { log } from "../logger.js";
 import { serializeToolResult } from "./truncate.js";
 
@@ -29,7 +29,7 @@ export type StreamEvent =
   | { type: "thinking"; delta: string }
   | { type: "tool_use"; name: string; id: string }
   | { type: "tool_result"; name: string; ok: boolean }
-  | { type: "done"; model: string; conversationId?: string }
+  | { type: "done"; model: string }
   | { type: "error"; error: string };
 
 export type Emit = (event: StreamEvent) => void;
@@ -59,13 +59,13 @@ function requireApiKey(): string {
  * cache instead of reprocessing it.
  */
 function buildSystem(request: ChatRequest): Anthropic.TextBlockParam[] {
-  const context = BrokerClient.parseContext(request.context);
-  const systemPrompt = BrokerClient.getSystemPrompt(context);
+  const context = McpClient.parseContext(request.context);
+  const systemPrompt = McpClient.getSystemPrompt(context);
   return [{ type: "text", text: systemPrompt, cache_control: { type: "ephemeral" } }];
 }
 
 async function buildTools(): Promise<Anthropic.Tool[]> {
-  const toolDefs = await BrokerClient.getToolsCached();
+  const toolDefs = await McpClient.getToolsCached();
   return toolDefs.map((tool) => ({
     name: tool.name,
     description: tool.description,
@@ -129,7 +129,7 @@ function fallbackFor(message: Anthropic.Message): string {
 async function runToolRound(
   message: Anthropic.Message,
   toolUses: Anthropic.ToolUseBlock[],
-  brokerClient: BrokerClient,
+  mcpClient: McpClient,
   messages: Anthropic.MessageParam[],
   emit?: Emit,
 ): Promise<void> {
@@ -143,7 +143,7 @@ async function runToolRound(
 
   const toolResults: Anthropic.ToolResultBlockParam[] = await Promise.all(
     toolUses.map(async (toolUse) => {
-      const result = await brokerClient.executeTool({
+      const result = await mcpClient.executeTool({
         name: toolUse.name,
         arguments: toolUse.input as Record<string, unknown>,
       });
@@ -178,7 +178,7 @@ async function runToolRound(
  */
 export async function callAnthropic(
   request: ChatRequest,
-  brokerClient: BrokerClient,
+  mcpClient: McpClient,
 ): Promise<ChatResponse> {
   const apiKey = requireApiKey();
   // The SDK reads ANTHROPIC_BASE_URL from the environment when baseURL is not
@@ -202,7 +202,7 @@ export async function callAnthropic(
     if (toolUses.length === 0) {
       return finalize(message, request);
     }
-    await runToolRound(message, toolUses, brokerClient, messages);
+    await runToolRound(message, toolUses, mcpClient, messages);
   }
 
   // Max rounds reached — one final call without tools to force a textual
@@ -228,7 +228,7 @@ export async function callAnthropic(
  */
 export async function streamAnthropic(
   request: ChatRequest,
-  brokerClient: BrokerClient,
+  mcpClient: McpClient,
   emit: Emit,
   signal?: AbortSignal,
 ): Promise<void> {
@@ -289,10 +289,10 @@ export async function streamAnthropic(
       if (!textOf(message)) {
         emit({ type: "text", delta: fallbackFor(message) });
       }
-      emit({ type: "done", model: message.model, conversationId: request.conversationId });
+      emit({ type: "done", model: message.model });
       return;
     }
-    await runToolRound(message, toolUses, brokerClient, messages, emit);
+    await runToolRound(message, toolUses, mcpClient, messages, emit);
   }
 
   // Max rounds reached — final pass without tools.
@@ -307,7 +307,7 @@ export async function streamAnthropic(
   if (!textOf(finalMessage)) {
     emit({ type: "text", delta: fallbackFor(finalMessage) });
   }
-  emit({ type: "done", model: finalMessage.model, conversationId: request.conversationId });
+  emit({ type: "done", model: finalMessage.model });
 }
 
 // ---------------------------------------------------------------------------
@@ -320,7 +320,6 @@ function finalize(message: Anthropic.Message, request: ChatRequest): ChatRespons
     message: textOf(message) || fallbackFor(message),
     provider: LLMProvider.ANTHROPIC,
     model: message.model,
-    conversationId: request.conversationId,
   };
 }
 

--- a/llm-bridge/src/providers/copilot.ts
+++ b/llm-bridge/src/providers/copilot.ts
@@ -1,7 +1,7 @@
 import axios from "axios";
 import type { ChatRequest, ChatResponse } from "../types/index.js";
 import { LLMProvider } from "../types/index.js";
-import { BrokerClient } from "../brokerClient.js";
+import { McpClient } from "../mcpClient.js";
 import { log } from "../logger.js";
 import { serializeToolResult } from "./truncate.js";
 
@@ -18,7 +18,7 @@ const MAX_TOOL_ROUNDS = 10;
 // GitHub Copilot uses OpenAI-compatible API
 export async function callCopilot(
   request: ChatRequest,
-  brokerClient: BrokerClient
+  mcpClient: McpClient
 ): Promise<ChatResponse> {
   // Trim before empty-check; whitespace-only counts as not-configured.
   const apiKey = process.env.GITHUB_TOKEN?.trim();
@@ -27,8 +27,8 @@ export async function callCopilot(
   }
 
   const model = request.model || "gpt-4o";
-  const context = BrokerClient.parseContext(request.context);
-  const systemPrompt = BrokerClient.getSystemPrompt(context);
+  const context = McpClient.parseContext(request.context);
+  const systemPrompt = McpClient.getSystemPrompt(context);
 
   // Build messages with history
   const messages: CopilotMessage[] = [
@@ -47,7 +47,7 @@ export async function callCopilot(
   messages.push({ role: "user", content: request.message });
 
   // Build tools from cached MCP definitions (OpenAI format)
-  const toolDefs = await BrokerClient.getToolsCached();
+  const toolDefs = await McpClient.getToolsCached();
   const tools = toolDefs.map((tool) => ({
     type: "function",
     function: {
@@ -85,7 +85,6 @@ export async function callCopilot(
         message: message.content,
         provider: LLMProvider.COPILOT,
         model: response.data.model,
-        conversationId: request.conversationId,
       };
     }
 
@@ -111,7 +110,7 @@ export async function callCopilot(
           };
         }
 
-        const result = await brokerClient.executeTool({
+        const result = await mcpClient.executeTool({
           name: toolCall.function.name,
           arguments: parsedArgs,
         });
@@ -139,6 +138,5 @@ export async function callCopilot(
     message: finalResponse.data.choices[0].message.content,
     provider: LLMProvider.COPILOT,
     model: finalResponse.data.model,
-    conversationId: request.conversationId,
   };
 }

--- a/llm-bridge/src/providers/gemini.ts
+++ b/llm-bridge/src/providers/gemini.ts
@@ -1,7 +1,7 @@
 import axios from "axios";
 import type { ChatRequest, ChatResponse } from "../types/index.js";
 import { LLMProvider } from "../types/index.js";
-import { BrokerClient } from "../brokerClient.js";
+import { McpClient } from "../mcpClient.js";
 import { log } from "../logger.js";
 import { serializeToolResult } from "./truncate.js";
 
@@ -9,7 +9,7 @@ const MAX_TOOL_ROUNDS = 10;
 
 export async function callGemini(
   request: ChatRequest,
-  brokerClient: BrokerClient
+  mcpClient: McpClient
 ): Promise<ChatResponse> {
   // Trim before empty-check; whitespace-only counts as not-configured.
   const apiKey = process.env.GOOGLE_API_KEY?.trim();
@@ -18,11 +18,11 @@ export async function callGemini(
   }
 
   const model = request.model || "gemini-2.0-flash-exp";
-  const context = BrokerClient.parseContext(request.context);
-  const systemPrompt = BrokerClient.getSystemPrompt(context);
+  const context = McpClient.parseContext(request.context);
+  const systemPrompt = McpClient.getSystemPrompt(context);
 
   // Build function declarations from cached MCP definitions
-  const toolDefs = await BrokerClient.getToolsCached();
+  const toolDefs = await McpClient.getToolsCached();
   const functionDeclarations = toolDefs.map((tool) => ({
     name: tool.name,
     description: tool.description,
@@ -88,7 +88,6 @@ export async function callGemini(
         message: textPart?.text || "No response from Gemini",
         provider: LLMProvider.GEMINI,
         model,
-        conversationId: request.conversationId,
       };
     }
 
@@ -101,7 +100,7 @@ export async function callGemini(
     // Execute function calls and build responses
     const functionResponses = await Promise.all(
       functionCalls.map(async (part: any) => {
-        const result = await brokerClient.executeTool({
+        const result = await mcpClient.executeTool({
           name: part.functionCall.name,
           arguments: part.functionCall.args,
         });
@@ -143,6 +142,5 @@ export async function callGemini(
     message: textPart?.text || "No response from Gemini",
     provider: LLMProvider.GEMINI,
     model,
-    conversationId: request.conversationId,
   };
 }

--- a/llm-bridge/src/providers/openai.ts
+++ b/llm-bridge/src/providers/openai.ts
@@ -1,7 +1,7 @@
 import axios from "axios";
 import type { ChatRequest, ChatResponse } from "../types/index.js";
 import { LLMProvider } from "../types/index.js";
-import { BrokerClient } from "../brokerClient.js";
+import { McpClient } from "../mcpClient.js";
 import { log } from "../logger.js";
 import { serializeToolResult } from "./truncate.js";
 
@@ -26,7 +26,7 @@ const MAX_TOOL_ROUNDS = 10;
 
 export async function callOpenAI(
   request: ChatRequest,
-  brokerClient: BrokerClient
+  mcpClient: McpClient
 ): Promise<ChatResponse> {
   // Trim before empty-check; whitespace-only counts as not-configured.
   // See anthropic.ts for the disable-by-whitespace rationale.
@@ -36,8 +36,8 @@ export async function callOpenAI(
   }
 
   const model = request.model || "gpt-4o";
-  const context = BrokerClient.parseContext(request.context);
-  const systemPrompt = BrokerClient.getSystemPrompt(context);
+  const context = McpClient.parseContext(request.context);
+  const systemPrompt = McpClient.getSystemPrompt(context);
 
   // Build messages with history
   const messages: OpenAIMessage[] = [
@@ -56,7 +56,7 @@ export async function callOpenAI(
   messages.push({ role: "user", content: request.message });
 
   // Build tools from cached MCP definitions
-  const toolDefs = await BrokerClient.getToolsCached();
+  const toolDefs = await McpClient.getToolsCached();
   const tools: OpenAITool[] = toolDefs.map((tool) => ({
     type: "function",
     function: {
@@ -94,7 +94,6 @@ export async function callOpenAI(
         message: message.content,
         provider: LLMProvider.OPENAI,
         model: response.data.model,
-        conversationId: request.conversationId,
       };
     }
 
@@ -120,7 +119,7 @@ export async function callOpenAI(
           };
         }
 
-        const result = await brokerClient.executeTool({
+        const result = await mcpClient.executeTool({
           name: toolCall.function.name,
           arguments: parsedArgs,
         });
@@ -148,6 +147,5 @@ export async function callOpenAI(
     message: finalResponse.data.choices[0].message.content,
     provider: LLMProvider.OPENAI,
     model: finalResponse.data.model,
-    conversationId: request.conversationId,
   };
 }

--- a/llm-bridge/src/types/index.ts
+++ b/llm-bridge/src/types/index.ts
@@ -21,7 +21,6 @@ export const ChatRequestSchema = z.object({
   message: z.string().min(1).max(50000),
   provider: z.nativeEnum(LLMProvider).optional(),
   model: z.string().optional(),
-  conversationId: z.string().optional(),
   context: z.string().max(2000).optional(),
   history: z.array(MessageSchema).max(100).optional(),
 });
@@ -32,7 +31,6 @@ export interface ChatResponse {
   message: string;
   provider: LLMProvider;
   model: string;
-  conversationId?: string;
 }
 
 export interface ErrorResponse {


### PR DESCRIPTION
WS-A of SIMPLIFICATION-GOAL.md (#1163).

- BrokerClient → McpClient (file + class + imports) — it has only ever talked to the MCP server since the tool path moved; .env.example loses the dead BROKER_URL lines.
- conversationId removed end to end: request schema, all four providers, SSE done event. It was never set by the frontend nor persisted anywhere — pure dead threading.
- The unused non-streaming /api/chat route is deliberately NOT touched here — it's entangled with the provider non-stream entry points and will go with the provider-loop consolidation.

Verified: tsc build + lint + 59 tests green.

https://claude.ai/code/session_019iDb3ymyUBM3NZPRd5M39U