### PR TITLE
test(llm-bridge,frontend): G3 SSE stream contract pinned on both ends

### DIFF
--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -663,6 +663,54 @@ jobs:
               });
             }
 
+  # Test llm-bridge (tsc build via pretest deps + node:test suite), including
+  # the G3 SSE contract recordings under llm-bridge/contract/ - the emitter
+  # side of the stream contract. SIMPLIFICATION-GOAL.md section 3.
+  test-llm-bridge:
+    runs-on: ubuntu-latest
+    needs: detect-changes
+    if: needs.detect-changes.outputs.llm-bridge == 'true' || needs.detect-changes.outputs.frontend == 'true'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Set up Node
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
+        with:
+          node-version: '22'
+          cache: npm
+          cache-dependency-path: llm-bridge/package-lock.json
+
+      - name: Test
+        working-directory: llm-bridge
+        run: |
+          npm ci
+          npm test
+
+  # Test frontend (vitest), including the G3 SSE contract consumer side -
+  # replays llm-bridge/contract recordings through the real SSE parser, so it
+  # runs when EITHER component changes.
+  test-frontend:
+    runs-on: ubuntu-latest
+    needs: detect-changes
+    if: needs.detect-changes.outputs.frontend == 'true' || needs.detect-changes.outputs.llm-bridge == 'true'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Set up Node
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
+        with:
+          node-version: '22'
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Test
+        working-directory: frontend
+        run: |
+          npm ci
+          npm test
+
   # Build MCP Server
   build-mcp-server:
     needs: detect-changes

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -36,7 +36,8 @@
         "tailwindcss": "^4.1.16",
         "typescript": "~6.0.0",
         "typescript-eslint": "^8.45.0",
-        "vite": "^8.0.0"
+        "vite": "^8.0.0",
+        "vitest": "^4.1.10"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -1236,9 +1237,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1256,9 +1254,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1276,9 +1271,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1296,9 +1288,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1316,9 +1305,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1336,9 +1322,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1422,6 +1405,13 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
       "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "dev": true,
       "license": "MIT"
     },
@@ -1558,9 +1548,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1578,9 +1565,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1598,9 +1582,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1618,9 +1599,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1795,6 +1773,17 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
       }
     },
     "node_modules/@types/d3": {
@@ -2058,6 +2047,13 @@
       "dependencies": {
         "@types/ms": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/esrecurse": {
       "version": "4.3.1",
@@ -2428,6 +2424,119 @@
         }
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -2478,6 +2587,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/asynckit": {
@@ -2657,6 +2776,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/character-entities": {
@@ -3009,6 +3138,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -3286,6 +3422,16 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -3294,6 +3440,16 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/extend": {
@@ -5136,6 +5292,20 @@
         "node": ">=18"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -5230,6 +5400,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -5544,6 +5721,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -5563,6 +5747,20 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stringify-entities": {
       "version": "4.0.4",
@@ -5616,6 +5814,23 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
@@ -5631,6 +5846,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/trim-lines": {
@@ -5981,6 +6206,96 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -5995,6 +6310,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run"
   },
   "dependencies": {
     "@tailwindcss/typography": "^0.5.19",
@@ -38,6 +39,7 @@
     "tailwindcss": "^4.1.16",
     "typescript": "~6.0.0",
     "typescript-eslint": "^8.45.0",
-    "vite": "^8.0.0"
+    "vite": "^8.0.0",
+    "vitest": "^4.1.10"
   }
 }

