### PR TITLE
test(mcp-server): G1 wire-contract snapshot gate + fix suite deadlock

### DIFF
--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -768,6 +768,31 @@ jobs:
               });
             }
 
+  # Test MCP server (go vet / go test), including the G1 tool-contract
+  # snapshot: testdata/contract goldens pin the wire-visible MCP contract
+  # (tools/list + per-tool call results) that any reimplementation of the
+  # tool set must reproduce byte-for-byte. SIMPLIFICATION-GOAL.md section 3.
+  # GOTOOLCHAIN=local + matrix >= go.mod per advisor-ci-gotchas.
+  test-mcp-server:
+    runs-on: ubuntu-latest
+    needs: detect-changes
+    if: needs.detect-changes.outputs.mcp-server == 'true'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
+        with:
+          go-version: '1.26.x'
+          cache-dependency-path: mcp-server/go.sum
+
+      - name: Vet and test (includes G1 contract snapshot)
+        working-directory: mcp-server
+        run: |
+          go vet ./...
+          go test ./... -timeout 300s
+
   # Build Evaluator
   build-evaluator:
     needs: detect-changes

--- a/mcp-server/tools/broker_client_test.go
+++ b/mcp-server/tools/broker_client_test.go
@@ -278,8 +278,17 @@ func TestBrokerClient_OversizedBodyTruncated(t *testing.T) {
 		chunk := strings.Repeat(`{"k":"v"},`, 1024)
 		written := 1
 		for written < oversized {
-			n, _ := w.Write([]byte(chunk))
+			n, err := w.Write([]byte(chunk))
 			written += n
+			if err != nil {
+				// The client stops reading at its 10 MB cap and drops the
+				// connection; from then on Write returns (0, err) forever.
+				// The old code discarded err, so written stopped advancing
+				// and this loop spun until the 600s package timeout while
+				// srv.Close() waited on the handler — the intermittent
+				// full-suite deadlock. Bail on first write error.
+				return
+			}
 		}
 	}))
 	defer srv.Close()