--- a/frontend/src/services/aiApi.contract.test.ts
+++ b/frontend/src/services/aiApi.contract.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, expect, test, vi } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { streamChatMessage } from './aiApi';
+
+// G3 SSE stream contract — consumer side (SIMPLIFICATION-GOAL.md §3).
+//
+// Replays the exact recording the llm-bridge emitter test produced
+// (llm-bridge/contract/sse_session.golden.txt) through the real parser and
+// asserts the handler-level event sequence matches the canonical decoded list
+// (sse_events.golden.json). The two sides of the wire test against the same
+// bytes: if either endpoint changes the contract, one of the two suites goes
+// red. Regenerate the recordings from the llm-bridge side only
+// (UPDATE_GOLDEN=1 npm test there), never by hand.
+
+const contractDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../llm-bridge/contract');
+const golden = (name: string) => fs.readFileSync(path.join(contractDir, name), 'utf8');
+
+function fetchStreaming(body: string) {
+  return vi.fn(async () => new Response(
+    new ReadableStream<Uint8Array>({
+      start(controller) {
+        // Deliver in 40-byte chunks so the parser's incremental buffering is
+        // exercised, not just the whole-body happy path.
+        const bytes = new TextEncoder().encode(body);
+        for (let i = 0; i < bytes.length; i += 40) controller.enqueue(bytes.slice(i, i + 40));
+        controller.close();
+      },
+    }),
+    { status: 200, headers: { 'Content-Type': 'text/event-stream' } },
+  ));
+}
+
+// Project a canonical wire event to the handler-level view the UI consumes.
+// (tool_use `id` is deliberately not surfaced to the UI.)
+type WireEvent = { type: string; delta?: string; name?: string; ok?: boolean; model?: string; error?: string };
+function handlerView(e: WireEvent): unknown {
+  switch (e.type) {
+    case 'text': return { type: 'text', delta: e.delta };
+    case 'thinking': return { type: 'thinking', delta: e.delta };
+    case 'tool_use': return { type: 'tool_use', name: e.name };
+    case 'tool_result': return { type: 'tool_result', name: e.name, ok: e.ok };
+    case 'done': return { type: 'done', model: e.model };
+    case 'error': return { type: 'error', error: e.error };
+    default: throw new Error(`unknown wire event type: ${e.type}`);
+  }
+}
+
+function collectingHandlers(events: unknown[]) {
+  return {
+    onText: (delta: string) => events.push({ type: 'text', delta }),
+    onThinking: (delta: string) => events.push({ type: 'thinking', delta }),
+    onToolUse: (name: string) => events.push({ type: 'tool_use', name }),
+    onToolResult: (name: string, ok: boolean) => events.push({ type: 'tool_result', name, ok }),
+    onDone: (info: { model: string }) => events.push({ type: 'done', model: info.model }),
+    onError: (error: string) => events.push({ type: 'error', error }),
+  };
+}
+
+afterEach(() => vi.unstubAllGlobals());
+
+test('G3: parser decodes the recorded session into the canonical event sequence', async () => {
+  const events: unknown[] = [];
+  vi.stubGlobal('fetch', fetchStreaming(golden('sse_session.golden.txt')));
+
+  await streamChatMessage('how many pods?', [], undefined, collectingHandlers(events));
+
+  const expected = (JSON.parse(golden('sse_events.golden.json')) as WireEvent[]).map(handlerView);
+  expect(events).toEqual(expected);
+});
+
+test('G3: parser surfaces the recorded upstream-overload error frame', async () => {
+  const events: unknown[] = [];
+  vi.stubGlobal('fetch', fetchStreaming(golden('sse_error.golden.txt')));
+
+  await streamChatMessage('hi', [], undefined, collectingHandlers(events));
+
+  const errors = events.filter((e) => (e as WireEvent).type === 'error');
+  expect(errors).toHaveLength(1);
+  expect((errors[0] as WireEvent).error).toBeTruthy();
+});

--- a/frontend/src/services/aiApi.ts
+++ b/frontend/src/services/aiApi.ts
@@ -19,13 +19,12 @@ export interface StreamHandlers {
   onThinking?: (delta: string) => void;
   onToolUse?: (name: string) => void;
   onToolResult?: (name: string, ok: boolean) => void;
-  onDone?: (info: { model: string; conversationId?: string }) => void;
+  onDone?: (info: { model: string }) => void;
   onError?: (error: string) => void;
 }
 
 export interface StreamOptions {
   provider?: LLMProvider;
-  conversationId?: string;
   signal?: AbortSignal;
 }
 
@@ -52,7 +51,6 @@ export async function streamChatMessage(
         history,
         context,
         provider: options.provider,
-        conversationId: options.conversationId,
       }),
       signal: options.signal,
     });
@@ -113,7 +111,7 @@ export async function streamChatMessage(
         handlers.onToolResult?.(event.name as string, event.ok as boolean);
         break;
       case 'done':
-        handlers.onDone?.({ model: event.model as string, conversationId: event.conversationId as string | undefined });
+        handlers.onDone?.({ model: event.model as string });
         break;
       case 'error':
         handlers.onError?.(event.error as string);

--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -24,5 +24,6 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx"]
 }

--- a/llm-bridge/contract/sse_error.golden.txt
+++ b/llm-bridge/contract/sse_error.golden.txt
@@ -1,0 +1,3 @@
+event: error
+data: {"type":"error","error":"The AI provider is temporarily overloaded. Please retry in a few seconds."}
+

--- a/llm-bridge/contract/sse_events.golden.json
+++ b/llm-bridge/contract/sse_events.golden.json
@@ -1,0 +1,28 @@
+[
+  {
+    "type": "thinking",
+    "delta": "Checking the cluster inventory."
+  },
+  {
+    "type": "tool_use",
+    "name": "get_cluster_pods",
+    "id": "toolu_contract_1"
+  },
+  {
+    "type": "tool_result",
+    "name": "get_cluster_pods",
+    "ok": true
+  },
+  {
+    "type": "text",
+    "delta": "Your cluster runs "
+  },
+  {
+    "type": "text",
+    "delta": "2 pods."
+  },
+  {
+    "type": "done",
+    "model": "claude-opus-4-8"
+  }
+]

--- a/llm-bridge/contract/sse_session.golden.txt
+++ b/llm-bridge/contract/sse_session.golden.txt
@@ -1,0 +1,18 @@
+event: thinking
+data: {"type":"thinking","delta":"Checking the cluster inventory."}
+
+event: tool_use
+data: {"type":"tool_use","name":"get_cluster_pods","id":"toolu_contract_1"}
+
+event: tool_result
+data: {"type":"tool_result","name":"get_cluster_pods","ok":true}
+
+event: text
+data: {"type":"text","delta":"Your cluster runs "}
+
+event: text
+data: {"type":"text","delta":"2 pods."}
+
+event: done
+data: {"type":"done","model":"claude-opus-4-8"}
+

--- a/llm-bridge/src/contract.sse.test.ts
+++ b/llm-bridge/src/contract.sse.test.ts
@@ -1,0 +1,164 @@
+import { test, before, after } from "node:test";
+import assert from "node:assert/strict";
+import http from "node:http";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import type { AddressInfo } from "node:net";
+
+import { app } from "./index.js";
+import { McpClient } from "./mcpClient.js";
+
+// G3 SSE stream contract (SIMPLIFICATION-GOAL.md §3).
+//
+// Records a full assistant session — thinking, a tool round (tool_use +
+// tool_result), streamed text, and the terminal done frame — as raw SSE bytes
+// plus the decoded event list. The goldens under llm-bridge/contract/ are THE
+// stream contract: the frontend parser test (frontend/src/services/
+// aiApi.contract.test.ts) replays sse_session.golden.txt and must decode the
+// exact event sequence in sse_events.golden.json. A diff on either side is a
+// contract change. Regenerate deliberately: UPDATE_GOLDEN=1 npm test
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const contractDir = path.resolve(__dirname, "..", "contract");
+
+function sse(event: string, data: unknown): string {
+  return `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
+}
+
+const messageStart = (id: string) =>
+  sse("message_start", {
+    type: "message_start",
+    message: {
+      id,
+      type: "message",
+      role: "assistant",
+      model: "claude-opus-4-8",
+      content: [],
+      stop_reason: null,
+      stop_sequence: null,
+      usage: { input_tokens: 1, output_tokens: 0 },
+    },
+  });
+
+// Round 1: a summarized-thinking block, then a tool_use block → stop_reason tool_use.
+const toolRoundSSE =
+  messageStart("msg_contract_1") +
+  sse("content_block_start", { type: "content_block_start", index: 0, content_block: { type: "thinking", thinking: "" } }) +
+  sse("content_block_delta", { type: "content_block_delta", index: 0, delta: { type: "thinking_delta", thinking: "Checking the cluster inventory." } }) +
+  sse("content_block_stop", { type: "content_block_stop", index: 0 }) +
+  sse("content_block_start", { type: "content_block_start", index: 1, content_block: { type: "tool_use", id: "toolu_contract_1", name: "get_cluster_pods", input: {} } }) +
+  sse("content_block_delta", { type: "content_block_delta", index: 1, delta: { type: "input_json_delta", partial_json: "{}" } }) +
+  sse("content_block_stop", { type: "content_block_stop", index: 1 }) +
+  sse("message_delta", { type: "message_delta", delta: { stop_reason: "tool_use" }, usage: { output_tokens: 5 } }) +
+  sse("message_stop", { type: "message_stop" });
+
+// Round 2: the final streamed text answer.
+const textRoundSSE =
+  messageStart("msg_contract_2") +
+  sse("content_block_start", { type: "content_block_start", index: 0, content_block: { type: "text", text: "" } }) +
+  sse("content_block_delta", { type: "content_block_delta", index: 0, delta: { type: "text_delta", text: "Your cluster runs " } }) +
+  sse("content_block_delta", { type: "content_block_delta", index: 0, delta: { type: "text_delta", text: "2 pods." } }) +
+  sse("content_block_stop", { type: "content_block_stop", index: 0 }) +
+  sse("message_delta", { type: "message_delta", delta: { stop_reason: "end_turn" }, usage: { output_tokens: 8 } }) +
+  sse("message_stop", { type: "message_stop" });
+
+let anthropicMock: http.Server;
+let appServer: http.Server;
+let appURL = "";
+let mockCalls = 0;
+let failNext = false;
+
+before(async () => {
+  anthropicMock = http.createServer((_req, res) => {
+    if (failNext) {
+      res.writeHead(529, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ type: "error", error: { type: "overloaded_error", message: "Overloaded" } }));
+      return;
+    }
+    mockCalls += 1;
+    res.writeHead(200, { "Content-Type": "text/event-stream" });
+    res.end(mockCalls === 1 ? toolRoundSSE : textRoundSSE);
+  });
+  await new Promise<void>((resolve) => anthropicMock.listen(0, "127.0.0.1", resolve));
+  const mockPort = (anthropicMock.address() as AddressInfo).port;
+
+  process.env.ANTHROPIC_API_KEY = "test-key";
+  process.env.ANTHROPIC_BASE_URL = `http://127.0.0.1:${mockPort}`;
+  delete process.env.OPENAI_API_KEY;
+  delete process.env.GOOGLE_API_KEY;
+  delete process.env.GITHUB_TOKEN;
+
+  const stub = McpClient as unknown as {
+    getToolsCached: () => Promise<unknown[]>;
+    prototype: { executeTool: (tc: { name: string }) => Promise<unknown> };
+  };
+  stub.getToolsCached = async () => [
+    { name: "get_cluster_pods", description: "List pods.", parameters: { type: "object", properties: {}, required: [] } },
+  ];
+  stub.prototype.executeTool = async (tc) => ({
+    tool: tc.name,
+    result: JSON.stringify([{ pod_name: "web-1" }, { pod_name: "batch-1" }]),
+  });
+
+  appServer = app.listen(0, "127.0.0.1");
+  await new Promise<void>((resolve) => appServer.once("listening", () => resolve()));
+  appURL = `http://127.0.0.1:${(appServer.address() as AddressInfo).port}`;
+});
+
+after(async () => {
+  await new Promise<void>((resolve) => appServer.close(() => resolve()));
+  await new Promise<void>((resolve) => anthropicMock.close(() => resolve()));
+});
+
+function checkGolden(name: string, got: string) {
+  const p = path.join(contractDir, name);
+  if (process.env.UPDATE_GOLDEN) {
+    fs.mkdirSync(contractDir, { recursive: true });
+    fs.writeFileSync(p, got);
+    return;
+  }
+  const want = fs.readFileSync(p, "utf8");
+  assert.equal(
+    got,
+    want,
+    `SSE CONTRACT DRIFT in ${name}. The frontend parser tests against this exact recording; if the change is intentional, regenerate with UPDATE_GOLDEN=1 and update both sides in the same PR.`,
+  );
+}
+
+test("G3: full session (thinking + tool round + text + done) matches recording", async () => {
+  mockCalls = 0;
+  failNext = false;
+  const res = await fetch(`${appURL}/api/chat/stream`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ message: "how many pods?", provider: "anthropic" }),
+  });
+  assert.equal(res.status, 200);
+  const body = await res.text();
+
+  checkGolden("sse_session.golden.txt", body);
+
+  // Decoded event list — the canonical sequence the frontend must produce.
+  const events = body
+    .split("\n")
+    .filter((l) => l.startsWith("data: "))
+    .map((l) => JSON.parse(l.slice(6)));
+  checkGolden("sse_events.golden.json", JSON.stringify(events, null, 2) + "\n");
+});
+
+test("G3: upstream overload surfaces as a terminal error frame", async () => {
+  failNext = true;
+  try {
+    const res = await fetch(`${appURL}/api/chat/stream`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ message: "hi", provider: "anthropic" }),
+    });
+    const body = await res.text();
+    checkGolden("sse_error.golden.txt", body);
+    assert.match(body, /event: error\n/);
+  } finally {
+    failNext = false;
+  }
+});


### PR DESCRIPTION
Task G3 of SIMPLIFICATION-GOAL.md (gates, §3).

- **Recordings** (`llm-bridge/contract/`): `sse_session.golden.txt` (raw SSE bytes of a full session: thinking → tool_use → tool_result → streamed text → done), `sse_events.golden.json` (canonical decoded sequence), `sse_error.golden.txt` (upstream 529 → terminal error frame). Produced through the real Express app + real provider loop against a mocked Anthropic upstream and stubbed tool executor.
- **Consumer side**: frontend gains vitest; `aiApi.contract.test.ts` replays the same bytes (in 40-byte chunks, exercising incremental buffering) through the real parser and must produce the identical handler-level sequence.
- **Cleanup**: dead `conversationId` removed from frontend stream types (matches the pinned `done` frame); test files excluded from the app tsc build.
- **CI**: new `test-llm-bridge` + `test-frontend` jobs — first CI test coverage for both components; each triggers on changes to either side of the contract. `setup-node` pinned to the verified v5 SHA.

Verified locally: llm-bridge 61 tests, frontend 2 contract tests + lint + build, all green.

https://claude.ai/code/session_019iDb3ymyUBM3NZPRd5M39U