--- a/mcp-server/tools/contract_test.go
+++ b/mcp-server/tools/contract_test.go
@@ -1,0 +1,177 @@
+package tools
+
+// G1 tool-contract snapshot (SIMPLIFICATION-GOAL.md §3).
+//
+// Pins the wire-visible MCP contract exactly as llm-bridge sees it: an
+// in-memory MCP client connects to the real registered server and the test
+// snapshots (a) the full tools/list result — names, descriptions, input
+// schemas — and (b) a tools/call result per tool against fixture broker and
+// advisor responses.
+//
+// The goldens under testdata/contract/ are the reference ANY reimplementation
+// of this tool set must reproduce byte-for-byte (WS-B assistant merge): replay
+// backend_fixtures.json through the new implementation and the same calls must
+// yield the same results. A diff here is a contract change — never noise.
+// Regenerate deliberately with: UPDATE_GOLDEN=1 go test ./tools -run Contract
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+const contractDir = "testdata/contract"
+
+// calls: one representative invocation per tool, in registry order.
+var contractCalls = []struct {
+	Tool string
+	Args map[string]any
+}{
+	{"get_pod_network_traffic", map[string]any{"pod_name": "web-1"}},
+	{"get_pod_syscalls", map[string]any{"pod_name": "web-1"}},
+	{"get_pod_details", map[string]any{"ip": "10.0.0.1"}},
+	{"get_service_details", map[string]any{"ip": "10.96.0.10"}},
+	{"get_cluster_traffic", map[string]any{}},
+	{"get_cluster_pods", map[string]any{}},
+	{"get_pod_details_by_name", map[string]any{"pod_name": "web-1"}},
+	{"list_services", map[string]any{}},
+	{"get_pods_on_node", map[string]any{"node": "node-a"}},
+	{"get_audit_verdicts", map[string]any{}},
+	{"generate_network_policy", map[string]any{"pod_name": "web-1"}},
+	{"generate_seccomp_profile", map[string]any{"pod_name": "web-1"}},
+}
+
+// backendServer serves testdata/contract/backend_fixtures.json — a map of
+// URL path → response body. Broker and advisor paths share one server; the
+// fixture file is language-neutral so the WS-B TS port replays it verbatim.
+func backendServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	raw, err := os.ReadFile(filepath.Join(contractDir, "backend_fixtures.json"))
+	if err != nil {
+		t.Fatalf("read backend fixtures: %v", err)
+	}
+	var fixtures map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &fixtures); err != nil {
+		t.Fatalf("parse backend fixtures: %v", err)
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, ok := fixtures[r.URL.Path]
+		if !ok {
+			t.Errorf("contract backend: no fixture for path %q", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		// Advisor endpoints return YAML/JSON text bodies; the fixture stores
+		// them as JSON strings. Everything else is raw JSON.
+		var asString string
+		if json.Unmarshal(body, &asString) == nil {
+			w.Header().Set("Content-Type", "text/plain")
+			_, _ = w.Write([]byte(asString))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(body)
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func connectContractSession(t *testing.T, backendURL string) *mcp.ClientSession {
+	t.Helper()
+	t.Setenv("ADVISOR_URL", backendURL)
+
+	server := mcp.NewServer(&mcp.Implementation{Name: "kguardian-mcp", Version: "1.0.0"}, nil)
+	RegisterTools(server, backendURL)
+
+	st, ct := mcp.NewInMemoryTransports()
+	ctx := context.Background()
+	ss, err := server.Connect(ctx, st, nil)
+	if err != nil {
+		t.Fatalf("server connect: %v", err)
+	}
+	t.Cleanup(func() { _ = ss.Close() })
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "contract-test", Version: "0.0.0"}, nil)
+	cs, err := client.Connect(ctx, ct, nil)
+	if err != nil {
+		t.Fatalf("client connect: %v", err)
+	}
+	t.Cleanup(func() { _ = cs.Close() })
+	return cs
+}
+
+func checkGolden(t *testing.T, name string, got []byte) {
+	t.Helper()
+	path := filepath.Join(contractDir, name)
+	if os.Getenv("UPDATE_GOLDEN") != "" {
+		if err := os.WriteFile(path, got, 0o644); err != nil {
+			t.Fatalf("update golden %s: %v", name, err)
+		}
+		t.Logf("updated golden %s", name)
+		return
+	}
+	want, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read golden %s (run UPDATE_GOLDEN=1 go test ./tools -run Contract to create): %v", name, err)
+	}
+	if string(want) != string(got) {
+		t.Errorf("CONTRACT DRIFT in %s.\nThis golden is the wire contract any tool-set reimplementation must match.\nIf the change is intentional, regenerate with UPDATE_GOLDEN=1 and call it out in review.\n--- want ---\n%s\n--- got ---\n%s", name, want, got)
+	}
+}
+
+// TestContract_ToolsList pins names, descriptions, and input schemas for all
+// 12 tools exactly as served over MCP.
+func TestContract_ToolsList(t *testing.T) {
+	backend := backendServer(t)
+	cs := connectContractSession(t, backend.URL)
+
+	res, err := cs.ListTools(context.Background(), &mcp.ListToolsParams{})
+	if err != nil {
+		t.Fatalf("tools/list: %v", err)
+	}
+	if len(res.Tools) != len(contractCalls) {
+		t.Fatalf("tool count drift: got %d tools, contract has %d", len(res.Tools), len(contractCalls))
+	}
+	got, err := json.MarshalIndent(res.Tools, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal tools/list: %v", err)
+	}
+	checkGolden(t, "tools_list.golden.json", append(got, '\n'))
+}
+
+// TestContract_ToolCalls replays one call per tool against the fixture
+// backend and pins each full CallToolResult.
+func TestContract_ToolCalls(t *testing.T) {
+	backend := backendServer(t)
+	cs := connectContractSession(t, backend.URL)
+
+	results := make(map[string]json.RawMessage, len(contractCalls))
+	for _, call := range contractCalls {
+		res, err := cs.CallTool(context.Background(), &mcp.CallToolParams{
+			Name:      call.Tool,
+			Arguments: call.Args,
+		})
+		if err != nil {
+			t.Fatalf("tools/call %s: %v", call.Tool, err)
+		}
+		if res.IsError {
+			t.Errorf("tools/call %s returned IsError=true against fixture data: %+v", call.Tool, res.Content)
+		}
+		raw, err := json.Marshal(res)
+		if err != nil {
+			t.Fatalf("marshal result for %s: %v", call.Tool, err)
+		}
+		results[call.Tool] = raw
+	}
+	got, err := json.MarshalIndent(results, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal call results: %v", err)
+	}
+	checkGolden(t, "tool_calls.golden.json", append(got, '\n'))
+}

--- a/mcp-server/tools/testdata/contract/backend_fixtures.json
+++ b/mcp-server/tools/testdata/contract/backend_fixtures.json
@@ -1,0 +1,34 @@
+{
+  "/pod/traffic/web-1": [
+    {"uuid": "11111111-1111-1111-1111-111111111111", "pod_name": "web-1", "pod_namespace": "prod", "pod_ip": "10.0.0.1", "pod_port": "8080", "ip_protocol": "TCP", "traffic_type": "INGRESS", "traffic_in_out_ip": "10.0.0.7", "traffic_in_out_port": "43122", "decision": "ALLOW", "time_stamp": "2026-07-20T10:00:00"},
+    {"uuid": "22222222-2222-2222-2222-222222222222", "pod_name": "web-1", "pod_namespace": "prod", "pod_ip": "10.0.0.1", "pod_port": "44310", "ip_protocol": "TCP", "traffic_type": "EGRESS", "traffic_in_out_ip": "10.96.0.10", "traffic_in_out_port": "5432", "decision": "ALLOW", "time_stamp": "2026-07-20T10:00:05"},
+    {"uuid": "33333333-3333-3333-3333-333333333333", "pod_name": "web-1", "pod_namespace": "prod", "pod_ip": "10.0.0.1", "pod_port": "44311", "ip_protocol": "UDP", "traffic_type": "EGRESS", "traffic_in_out_ip": "10.0.0.53", "traffic_in_out_port": "53", "decision": "DROP", "time_stamp": "2026-07-20T10:00:09"}
+  ],
+  "/pod/syscalls/web-1": {"pod_name": "web-1", "syscalls": "accept4,bind,clone,close,epoll_wait,openat,read,recvfrom,sendto,socket,write", "arch": "x86_64"},
+  "/pod/ip/10.0.0.1": {"pod_name": "web-1", "pod_namespace": "prod", "pod_ip": "10.0.0.1", "node_name": "node-a", "is_dead": false, "workload_selector_labels": {"app": "web"}, "pod_obj": {"metadata": {"name": "web-1", "namespace": "prod", "labels": {"app": "web"}}, "spec": {"nodeName": "node-a", "containers": [{"name": "web", "image": "nginx:1.27"}]}}},
+  "/svc/ip/10.96.0.10": {"svc_name": "db", "svc_namespace": "prod", "svc_ip": "10.96.0.10", "service_spec": {"selector": {"app": "db"}, "ports": [{"port": 5432, "protocol": "TCP", "targetPort": 5432}]}},
+  "/pod/traffic": [
+    {"uuid": "11111111-1111-1111-1111-111111111111", "pod_name": "web-1", "pod_namespace": "prod", "pod_ip": "10.0.0.1", "pod_port": "8080", "ip_protocol": "TCP", "traffic_type": "INGRESS", "traffic_in_out_ip": "10.0.0.7", "traffic_in_out_port": "43122", "decision": "ALLOW", "time_stamp": "2026-07-20T10:00:00"},
+    {"uuid": "22222222-2222-2222-2222-222222222222", "pod_name": "web-1", "pod_namespace": "prod", "pod_ip": "10.0.0.1", "pod_port": "44310", "ip_protocol": "TCP", "traffic_type": "EGRESS", "traffic_in_out_ip": "10.96.0.10", "traffic_in_out_port": "5432", "decision": "ALLOW", "time_stamp": "2026-07-20T10:00:05"},
+    {"uuid": "44444444-4444-4444-4444-444444444444", "pod_name": "batch-1", "pod_namespace": "jobs", "pod_ip": "10.0.0.9", "pod_port": "51000", "ip_protocol": "TCP", "traffic_type": "EGRESS", "traffic_in_out_ip": "203.0.113.9", "traffic_in_out_port": "443", "decision": "DROP", "time_stamp": "2026-07-20T10:01:00"}
+  ],
+  "/pod/info": [
+    {"pod_name": "web-1", "pod_namespace": "prod", "pod_ip": "10.0.0.1", "node_name": "node-a", "is_dead": false, "workload_selector_labels": {"app": "web"}, "pod_obj": {"spec": "heavyweight-stripped"}},
+    {"pod_name": "batch-1", "pod_namespace": "jobs", "pod_ip": "10.0.0.9", "node_name": "node-b", "is_dead": false, "workload_selector_labels": {"job-name": "batch"}, "pod_obj": {"spec": "heavyweight-stripped"}},
+    {"pod_name": "old-1", "pod_namespace": "prod", "pod_ip": "10.0.0.99", "node_name": "node-a", "is_dead": true, "pod_obj": {"spec": "heavyweight-stripped"}}
+  ],
+  "/pod/name/web-1": {"pod_name": "web-1", "pod_namespace": "prod", "pod_ip": "10.0.0.1", "node_name": "node-a", "is_dead": false, "workload_selector_labels": {"app": "web"}, "pod_obj": {"spec": "heavyweight-stripped"}},
+  "/svc/info": [
+    {"svc_name": "db", "svc_namespace": "prod", "svc_ip": "10.96.0.10", "service_spec": {"selector": {"app": "db"}, "ports": [{"port": 5432, "protocol": "TCP"}]}},
+    {"svc_name": "web", "svc_namespace": "prod", "svc_ip": "10.96.0.20", "service_spec": {"selector": {"app": "web"}, "ports": [{"port": 80, "protocol": "TCP"}]}}
+  ],
+  "/pod/list/node-a": [
+    {"pod_name": "web-1", "pod_namespace": "prod", "pod_ip": "10.0.0.1", "node_name": "node-a", "is_dead": false, "workload_selector_labels": {"app": "web"}}
+  ],
+  "/audit/verdicts": [
+    {"policy_namespace": "prod", "policy_name": "web-lockdown", "src_pod": "batch-1", "src_namespace": "jobs", "dst_pod": "web-1", "dst_namespace": "prod", "port": 8080, "protocol": "TCP", "direction": "Ingress", "verdict": "WouldDeny", "reason": "no ingress rule matches peer namespace jobs", "observed_at": "2026-07-20T10:01:30Z"},
+    {"policy_namespace": "prod", "policy_name": "web-lockdown", "src_pod": "web-1", "src_namespace": "prod", "dst_pod": "db-0", "dst_namespace": "prod", "port": 5432, "protocol": "TCP", "direction": "Egress", "verdict": "Allow", "reason": "egress rule 0 matches", "observed_at": "2026-07-20T10:00:06Z"}
+  ],
+  "/generate/networkpolicy": "apiVersion: networking.k8s.io/v1\nkind: NetworkPolicy\nmetadata:\n  name: web-1-policy\n  namespace: prod\nspec:\n  podSelector:\n    matchLabels:\n      app: web\n  policyTypes:\n    - Ingress\n    - Egress\n  ingress:\n    - from:\n        - podSelector:\n            matchLabels:\n              app: frontend\n      ports:\n        - protocol: TCP\n          port: 8080\n  egress:\n    - to:\n        - podSelector:\n            matchLabels:\n              app: db\n      ports:\n        - protocol: TCP\n          port: 5432\n",
+  "/generate/seccomp": "{\n  \"defaultAction\": \"SCMP_ACT_ERRNO\",\n  \"architectures\": [\"SCMP_ARCH_X86_64\"],\n  \"syscalls\": [\n    {\n      \"names\": [\"accept4\", \"bind\", \"clone\", \"close\", \"epoll_wait\", \"openat\", \"read\", \"recvfrom\", \"sendto\", \"socket\", \"write\"],\n      \"action\": \"SCMP_ACT_ALLOW\"\n    }\n  ]\n}\n"
+}

--- a/mcp-server/tools/testdata/contract/tool_calls.golden.json
+++ b/mcp-server/tools/testdata/contract/tool_calls.golden.json
@@ -1,0 +1,134 @@
+{
+  "generate_network_policy": {
+    "content": [
+      {
+        "type": "text",
+        "text": "apiVersion: networking.k8s.io/v1\nkind: NetworkPolicy\nmetadata:\n  name: web-1-policy\n  namespace: prod\nspec:\n  podSelector:\n    matchLabels:\n      app: web\n  policyTypes:\n    - Ingress\n    - Egress\n  ingress:\n    - from:\n        - podSelector:\n            matchLabels:\n              app: frontend\n      ports:\n        - protocol: TCP\n          port: 8080\n  egress:\n    - to:\n        - podSelector:\n            matchLabels:\n              app: db\n      ports:\n        - protocol: TCP\n          port: 5432\n"
+      }
+    ],
+    "structuredContent": {
+      "data": ""
+    }
+  },
+  "generate_seccomp_profile": {
+    "content": [
+      {
+        "type": "text",
+        "text": "{\n  \"defaultAction\": \"SCMP_ACT_ERRNO\",\n  \"architectures\": [\"SCMP_ARCH_X86_64\"],\n  \"syscalls\": [\n    {\n      \"names\": [\"accept4\", \"bind\", \"clone\", \"close\", \"epoll_wait\", \"openat\", \"read\", \"recvfrom\", \"sendto\", \"socket\", \"write\"],\n      \"action\": \"SCMP_ACT_ALLOW\"\n    }\n  ]\n}\n"
+      }
+    ],
+    "structuredContent": {
+      "data": ""
+    }
+  },
+  "get_audit_verdicts": {
+    "content": [
+      {
+        "type": "text",
+        "text": "[{\"direction\":\"Ingress\",\"dst_namespace\":\"prod\",\"dst_pod\":\"web-1\",\"observed_at\":\"2026-07-20T10:01:30Z\",\"policy_name\":\"web-lockdown\",\"policy_namespace\":\"prod\",\"port\":8080,\"protocol\":\"TCP\",\"reason\":\"no ingress rule matches peer namespace jobs\",\"src_namespace\":\"jobs\",\"src_pod\":\"batch-1\",\"verdict\":\"WouldDeny\"},{\"direction\":\"Egress\",\"dst_namespace\":\"prod\",\"dst_pod\":\"db-0\",\"observed_at\":\"2026-07-20T10:00:06Z\",\"policy_name\":\"web-lockdown\",\"policy_namespace\":\"prod\",\"port\":5432,\"protocol\":\"TCP\",\"reason\":\"egress rule 0 matches\",\"src_namespace\":\"prod\",\"src_pod\":\"web-1\",\"verdict\":\"Allow\"}]"
+      }
+    ],
+    "structuredContent": {
+      "data": ""
+    }
+  },
+  "get_cluster_pods": {
+    "content": [
+      {
+        "type": "text",
+        "text": "[{\"is_dead\":false,\"node_name\":\"node-a\",\"pod_ip\":\"10.0.0.1\",\"pod_name\":\"web-1\",\"pod_namespace\":\"prod\",\"workload_selector_labels\":{\"app\":\"web\"}},{\"is_dead\":false,\"node_name\":\"node-b\",\"pod_ip\":\"10.0.0.9\",\"pod_name\":\"batch-1\",\"pod_namespace\":\"jobs\",\"workload_selector_labels\":{\"job-name\":\"batch\"}}]"
+      }
+    ],
+    "structuredContent": {
+      "data": ""
+    }
+  },
+  "get_cluster_traffic": {
+    "content": [
+      {
+        "type": "text",
+        "text": "{\"pod_count\":2,\"pods\":{\"batch-1\":{\"allow_count\":0,\"drop_count\":1,\"egress_count\":1,\"ingress_count\":0,\"unique_peer_count\":1},\"web-1\":{\"allow_count\":2,\"drop_count\":0,\"egress_count\":1,\"ingress_count\":1,\"unique_peer_count\":2}},\"total_drop_count\":1,\"total_records\":3}"
+      }
+    ],
+    "structuredContent": {
+      "data": ""
+    }
+  },
+  "get_pod_details": {
+    "content": [
+      {
+        "type": "text",
+        "text": "{\"is_dead\":false,\"node_name\":\"node-a\",\"pod_ip\":\"10.0.0.1\",\"pod_name\":\"web-1\",\"pod_namespace\":\"prod\",\"workload_selector_labels\":{\"app\":\"web\"}}"
+      }
+    ],
+    "structuredContent": {
+      "data": ""
+    }
+  },
+  "get_pod_details_by_name": {
+    "content": [
+      {
+        "type": "text",
+        "text": "{\"is_dead\":false,\"node_name\":\"node-a\",\"pod_ip\":\"10.0.0.1\",\"pod_name\":\"web-1\",\"pod_namespace\":\"prod\",\"workload_selector_labels\":{\"app\":\"web\"}}"
+      }
+    ],
+    "structuredContent": {
+      "data": ""
+    }
+  },
+  "get_pod_network_traffic": {
+    "content": [
+      {
+        "type": "text",
+        "text": "[{\"decision\":\"ALLOW\",\"ip_protocol\":\"TCP\",\"pod_ip\":\"10.0.0.1\",\"pod_name\":\"web-1\",\"pod_namespace\":\"prod\",\"pod_port\":\"8080\",\"time_stamp\":\"2026-07-20T10:00:00\",\"traffic_in_out_ip\":\"10.0.0.7\",\"traffic_in_out_port\":\"43122\",\"traffic_type\":\"INGRESS\",\"uuid\":\"11111111-1111-1111-1111-111111111111\"},{\"decision\":\"ALLOW\",\"ip_protocol\":\"TCP\",\"pod_ip\":\"10.0.0.1\",\"pod_name\":\"web-1\",\"pod_namespace\":\"prod\",\"pod_port\":\"44310\",\"time_stamp\":\"2026-07-20T10:00:05\",\"traffic_in_out_ip\":\"10.96.0.10\",\"traffic_in_out_port\":\"5432\",\"traffic_type\":\"EGRESS\",\"uuid\":\"22222222-2222-2222-2222-222222222222\"},{\"decision\":\"DROP\",\"ip_protocol\":\"UDP\",\"pod_ip\":\"10.0.0.1\",\"pod_name\":\"web-1\",\"pod_namespace\":\"prod\",\"pod_port\":\"44311\",\"time_stamp\":\"2026-07-20T10:00:09\",\"traffic_in_out_ip\":\"10.0.0.53\",\"traffic_in_out_port\":\"53\",\"traffic_type\":\"EGRESS\",\"uuid\":\"33333333-3333-3333-3333-333333333333\"}]"
+      }
+    ],
+    "structuredContent": {
+      "data": ""
+    }
+  },
+  "get_pod_syscalls": {
+    "content": [
+      {
+        "type": "text",
+        "text": "{\"arch\":\"x86_64\",\"pod_name\":\"web-1\",\"syscalls\":\"accept4,bind,clone,close,epoll_wait,openat,read,recvfrom,sendto,socket,write\"}"
+      }
+    ],
+    "structuredContent": {
+      "data": ""
+    }
+  },
+  "get_pods_on_node": {
+    "content": [
+      {
+        "type": "text",
+        "text": "[{\"is_dead\":false,\"node_name\":\"node-a\",\"pod_ip\":\"10.0.0.1\",\"pod_name\":\"web-1\",\"pod_namespace\":\"prod\",\"workload_selector_labels\":{\"app\":\"web\"}}]"
+      }
+    ],
+    "structuredContent": {
+      "data": ""
+    }
+  },
+  "get_service_details": {
+    "content": [
+      {
+        "type": "text",
+        "text": "{\"svc_ip\":\"10.96.0.10\",\"svc_name\":\"db\",\"svc_namespace\":\"prod\"}"
+      }
+    ],
+    "structuredContent": {
+      "data": ""
+    }
+  },
+  "list_services": {
+    "content": [
+      {
+        "type": "text",
+        "text": "[{\"svc_ip\":\"10.96.0.10\",\"svc_name\":\"db\",\"svc_namespace\":\"prod\"},{\"svc_ip\":\"10.96.0.20\",\"svc_name\":\"web\",\"svc_namespace\":\"prod\"}]"
+      }
+    ],
+    "structuredContent": {
+      "data": ""
+    }
+  }
+}

--- a/mcp-server/tools/testdata/contract/tools_list.golden.json
+++ b/mcp-server/tools/testdata/contract/tools_list.golden.json
@@ -1,0 +1,374 @@
+[
+  {
+    "description": "Generate a least-privilege Kubernetes NetworkPolicy (or CiliumNetworkPolicy) for a pod from its observed traffic. Returns ready-to-apply YAML. Parameters: pod_name (required); policy_type ('kubernetes' for a standard NetworkPolicy — the default — or 'cilium'). Use when the user asks to 'generate/create a network policy', 'lock down this pod', or 'restrict traffic for X'. The policy is deterministically synthesised by the advisor from captured flows, not guessed.",
+    "inputSchema": {
+      "additionalProperties": false,
+      "properties": {
+        "pod_name": {
+          "description": "The name of the pod to generate a least-privilege network policy for",
+          "type": "string"
+        },
+        "policy_type": {
+          "description": "Policy flavour: 'kubernetes' (standard NetworkPolicy, default) or 'cilium' (CiliumNetworkPolicy)",
+          "type": "string"
+        }
+      },
+      "required": [
+        "pod_name"
+      ],
+      "type": "object"
+    },
+    "name": "generate_network_policy",
+    "outputSchema": {
+      "additionalProperties": false,
+      "properties": {
+        "data": {
+          "description": "Generated network policy in YAML format",
+          "type": "string"
+        }
+      },
+      "required": [
+        "data"
+      ],
+      "type": "object"
+    }
+  },
+  {
+    "description": "Generate a least-privilege seccomp profile for a pod from its observed syscalls. Returns ready-to-use seccomp JSON (allow-lists the observed syscalls, denies the rest). Parameter: pod_name (required). Use when the user asks to 'generate/create a seccomp profile' or 'restrict syscalls for X'.",
+    "inputSchema": {
+      "additionalProperties": false,
+      "properties": {
+        "pod_name": {
+          "description": "The name of the pod to generate a seccomp profile for",
+          "type": "string"
+        }
+      },
+      "required": [
+        "pod_name"
+      ],
+      "type": "object"
+    },
+    "name": "generate_seccomp_profile",
+    "outputSchema": {
+      "additionalProperties": false,
+      "properties": {
+        "data": {
+          "description": "Generated seccomp profile in JSON format",
+          "type": "string"
+        }
+      },
+      "required": [
+        "data"
+      ],
+      "type": "object"
+    }
+  },
+  {
+    "description": "Get network-policy evaluation verdicts — flows the AuditNetworkPolicy/AuditClusterNetworkPolicy engine evaluated as Allow or WouldDeny. Returns source/destination pod+namespace, port, protocol, direction, the human-readable reason, and observed_at, newest first. All filters optional: policy, namespace (a single namespace; omit to span all, which includes cluster-scoped), cluster_scoped (true = ONLY cluster-scoped verdicts), verdict ('Allow'|'WouldDeny'), direction ('Ingress'|'Egress'), limit (default 100, max 500). Use for security questions like 'what traffic would be denied', 'why is this flow blocked', or 'show recent policy violations'.",
+    "inputSchema": {
+      "additionalProperties": false,
+      "properties": {
+        "cluster_scoped": {
+          "description": "Set true to return ONLY cluster-scoped AuditClusterNetworkPolicy verdicts. Takes precedence over namespace.",
+          "type": "boolean"
+        },
+        "direction": {
+          "description": "Optional direction filter: 'Ingress' or 'Egress'.",
+          "type": "string"
+        },
+        "limit": {
+          "description": "Optional cap on rows returned. Defaults to 100, hard cap 500. Results are ordered newest-first.",
+          "type": "integer"
+        },
+        "namespace": {
+          "description": "Optional policy namespace to filter to a single namespace's AuditNetworkPolicy verdicts. Omit to span all namespaces (cluster-scoped verdicts are included). To see ONLY cluster-scoped verdicts, set cluster_scoped instead of using this field.",
+          "type": "string"
+        },
+        "policy": {
+          "description": "Optional policy name to filter by (matches an AuditNetworkPolicy or AuditClusterNetworkPolicy by name).",
+          "type": "string"
+        },
+        "verdict": {
+          "description": "Optional verdict filter: 'Allow' or 'WouldDeny'. Use 'WouldDeny' to see flows that the policy would block if enforced.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "name": "get_audit_verdicts",
+    "outputSchema": {
+      "additionalProperties": false,
+      "properties": {
+        "data": {
+          "description": "Audit verdict records in JSON format",
+          "type": "string"
+        }
+      },
+      "required": [
+        "data"
+      ],
+      "type": "object"
+    }
+  },
+  {
+    "description": "List pods in the cluster with compact metadata (name, namespace, IP, node, status). Heavyweight fields like pod_obj are stripped. Accepts an optional namespace parameter to filter results. Use when the user asks 'what pods are running' or needs a pod inventory.",
+    "inputSchema": {
+      "additionalProperties": false,
+      "properties": {
+        "namespace": {
+          "description": "Optional Kubernetes namespace to filter results. If omitted, returns pods from all namespaces.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "name": "get_cluster_pods",
+    "outputSchema": {
+      "additionalProperties": false,
+      "properties": {
+        "data": {
+          "description": "Compact pod list in JSON format",
+          "type": "string"
+        }
+      },
+      "required": [
+        "data"
+      ],
+      "type": "object"
+    }
+  },
+  {
+    "description": "Get a summary of network traffic across the cluster. Returns per-pod counts (ingress/egress, allow/drop, unique peers) plus a cluster-wide total_drop_count — not raw records. Dropped flows (decision=DROP) come from the eBPF network-policy-drop probe, so this also answers 'what traffic is being blocked/dropped'. Accepts an optional namespace filter. Use for overall traffic patterns, 'what pods are communicating', or 'where is traffic being dropped'.",
+    "inputSchema": {
+      "additionalProperties": false,
+      "properties": {
+        "namespace": {
+          "description": "Optional Kubernetes namespace to filter results. If omitted, returns a summary of all namespaces.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "name": "get_cluster_traffic",
+    "outputSchema": {
+      "additionalProperties": false,
+      "properties": {
+        "data": {
+          "description": "Cluster traffic summary in JSON format",
+          "type": "string"
+        }
+      },
+      "required": [
+        "data"
+      ],
+      "type": "object"
+    }
+  },
+  {
+    "description": "Look up a pod by its IP address. Returns pod name, namespace, IP, and full Kubernetes pod object. Use when the user has an IP address and wants to identify which pod it belongs to. Requires only ip.",
+    "inputSchema": {
+      "additionalProperties": false,
+      "properties": {
+        "ip": {
+          "description": "The IP address of the pod to query",
+          "type": "string"
+        }
+      },
+      "required": [
+        "ip"
+      ],
+      "type": "object"
+    },
+    "name": "get_pod_details",
+    "outputSchema": {
+      "additionalProperties": false,
+      "properties": {
+        "data": {
+          "description": "Pod details in JSON format",
+          "type": "string"
+        }
+      },
+      "required": [
+        "data"
+      ],
+      "type": "object"
+    }
+  },
+  {
+    "description": "Look up a pod by its name. Returns identity (name, namespace, IP, node, workload selector labels) with the heavyweight pod_obj stripped. Use when the user names a pod (e.g. from a traffic record) and wants its details — prefer this over get_pod_details, which requires an IP.",
+    "inputSchema": {
+      "additionalProperties": false,
+      "properties": {
+        "pod_name": {
+          "description": "The name of the pod to look up",
+          "type": "string"
+        }
+      },
+      "required": [
+        "pod_name"
+      ],
+      "type": "object"
+    },
+    "name": "get_pod_details_by_name",
+    "outputSchema": {
+      "additionalProperties": false,
+      "properties": {
+        "data": {
+          "description": "Pod details in JSON format",
+          "type": "string"
+        }
+      },
+      "required": [
+        "data"
+      ],
+      "type": "object"
+    }
+  },
+  {
+    "description": "Get network traffic for a specific pod by name. Returns source/destination IPs, ports, protocols, ingress/egress types, and packet decisions. Use when the user asks about a specific pod's connections or traffic. Requires only pod_name (not namespace-scoped — the broker resolves by name cluster-wide).",
+    "inputSchema": {
+      "additionalProperties": false,
+      "properties": {
+        "pod_name": {
+          "description": "The name of the pod to query traffic for",
+          "type": "string"
+        }
+      },
+      "required": [
+        "pod_name"
+      ],
+      "type": "object"
+    },
+    "name": "get_pod_network_traffic",
+    "outputSchema": {
+      "additionalProperties": false,
+      "properties": {
+        "data": {
+          "description": "Network traffic data in JSON format",
+          "type": "string"
+        }
+      },
+      "required": [
+        "data"
+      ],
+      "type": "object"
+    }
+  },
+  {
+    "description": "Get system calls made by a specific pod. Returns syscall names, frequencies, and architecture. Use when the user asks about a pod's syscalls, seccomp profile, or suspicious behavior. Requires only pod_name (not namespace-scoped).",
+    "inputSchema": {
+      "additionalProperties": false,
+      "properties": {
+        "pod_name": {
+          "description": "The name of the pod to query syscalls for",
+          "type": "string"
+        }
+      },
+      "required": [
+        "pod_name"
+      ],
+      "type": "object"
+    },
+    "name": "get_pod_syscalls",
+    "outputSchema": {
+      "additionalProperties": false,
+      "properties": {
+        "data": {
+          "description": "Syscall data in JSON format",
+          "type": "string"
+        }
+      },
+      "required": [
+        "data"
+      ],
+      "type": "object"
+    }
+  },
+  {
+    "description": "List the pods recorded on a specific Kubernetes node (compact metadata: name, namespace, IP, node, workload labels; live pods only). Use for blast-radius / 'what runs on node X' / 'which workloads share a node' questions. Requires node.",
+    "inputSchema": {
+      "additionalProperties": false,
+      "properties": {
+        "node": {
+          "description": "The name of the Kubernetes node to list pods for",
+          "type": "string"
+        }
+      },
+      "required": [
+        "node"
+      ],
+      "type": "object"
+    },
+    "name": "get_pods_on_node",
+    "outputSchema": {
+      "additionalProperties": false,
+      "properties": {
+        "data": {
+          "description": "Pods on the node, in JSON format",
+          "type": "string"
+        }
+      },
+      "required": [
+        "data"
+      ],
+      "type": "object"
+    }
+  },
+  {
+    "description": "Look up a Kubernetes service by its cluster IP. Returns service name, namespace, IP, ports, and full service spec. Use when the user has a service IP and wants to identify the service. Requires only ip.",
+    "inputSchema": {
+      "additionalProperties": false,
+      "properties": {
+        "ip": {
+          "description": "The IP address of the service to query",
+          "type": "string"
+        }
+      },
+      "required": [
+        "ip"
+      ],
+      "type": "object"
+    },
+    "name": "get_service_details",
+    "outputSchema": {
+      "additionalProperties": false,
+      "properties": {
+        "data": {
+          "description": "Service details in JSON format",
+          "type": "string"
+        }
+      },
+      "required": [
+        "data"
+      ],
+      "type": "object"
+    }
+  },
+  {
+    "description": "List Kubernetes services in the cluster with compact metadata (name, namespace, cluster IP, selector, ports). Accepts an optional namespace parameter to filter results. Use when the user asks 'what services exist' or needs a service inventory — get_service_details only resolves a single known IP.",
+    "inputSchema": {
+      "additionalProperties": false,
+      "properties": {
+        "namespace": {
+          "description": "Optional Kubernetes namespace to filter results. If omitted, returns services across all namespaces.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "name": "list_services",
+    "outputSchema": {
+      "additionalProperties": false,
+      "properties": {
+        "data": {
+          "description": "Service inventory in JSON format",
+          "type": "string"
+        }
+      },
+      "required": [
+        "data"
+      ],
+      "type": "object"
+    }
+  }
+]


### PR DESCRIPTION
Task G1 of SIMPLIFICATION-GOAL.md (gates, §3).

- **Wire contract pinned**: `tools/testdata/contract/` holds `tools_list.golden.json` (12 tools: names/descriptions/schemas exactly as served over MCP) and `tool_calls.golden.json` (full CallToolResult per tool) generated through a real in-memory MCP client against the registered server, with broker+advisor responses served from language-neutral `backend_fixtures.json` — the WS-B TS port replays the same fixtures and must produce the same bytes.
- **Known flake root-caused and fixed**: `TestBrokerClient_OversizedBodyTruncated` (sibling charter WS5) discarded write errors in its fixture handler → infinite `(0, err)` write loop after the client hit its 10 MB cap → `srv.Close()` deadlock until the 600 s package timeout. Verified fixed with `-count=30` / suite `-count=3`.
- **First CI test gate for mcp-server**: `test-mcp-server` job (vet + test, path-gated). Contract drift now fails PRs with an explicit CONTRACT DRIFT message.

https://claude.ai/code/session_019iDb3ymyUBM3NZPRd5M39U