### PR TITLE
feat(llm-bridge): run MCP tools in-process, drop the mcp-server hop (WS-B)

### DIFF
--- a/charts/kguardian/templates/llm-bridge/deployment.yaml
+++ b/charts/kguardian/templates/llm-bridge/deployment.yaml
@@ -48,14 +48,16 @@ spec:
           env:
             - name: PORT
               value: "{{ .Values.llmBridge.container.port }}"
-            # llm-bridge no longer talks to the broker directly — all
-            # tool calls route through the MCP server, which in turn
-            # talks to the broker. BROKER_URL was previously set here
-            # but never read by the llm-bridge process; removed to
-            # avoid the false impression that overriding it changes
-            # behavior. (The mcp-server has its own BROKER_URL.)
-            - name: MCP_SERVER_URL
-              value: "http://{{ .Values.mcpServer.service.name }}.{{ include "kguardian.namespace" . }}.svc.cluster.local:{{ .Values.mcpServer.service.port }}"
+            # WS-B: the assistant runs the 12 tools in-process and reaches the
+            # data plane directly — no mcp-server hop. It calls the broker for
+            # the 10 data tools and the advisor for the 2 generate tools.
+            - name: BROKER_URL
+              value: "http://{{ .Values.broker.service.name }}.{{ include "kguardian.namespace" . }}.svc.cluster.local:{{ .Values.broker.service.port }}"
+            {{- if include "kguardian.advisorEnabled" . }}
+            - name: ADVISOR_URL
+              value: "http://{{ .Values.advisor.service.name }}.{{ include "kguardian.namespace" . }}.svc.cluster.local:{{ .Values.advisor.service.port }}"
+            {{- end }}
+            {{- include "kguardian.brokerAuthEnv" . | nindent 12 }}
             - name: NODE_ENV
               value: "production"
             {{- if .Values.llmBridge.secrets.openai.enabled }}

--- a/llm-bridge/package-lock.json
+++ b/llm-bridge/package-lock.json
@@ -10,7 +10,6 @@
       "license": "BUSL-1.1",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.115.0",
-        "@modelcontextprotocol/sdk": "^1.23.0",
         "axios": "^1.7.9",
         "cors": "^2.8.5",
         "dotenv": "^17.0.0",
@@ -616,18 +615,6 @@
         "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
-    "node_modules/@hono/node-server": {
-      "version": "1.19.9",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.9.tgz",
-      "integrity": "sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.14.1"
-      },
-      "peerDependencies": {
-        "hono": "^4"
-      }
-    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -679,68 +666,6 @@
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
       }
-    },
-    "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
-      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@hono/node-server": "^1.19.9",
-        "ajv": "^8.17.1",
-        "ajv-formats": "^3.0.1",
-        "content-type": "^1.0.5",
-        "cors": "^2.8.5",
-        "cross-spawn": "^7.0.5",
-        "eventsource": "^3.0.2",
-        "eventsource-parser": "^3.0.0",
-        "express": "^5.2.1",
-        "express-rate-limit": "^8.2.1",
-        "hono": "^4.11.4",
-        "jose": "^6.1.3",
-        "json-schema-typed": "^8.0.2",
-        "pkce-challenge": "^5.0.0",
-        "raw-body": "^3.0.0",
-        "zod": "^3.25 || ^4.0",
-        "zod-to-json-schema": "^3.25.1"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@cfworker/json-schema": "^4.1.1",
-        "zod": "^3.25 || ^4.0"
-      },
-      "peerDependenciesMeta": {
-        "@cfworker/json-schema": {
-          "optional": true
-        },
-        "zod": {
-          "optional": false
-        }
-      }
-    },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/ajv": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
-      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "license": "MIT"
     },
     "node_modules/@stablelib/base64": {
       "version": "1.0.1",
@@ -1196,45 +1121,6 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
-    "node_modules/ajv-formats": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
-      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "^8.0.0"
-      },
-      "peerDependencies": {
-        "ajv": "^8.0.0"
-      },
-      "peerDependenciesMeta": {
-        "ajv": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/ajv-formats/node_modules/ajv": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/ajv-formats/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "license": "MIT"
-    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -1410,6 +1296,7 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -1809,27 +1696,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/eventsource": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
-      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
-      "license": "MIT",
-      "dependencies": {
-        "eventsource-parser": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/eventsource-parser": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
-      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
     "node_modules/express": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
@@ -1921,6 +1787,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-json-stable-stringify": {
@@ -1942,22 +1809,6 @@
       "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
       "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
       "license": "Unlicense"
-    },
-    "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fastify"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fastify"
-        }
-      ],
-      "license": "BSD-3-Clause"
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -2224,15 +2075,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/hono": {
-      "version": "4.11.9",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.9.tgz",
-      "integrity": "sha512-Eaw2YTGM6WOxA6CXbckaEvslr2Ne4NFsKrvc0v97JD5awbmeBLO5w9Ho9L9kmKonrwF9RJlW6BxT1PVv/agBHQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=16.9.0"
-      }
-    },
     "node_modules/http-errors": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
@@ -2355,16 +2197,8 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
       "license": "ISC"
-    },
-    "node_modules/jose": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-6.1.3.tgz",
-      "integrity": "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/panva"
-      }
     },
     "node_modules/json-buffer": {
       "version": "3.0.1",
@@ -2392,12 +2226,6 @@
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/json-schema-typed": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
-      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
-      "license": "BSD-2-Clause"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -2650,6 +2478,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -2676,15 +2505,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/pkce-challenge": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
-      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=16.20.0"
       }
     },
     "node_modules/prelude-ls": {
@@ -2782,15 +2602,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/require-from-string": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/router": {
@@ -2916,6 +2727,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -2928,6 +2740,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -3213,6 +3026,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -3260,15 +3074,6 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "node_modules/zod-to-json-schema": {
-      "version": "3.25.1",
-      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz",
-      "integrity": "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==",
-      "license": "ISC",
-      "peerDependencies": {
-        "zod": "^3.25 || ^4"
       }
     }
   }

--- a/llm-bridge/package.json
+++ b/llm-bridge/package.json
@@ -23,7 +23,6 @@
   "license": "BUSL-1.1",
   "dependencies": {
     "@anthropic-ai/sdk": "^0.115.0",
-    "@modelcontextprotocol/sdk": "^1.23.0",
     "axios": "^1.7.9",
     "cors": "^2.8.5",
     "dotenv": "^17.0.0",

--- a/llm-bridge/src/availableProviders.test.ts
+++ b/llm-bridge/src/availableProviders.test.ts
@@ -89,7 +89,7 @@ test("availableProvidersFromEnv: ignores unrelated env vars", () => {
   const got = availableProvidersFromEnv({
     PATH: "/usr/bin",
     HOME: "/home/foo",
-    MCP_SERVER_URL: "http://x:8081",
+    BROKER_URL: "http://x:9090",
   });
   assert.deepEqual(got, []);
 });

--- a/llm-bridge/src/index.ts
+++ b/llm-bridge/src/index.ts
@@ -237,7 +237,7 @@ function startServer() {
   const server = app.listen(port, () => {
     const availableProviders = getAvailableProviders();
     log.info(`LLM Bridge listening on port ${port}`);
-    log.info(`MCP Server URL: ${process.env.MCP_SERVER_URL || "(default)"}`);
+    log.info(`Broker URL: ${process.env.BROKER_URL || "(default)"} · Advisor URL: ${process.env.ADVISOR_URL || "(default)"}`);
     log.info(`Available providers: ${availableProviders.join(", ") || "NONE"}`);
 
     if (availableProviders.length === 0) {
@@ -248,7 +248,6 @@ function startServer() {
 
   // Graceful shutdown
   const shutdown = () => {
-    mcpClient.close();
     server.close();
     process.exit(0);
   };

--- a/llm-bridge/src/mcpClient.test.ts
+++ b/llm-bridge/src/mcpClient.test.ts
@@ -1,34 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { McpClient, resolveMcpUrl } from "./mcpClient.js";
-
-const DEFAULT_URL = "http://kguardian-mcp-server.kguardian.svc.cluster.local:8081";
-
-test("resolveMcpUrl prefers explicit arg over env over default", () => {
-  assert.equal(resolveMcpUrl("http://from-arg:8081", "http://from-env:8081"), "http://from-arg:8081");
-  assert.equal(resolveMcpUrl(undefined, "http://from-env:8081"), "http://from-env:8081");
-  assert.equal(resolveMcpUrl(undefined, undefined), DEFAULT_URL);
-});
-
-test("resolveMcpUrl trims whitespace from arg and env", () => {
-  // Surrounding whitespace must not slip through. Pre-fix, a
-  // MCP_SERVER_URL=" http://x:8081 " env var (typical Helm YAML
-  // literal artefact) would store the spaced value and produce a
-  // cryptic `TypeError: Invalid URL` from `new URL(this.mcpUrl)`
-  // inside the StreamableHTTPClientTransport — far from the
-  // env-var read site.
-  assert.equal(resolveMcpUrl("  http://from-arg:8081  "), "http://from-arg:8081");
-  assert.equal(resolveMcpUrl(undefined, "\thttp://from-env:8081\n"), "http://from-env:8081");
-});
-
-test("resolveMcpUrl treats whitespace-only as empty (falls through)", () => {
-  // A whitespace-only arg/env must NOT pass the truthy check;
-  // resolution should fall through to the next candidate.
-  assert.equal(resolveMcpUrl("   ", "http://from-env:8081"), "http://from-env:8081");
-  assert.equal(resolveMcpUrl(undefined, "   "), DEFAULT_URL);
-  assert.equal(resolveMcpUrl("  ", "  "), DEFAULT_URL);
-  assert.equal(resolveMcpUrl("", ""), DEFAULT_URL);
-});
+import { McpClient } from "./mcpClient.js";
+import { TOOL_DEFS } from "./tools/registry.js";
 
 // McpClient.parseContext is the gate that turns the LLM's free-form
 // context blob into a structured filter. A regression here either:
@@ -86,40 +59,16 @@ test("parseContext handles pre-empty arrays", () => {
   assert.deepEqual(got, { namespace: undefined, podNames: [] });
 });
 
-// The MCP server is the single source of truth for the tool surface — there is
-// no static fallback. Tool discovery failing (or returning nothing) must make
-// the request fail clearly, never silently answer the user with zero tools.
+// WS-B: tools are sourced from the in-repo registry (no MCP discovery hop).
+// getToolsCached must surface every registered tool in provider format.
 
-test("getToolsCached throws on an empty tool set (no static fallback)", async () => {
-  const C = McpClient as unknown as {
-    getToolDefinitionsFromMCP: () => Promise<unknown[]>;
-    toolDefsCache: unknown;
-  };
-  const orig = C.getToolDefinitionsFromMCP;
-  C.toolDefsCache = null;
-  C.getToolDefinitionsFromMCP = async () => [];
-  try {
-    await assert.rejects(() => McpClient.getToolsCached(), /no tools/);
-  } finally {
-    C.getToolDefinitionsFromMCP = orig;
-    C.toolDefsCache = null;
-  }
-});
-
-test("getToolsCached propagates a discovery failure (no static fallback)", async () => {
-  const C = McpClient as unknown as {
-    getToolDefinitionsFromMCP: () => Promise<unknown[]>;
-    toolDefsCache: unknown;
-  };
-  const orig = C.getToolDefinitionsFromMCP;
-  C.toolDefsCache = null;
-  C.getToolDefinitionsFromMCP = async () => {
-    throw new Error("MCP server unreachable");
-  };
-  try {
-    await assert.rejects(() => McpClient.getToolsCached(), /MCP server unreachable/);
-  } finally {
-    C.getToolDefinitionsFromMCP = orig;
-    C.toolDefsCache = null;
+test("getToolsCached returns every registered tool in provider format", async () => {
+  const tools = await McpClient.getToolsCached();
+  assert.equal(tools.length, TOOL_DEFS.length);
+  assert.equal(tools.length, 12);
+  for (const t of tools) {
+    assert.equal(typeof t.name, "string");
+    assert.equal(typeof t.description, "string");
+    assert.ok(t.parameters, `tool ${t.name} must carry a parameter schema`);
   }
 });

--- a/llm-bridge/src/mcpClient.ts
+++ b/llm-bridge/src/mcpClient.ts
@@ -1,268 +1,65 @@
-import { Client } from "@modelcontextprotocol/sdk/client/index.js";
-import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import { log } from "./logger.js";
 import type { ToolCall, ToolResult } from "./types/index.js";
+import { TOOL_DEFS } from "./tools/registry.js";
+import { executeInProcessTool } from "./tools/execute.js";
+
+// WS-B: the assistant's 12 tools run IN-PROCESS here — this class no longer
+// talks to a separate mcp-server over MCP transport; it reaches the broker and
+// advisor directly (src/tools/*). The public surface (executeTool,
+// getToolsCached, getSystemPrompt, parseContext) is unchanged so the provider
+// loops are untouched, and the src/tools parity test proves every tool
+// reproduces the mcp-server's outputs against the shared G1 fixtures.
+//
+// NOTE: the class keeps the name McpClient for a focused, reviewable diff; a
+// rename to `Assistant` is a trivial follow-up. The tool set is still exposed
+// as MCP tools to the model — only the transport (a network hop to a Go
+// service) is gone.
 
 export interface ParsedContext {
   namespace?: string;
   podNames?: string[];
 }
 
-/**
- * Resolve the MCP server URL from (in priority order): an explicit
- * constructor argument, the MCP_SERVER_URL env var, or the in-cluster
- * default. Each candidate is trim-empty defended so a whitespace-only
- * value (typical Helm YAML literal artefact, or a misconfigured
- * env-from-secret with stray whitespace) doesn't pass the truthy
- * check and surface later as a cryptic `TypeError: Invalid URL` from
- * `new URL(...)` inside the transport — far from the env-var read
- * site. Same defense-in-depth class as the mcp-server's
- * NewMcpClient TrimSpace and the broker's AuditClient::from_env
- * trim.
- *
- * Exported as a pure helper so the resolution contract can be unit-
- * tested without instantiating McpClient (which would also try to
- * import MCP transports just to test a string resolution).
- */
-export function resolveMcpUrl(arg?: string, envUrl?: string): string {
-  const argTrimmed = arg?.trim();
-  const envTrimmed = envUrl?.trim();
-  return argTrimmed || envTrimmed || "http://kguardian-mcp-server.kguardian.svc.cluster.local:8081";
-}
-
 export class McpClient {
-  private mcpClient: Client | null = null;
-  private mcpUrl: string;
-  private mcpInitialized: boolean = false;
-  private initPromise: Promise<void> | null = null;
-  private static toolDefsCache: any[] | null = null;
+  private static toolDefsCache: { name: string; description: string; parameters: unknown }[] | null = null;
 
   /**
-   * The class is named McpClient for historical reasons — before
-   * the MCP refactor it talked directly to the broker. Today all
-   * tool calls route through the MCP server (this.mcpUrl), and the
-   * broker is reached via the MCP server's own broker client. So
-   * only `mcpUrl` is meaningful; the previous `brokerUrl` parameter
-   * was declared but never stored — the static getToolDefinitionsFromMCP
-   * helper already acknowledged this by passing "" for it.
-   */
-  constructor(mcpUrl?: string) {
-    this.mcpUrl = resolveMcpUrl(mcpUrl, process.env.MCP_SERVER_URL);
-  }
-
-  /**
-   * Initialize MCP client connection (with mutex to prevent race conditions)
-   */
-  async initializeMCPClient(): Promise<void> {
-    if (this.mcpInitialized) return;
-    if (!this.initPromise) {
-      this.initPromise = this._doInit();
-    }
-    return this.initPromise;
-  }
-
-  private async _doInit(): Promise<void> {
-    try {
-      // Create Streamable HTTP transport (MCP spec 2025-03-26)
-      const transport = new StreamableHTTPClientTransport(new URL(this.mcpUrl));
-
-      // Create MCP client
-      this.mcpClient = new Client(
-        {
-          name: "kguardian-llm-bridge",
-          version: "1.2.1",
-        },
-        {
-          capabilities: {},
-        }
-      );
-
-      // Connect to MCP server
-      await this.mcpClient.connect(transport);
-      this.mcpInitialized = true;
-
-      log.info(`Connected to MCP server at ${this.mcpUrl}`);
-    } catch (error) {
-      // Reset the promise so future calls can retry
-      this.initPromise = null;
-      log.error("Failed to initialize MCP client:", error);
-      throw new Error(
-        `Failed to connect to MCP server at ${this.mcpUrl}: ${error instanceof Error ? error.message : String(error)}`,
-        { cause: error }
-      );
-    }
-  }
-
-  /**
-   * Reset MCP client connection state so the next call will reconnect
-   */
-  private resetConnection(): void {
-    this.mcpClient = null;
-    this.mcpInitialized = false;
-    this.initPromise = null;
-    log.info("MCP client connection reset — will reconnect on next call");
-  }
-
-  /**
-   * Check if an error is a connection-level failure worth retrying
-   */
-  private isConnectionError(error: unknown): boolean {
-    if (!(error instanceof Error)) return false;
-    const msg = error.message.toLowerCase();
-    return (
-      msg.includes("econnrefused") ||
-      msg.includes("econnreset") ||
-      msg.includes("socket hang up") ||
-      msg.includes("fetch failed") ||
-      msg.includes("network error")
-    );
-  }
-
-  /**
-   * Execute a tool call by routing to the MCP server.
-   * On connection errors, resets state and retries once.
+   * Execute a tool call in-process. Returns the same ToolResult shape the
+   * providers already consume: { data } on success (parsed JSON when the tool
+   * returned JSON, otherwise the raw string), or { data: null, error } on
+   * failure — a failing tool never throws, so one bad call can't abort the
+   * model's tool round.
    */
   async executeTool(toolCall: ToolCall): Promise<ToolResult> {
-    return this.executeToolInner(toolCall, true);
-  }
-
-  private async executeToolInner(
-    toolCall: ToolCall,
-    allowRetry: boolean
-  ): Promise<ToolResult> {
+    const { name, arguments: args } = toolCall;
+    log.debug(`Executing tool in-process: ${name}`);
+    const result = await executeInProcessTool(name, args || {});
+    if (result.isError) {
+      return { data: null, error: result.text };
+    }
     try {
-      // Ensure MCP client is initialized
-      await this.initializeMCPClient();
-
-      if (!this.mcpClient) {
-        throw new Error("MCP client not initialized");
-      }
-
-      const { name, arguments: args } = toolCall;
-
-      // Per-tool-call entry + exit logs at debug level. A chatty LLM
-      // can call tools dozens of times per session and the exit log
-      // (with the full result body) is multi-KB per call — far too
-      // verbose for steady-state INFO. Operators wanting per-call
-      // tracing run with LOG_LEVEL=debug.
-      log.debug(`Calling MCP tool: ${name}`);
-
-      // Call the tool using MCP SDK
-      const result = await this.mcpClient.callTool({
-        name,
-        arguments: args || {},
-      });
-
-      log.debug(`MCP tool ${name} returned:`, result);
-
-      // MCP SDK returns result with content array
-      if (result.content && Array.isArray(result.content)) {
-        // Extract text content from the response
-        const textContent = result.content.find((item) => item.type === "text");
-        if (textContent && "text" in textContent) {
-          try {
-            // Try to parse as JSON
-            const parsedData = JSON.parse(textContent.text);
-            return { data: parsedData };
-          } catch {
-            // If not JSON, return as-is
-            return { data: textContent.text };
-          }
-        }
-      }
-
-      // If we get here, return the raw result
-      return { data: result };
-    } catch (error) {
-      // On connection errors, reset and retry once
-      if (allowRetry && this.isConnectionError(error)) {
-        log.warn(
-          `Connection error calling MCP tool ${toolCall.name}, resetting and retrying:`,
-          error instanceof Error ? error.message : error
-        );
-        this.resetConnection();
-        return this.executeToolInner(toolCall, false);
-      }
-
-      log.error(`Error calling MCP tool ${toolCall.name}:`, error);
-      return {
-        data: null,
-        error: error instanceof Error ? error.message : String(error),
-      };
+      return { data: JSON.parse(result.text) };
+    } catch {
+      // Advisor tools return YAML/JSON text that is not necessarily a JSON
+      // object — forward it as-is.
+      return { data: result.text };
     }
   }
 
   /**
-   * Get available tools from MCP server
+   * Tool definitions for the LLM providers, sourced from the single in-repo
+   * registry. Kept async + cached to preserve the previous call signature.
    */
-  async getAvailableTools(): Promise<any[]> {
-    try {
-      await this.initializeMCPClient();
-
-      if (!this.mcpClient) {
-        throw new Error("MCP client not initialized");
-      }
-
-      const response = await this.mcpClient.listTools();
-      return response.tools || [];
-    } catch (error) {
-      // Propagate rather than swallow. The MCP server is the single source of
-      // truth for the tool surface; if discovery fails the assistant has no
-      // grounded tools, and answering ungrounded is worse than failing. The
-      // caller surfaces a clear "tool server unreachable" error to the user.
-      log.error("Error fetching tools from MCP server:", error);
-      throw error instanceof Error ? error : new Error(String(error));
-    }
-  }
-
-  /**
-   * Get tool definitions for LLMs
-   * This fetches the actual tools from the MCP server dynamically
-   */
-  static async getToolDefinitionsFromMCP(mcpUrl?: string): Promise<any[]> {
-    const client = new McpClient(mcpUrl);
-    try {
-      const tools = await client.getAvailableTools();
-
-      // Convert MCP tool format to LLM provider format.
-      return tools.map((tool: any) => ({
-        name: tool.name,
-        description: tool.description || "",
-        parameters: tool.inputSchema || {
-          type: "object",
-          properties: {},
-          required: [],
-        },
-      }));
-    } finally {
-      // Errors propagate (no static fallback) — the MCP server is the single
-      // source of truth for the tool surface.
-      await client.close();
-    }
-  }
-
-  /**
-   * Get tool definitions with caching. The MCP server is the single source of
-   * truth — there is no static fallback. If discovery fails or returns nothing,
-   * this throws so the request fails clearly rather than the model answering
-   * without its data tools. Only a successful, non-empty result is cached, so a
-   * transient MCP blip is retried on the next request.
-   */
-  static async getToolsCached(): Promise<any[]> {
+  static async getToolsCached(): Promise<{ name: string; description: string; parameters: unknown }[]> {
     if (McpClient.toolDefsCache) return McpClient.toolDefsCache;
-    const tools = await McpClient.getToolDefinitionsFromMCP();
-    if (!tools.length) {
-      throw new Error(
-        "MCP server returned no tools — the assistant cannot answer without its data tools. Check that the MCP server is reachable (MCP_SERVER_URL).",
-      );
-    }
-    McpClient.toolDefsCache = tools;
-    return tools;
+    McpClient.toolDefsCache = TOOL_DEFS.map((t) => ({
+      name: t.name,
+      description: t.description,
+      parameters: t.parameters,
+    }));
+    return McpClient.toolDefsCache;
   }
 
-  /**
-   * Get system prompt for kguardian AI assistant
-   */
   static getSystemPrompt(context?: ParsedContext): string {
     let prompt = `You are an AI assistant for kguardian, a Kubernetes security monitoring tool.
 
@@ -324,7 +121,7 @@ When a user mentions a pod name, use the appropriate tool immediately. Do NOT as
   }
 
   /**
-   * Parse a JSON context string from the frontend into a typed object
+   * Parse a JSON context string from the frontend into a typed object.
    */
   static parseContext(contextStr?: string): ParsedContext | undefined {
     if (!contextStr) return undefined;
@@ -336,19 +133,6 @@ When a user mentions a pod name, use the appropriate tool immediately. Do NOT as
       };
     } catch {
       return undefined;
-    }
-  }
-
-  /**
-   * Close the MCP client connection
-   */
-  async close(): Promise<void> {
-    if (this.mcpClient) {
-      await this.mcpClient.close();
-      this.mcpClient = null;
-      this.mcpInitialized = false;
-      this.initPromise = null;
-      log.info("MCP client connection closed");
     }
   }
 }

--- a/llm-bridge/src/tools/backendClient.ts
+++ b/llm-bridge/src/tools/backendClient.ts
@@ -1,0 +1,74 @@
+import { log } from "../logger.js";
+
+// Direct HTTP clients to the broker and advisor. WS-B: the assistant reaches
+// the data plane in-process instead of proxying through the mcp-server, so
+// these replace the MCP transport hop. Same endpoints, same optional broker
+// bearer token as the mcp-server used.
+
+const BROKER_TIMEOUT_MS = 90_000; // cluster-wide queries can be large
+const ADVISOR_TIMEOUT_MS = 60_000;
+
+function trimSlash(u: string): string {
+  return u.trim().replace(/\/+$/, "");
+}
+
+export function brokerURL(): string {
+  return trimSlash(process.env.BROKER_URL?.trim() || "http://kguardian-broker.kguardian.svc.cluster.local:9090");
+}
+
+export function advisorURL(): string {
+  return trimSlash(process.env.ADVISOR_URL?.trim() || "http://kguardian-advisor.kguardian.svc.cluster.local:8083");
+}
+
+function brokerAuthHeaders(): Record<string, string> {
+  const token = process.env.BROKER_AUTH_TOKEN?.trim();
+  return token ? { Authorization: `Bearer ${token}` } : {};
+}
+
+async function getWithTimeout(url: string, timeoutMs: number, headers: Record<string, string>, accept: string): Promise<Response> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await fetch(url, { headers: { Accept: accept, ...headers }, signal: controller.signal });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/** GET a broker endpoint and parse JSON. Throws on non-2xx or abort. */
+export async function brokerGetJSON(path: string): Promise<unknown> {
+  const url = `${brokerURL()}${path}`;
+  const resp = await getWithTimeout(url, BROKER_TIMEOUT_MS, brokerAuthHeaders(), "application/json");
+  if (!resp.ok) {
+    log.error(`broker GET ${path} -> ${resp.status}`);
+    throw new Error(`broker returned ${resp.status} for ${path}`);
+  }
+  return resp.json();
+}
+
+/** GET an advisor generate endpoint and return the raw text body (YAML/JSON). */
+export async function advisorGetText(path: string): Promise<string> {
+  const url = `${advisorURL()}${path}`;
+  const resp = await getWithTimeout(url, ADVISOR_TIMEOUT_MS, {}, "text/plain, application/json, application/yaml");
+  if (!resp.ok) {
+    log.error(`advisor GET ${path} -> ${resp.status}`);
+    throw new Error(`advisor returned ${resp.status} for ${path}`);
+  }
+  return resp.text();
+}
+
+/** Build the /audit/verdicts query string, mirroring the mcp-server's three
+ *  namespace modes (cluster-scoped = empty value present; single ns; or absent). */
+export function auditVerdictsQuery(args: {
+  policy?: string; namespace?: string; verdict?: string; direction?: string; limit?: number; cluster_scoped?: boolean;
+}): string {
+  const q = new URLSearchParams();
+  if (args.policy) q.set("policy", args.policy);
+  if (args.cluster_scoped) q.set("namespace", "");
+  else if (args.namespace) q.set("namespace", args.namespace);
+  if (args.verdict) q.set("verdict", args.verdict);
+  if (args.direction) q.set("direction", args.direction);
+  if (typeof args.limit === "number" && args.limit > 0) q.set("limit", String(args.limit));
+  const s = q.toString();
+  return s ? `?${s}` : "";
+}

--- a/llm-bridge/src/tools/compaction.ts
+++ b/llm-bridge/src/tools/compaction.ts
@@ -1,0 +1,109 @@
+// Response compaction — a faithful TypeScript port of the mcp-server's
+// tools/filter.go. The assistant executes the 12 tools in-process now (WS-B);
+// these transforms must produce data structurally identical to what the Go
+// mcp-server produced, which the G1 parity test enforces by replaying the
+// shared backend fixtures. Keep this in lockstep with filter.go until the Go
+// server is retired.
+
+type Rec = Record<string, unknown>;
+
+function isRecord(v: unknown): v is Rec {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+/** Filter a slice of records by a pod_namespace/svc_namespace field. */
+export function filterByNamespace(data: unknown, namespace: string): unknown {
+  if (!namespace) return data;
+  if (!Array.isArray(data)) return data;
+  return data.filter((item) => {
+    if (!isRecord(item)) return false;
+    return item.pod_namespace === namespace || item.svc_namespace === namespace;
+  });
+}
+
+/** Aggregate traffic records into per-pod summaries (compactTrafficSummary). */
+export function compactTrafficSummary(data: unknown): Rec {
+  if (!Array.isArray(data)) {
+    return { total_records: 0, pods: {} };
+  }
+  interface Stats { ingress: number; egress: number; allow: number; drop: number; peers: Set<string>; }
+  const pods = new Map<string, Stats>();
+  let totalDrop = 0;
+
+  for (const item of data) {
+    if (!isRecord(item)) continue;
+    const podName = typeof item.pod_name === "string" ? item.pod_name : "";
+    if (!podName) continue;
+    let s = pods.get(podName);
+    if (!s) { s = { ingress: 0, egress: 0, allow: 0, drop: 0, peers: new Set() }; pods.set(podName, s); }
+
+    const trafficType = typeof item.traffic_type === "string" ? item.traffic_type.toUpperCase() : "";
+    if (trafficType === "INGRESS") s.ingress++;
+    else if (trafficType === "EGRESS") s.egress++;
+
+    if (typeof item.traffic_in_out_ip === "string" && item.traffic_in_out_ip) s.peers.add(item.traffic_in_out_ip);
+
+    const decision = typeof item.decision === "string" ? item.decision.toUpperCase() : "";
+    if (decision === "DROP") { s.drop++; totalDrop++; }
+    else if (decision === "ALLOW") s.allow++;
+  }
+
+  const podSummaries: Rec = {};
+  for (const [name, s] of pods) {
+    podSummaries[name] = {
+      ingress_count: s.ingress,
+      egress_count: s.egress,
+      allow_count: s.allow,
+      drop_count: s.drop,
+      unique_peer_count: s.peers.size,
+    };
+  }
+  return {
+    total_records: data.length,
+    pod_count: pods.size,
+    total_drop_count: totalDrop,
+    pods: podSummaries,
+  };
+}
+
+const POD_KEEP = new Set([
+  "pod_name", "pod_namespace", "pod_ip", "node_name", "is_dead", "pod_identity", "workload_selector_labels",
+]);
+
+function compactPodRecord(m: Rec): Rec {
+  const slim: Rec = {};
+  for (const k of Object.keys(m)) if (POD_KEEP.has(k)) slim[k] = m[k];
+  return slim;
+}
+
+/** Strip heavyweight fields from a pod record or array of them. */
+export function compactPodsSummary(data: unknown): unknown {
+  if (isRecord(data)) return compactPodRecord(data);
+  if (!Array.isArray(data)) return data;
+  return data.map((item) => (isRecord(item) ? compactPodRecord(item) : item));
+}
+
+/** Drop pod records with is_dead === true (absent/non-bool treated as alive). */
+export function filterAlivePods(data: unknown): unknown {
+  if (!Array.isArray(data)) return data;
+  return data.filter((item) => !(isRecord(item) && item.is_dead === true));
+}
+
+function compactSvcRecord(m: Rec): Rec {
+  const keep = new Set(["svc_name", "svc_namespace", "svc_ip", "time_stamp"]);
+  const slim: Rec = {};
+  for (const k of Object.keys(m)) if (keep.has(k)) slim[k] = m[k];
+  const spec = m.service_spec;
+  if (isRecord(spec) && isRecord(spec.spec)) {
+    if ("selector" in spec.spec) slim.service_selector = spec.spec.selector;
+    if ("ports" in spec.spec) slim.service_ports = spec.spec.ports;
+  }
+  return slim;
+}
+
+/** Strip service_spec to selector/ports; single record or array. */
+export function compactSvc(data: unknown): unknown {
+  if (isRecord(data)) return compactSvcRecord(data);
+  if (!Array.isArray(data)) return data;
+  return data.map((item) => (isRecord(item) ? compactSvcRecord(item) : item));
+}

--- a/llm-bridge/src/tools/execute.ts
+++ b/llm-bridge/src/tools/execute.ts
@@ -1,0 +1,73 @@
+import { log } from "../logger.js";
+import { TOOL_DEFS } from "./registry.js";
+import { brokerGetJSON, advisorGetText, auditVerdictsQuery } from "./backendClient.js";
+import {
+  filterByNamespace, compactTrafficSummary, compactPodsSummary, filterAlivePods, compactSvc,
+} from "./compaction.js";
+
+// In-process tool execution (WS-B). Each of the 12 tools is a fetch from the
+// broker or advisor followed by the exact compaction the mcp-server applied
+// (tools/*.go handlers). The G1 parity test replays the shared backend
+// fixtures through executeInProcessTool and asserts the results match the Go
+// server's recorded outputs.
+
+const s = (v: unknown): string => (typeof v === "string" ? v : "");
+const enc = encodeURIComponent;
+
+export interface InProcessResult {
+  text: string;
+  isError: boolean;
+}
+
+type Handler = (args: Record<string, unknown>) => Promise<unknown>;
+
+const handlers: Record<string, Handler> = {
+  get_pod_network_traffic: (a) => brokerGetJSON(`/pod/traffic/${enc(s(a.pod_name))}`),
+  get_pod_syscalls: (a) => brokerGetJSON(`/pod/syscalls/${enc(s(a.pod_name))}`),
+  get_pod_details: async (a) => compactPodsSummary(await brokerGetJSON(`/pod/ip/${enc(s(a.ip))}`)),
+  get_service_details: async (a) => compactSvc(await brokerGetJSON(`/svc/ip/${enc(s(a.ip))}`)),
+  get_cluster_traffic: async (a) => {
+    const data = await brokerGetJSON(`/pod/traffic`);
+    const summary = compactTrafficSummary(filterByNamespace(data, s(a.namespace)));
+    if (s(a.namespace)) (summary as Record<string, unknown>).filtered_namespace = s(a.namespace);
+    return summary;
+  },
+  get_cluster_pods: async (a) => {
+    const data = await brokerGetJSON(`/pod/info`);
+    return compactPodsSummary(filterAlivePods(filterByNamespace(data, s(a.namespace))));
+  },
+  get_pod_details_by_name: async (a) => compactPodsSummary(await brokerGetJSON(`/pod/name/${enc(s(a.pod_name))}`)),
+  list_services: async (a) => compactSvc(filterByNamespace(await brokerGetJSON(`/svc/info`), s(a.namespace))),
+  get_pods_on_node: async (a) => compactPodsSummary(filterAlivePods(await brokerGetJSON(`/pod/list/${enc(s(a.node))}`))),
+  get_audit_verdicts: (a) =>
+    brokerGetJSON(`/audit/verdicts${auditVerdictsQuery({
+      policy: s(a.policy), namespace: s(a.namespace), verdict: s(a.verdict), direction: s(a.direction),
+      limit: typeof a.limit === "number" ? a.limit : undefined, cluster_scoped: a.cluster_scoped === true,
+    })}`),
+  generate_network_policy: async (a) => {
+    const type = s(a.policy_type) || "kubernetes";
+    return advisorGetText(`/generate/networkpolicy?pod=${enc(s(a.pod_name))}&type=${enc(type)}`);
+  },
+  generate_seccomp_profile: (a) => advisorGetText(`/generate/seccomp?pod=${enc(s(a.pod_name))}`),
+};
+
+const KNOWN = new Set(TOOL_DEFS.map((t) => t.name));
+
+/** Execute a tool in-process. Advisor tools return their raw text body; broker
+ *  tools return compacted JSON serialized to a string — matching what the LLM
+ *  received from the mcp-server. Errors become an is-error result, not a throw,
+ *  so one failing tool never aborts the model's tool round. */
+export async function executeInProcessTool(name: string, args: Record<string, unknown>): Promise<InProcessResult> {
+  if (!KNOWN.has(name)) {
+    return { text: `unknown tool: ${name}`, isError: true };
+  }
+  try {
+    const out = await handlers[name](args ?? {});
+    const text = typeof out === "string" ? out : JSON.stringify(out);
+    return { text, isError: false };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    log.error(`tool ${name} failed:`, msg);
+    return { text: `error executing ${name}: ${msg}`, isError: true };
+  }
+}

--- a/llm-bridge/src/tools/parity.test.ts
+++ b/llm-bridge/src/tools/parity.test.ts
@@ -1,0 +1,80 @@
+import { test, before, after } from "node:test";
+import assert from "node:assert/strict";
+import http from "node:http";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import type { AddressInfo } from "node:net";
+
+import { executeInProcessTool } from "./execute.js";
+import { TOOL_DEFS } from "./registry.js";
+
+// WS-B parity: the in-process tool layer must reproduce the mcp-server's
+// tool-call outputs. Replays the SAME shared fixtures the Go G1 test uses
+// (mcp-server/tools/testdata/contract) and asserts each tool's result equals
+// the Go server's recorded golden — broker tools compared as parsed JSON
+// (serialization/key-order is immaterial; the LLM consumes structure), advisor
+// tools compared as exact text. A drift here means the assistant would answer
+// differently than the mcp-server did.
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const contractDir = path.resolve(here, "../../../mcp-server/tools/testdata/contract");
+
+const fixtures = JSON.parse(fs.readFileSync(path.join(contractDir, "backend_fixtures.json"), "utf8")) as Record<string, unknown>;
+const golden = JSON.parse(fs.readFileSync(path.join(contractDir, "tool_calls.golden.json"), "utf8")) as Record<string, { content: { text: string }[] }>;
+
+// One representative call per tool — mirrors the Go contractCalls list.
+const CALLS: Record<string, Record<string, unknown>> = {
+  get_pod_network_traffic: { pod_name: "web-1" },
+  get_pod_syscalls: { pod_name: "web-1" },
+  get_pod_details: { ip: "10.0.0.1" },
+  get_service_details: { ip: "10.96.0.10" },
+  get_cluster_traffic: {},
+  get_cluster_pods: {},
+  get_pod_details_by_name: { pod_name: "web-1" },
+  list_services: {},
+  get_pods_on_node: { node: "node-a" },
+  get_audit_verdicts: {},
+  generate_network_policy: { pod_name: "web-1" },
+  generate_seccomp_profile: { pod_name: "web-1" },
+};
+
+const ADVISOR_TOOLS = new Set(["generate_network_policy", "generate_seccomp_profile"]);
+
+let server: http.Server;
+
+before(async () => {
+  server = http.createServer((req, res) => {
+    const urlPath = (req.url || "").split("?")[0];
+    // Advisor generate endpoints are keyed in fixtures without the query string.
+    const body = fixtures[urlPath];
+    if (body === undefined) { res.writeHead(404); res.end(); return; }
+    if (typeof body === "string") { res.writeHead(200, { "Content-Type": "text/plain" }); res.end(body); return; }
+    res.writeHead(200, { "Content-Type": "application/json" }); res.end(JSON.stringify(body));
+  });
+  await new Promise<void>((r) => server.listen(0, "127.0.0.1", r));
+  const port = (server.address() as AddressInfo).port;
+  process.env.BROKER_URL = `http://127.0.0.1:${port}`;
+  process.env.ADVISOR_URL = `http://127.0.0.1:${port}`;
+});
+
+after(async () => { await new Promise<void>((r) => server.close(() => r())); });
+
+test("every registered tool has a parity call", () => {
+  for (const t of TOOL_DEFS) assert.ok(CALLS[t.name], `missing parity call for ${t.name}`);
+  assert.equal(Object.keys(CALLS).length, TOOL_DEFS.length);
+});
+
+for (const [tool, args] of Object.entries(CALLS)) {
+  test(`parity: ${tool} reproduces the mcp-server golden`, async () => {
+    const got = await executeInProcessTool(tool, args);
+    assert.equal(got.isError, false, `${tool} errored: ${got.text}`);
+
+    const goldenText = golden[tool].content[0].text;
+    if (ADVISOR_TOOLS.has(tool)) {
+      assert.equal(got.text, goldenText, `${tool} advisor text drift`);
+    } else {
+      assert.deepEqual(JSON.parse(got.text), JSON.parse(goldenText), `${tool} broker data drift`);
+    }
+  });
+}

--- a/llm-bridge/src/tools/registry.ts
+++ b/llm-bridge/src/tools/registry.ts
@@ -1,0 +1,110 @@
+// Single source of truth for the assistant's tool set (WS-B). Ported from the
+// mcp-server's tools/all_tools.go toolDefs — names and descriptions must stay
+// identical (the G1 contract pins them on the Go side during the canary). The
+// provider loops build their provider-specific tool schema from `parameters`;
+// the system-prompt tool guide is generated from this list, so there is now
+// exactly one place a tool is described.
+
+export interface ToolDef {
+  name: string;
+  description: string;
+  // JSON Schema for the tool input, as the LLM providers consume it.
+  parameters: {
+    type: "object";
+    properties: Record<string, { type: string; description: string }>;
+    required: string[];
+  };
+}
+
+const str = (description: string) => ({ type: "string", description });
+
+export const TOOL_DEFS: ToolDef[] = [
+  {
+    name: "get_pod_network_traffic",
+    description:
+      "Get network traffic for a specific pod by name. Returns source/destination IPs, ports, protocols, ingress/egress types, and packet decisions. Use when the user asks about a specific pod's connections or traffic. Requires only pod_name (not namespace-scoped — the broker resolves by name cluster-wide).",
+    parameters: { type: "object", properties: { pod_name: str("The name of the pod to query traffic for") }, required: ["pod_name"] },
+  },
+  {
+    name: "get_pod_syscalls",
+    description:
+      "Get system calls made by a specific pod. Returns syscall names, frequencies, and architecture. Use when the user asks about a pod's syscalls, seccomp profile, or suspicious behavior. Requires only pod_name (not namespace-scoped).",
+    parameters: { type: "object", properties: { pod_name: str("The name of the pod to query syscalls for") }, required: ["pod_name"] },
+  },
+  {
+    name: "get_pod_details",
+    description:
+      "Look up a pod by its IP address. Returns pod name, namespace, IP, and full Kubernetes pod object. Use when the user has an IP address and wants to identify which pod it belongs to. Requires only ip.",
+    parameters: { type: "object", properties: { ip: str("The IP address of the pod to query") }, required: ["ip"] },
+  },
+  {
+    name: "get_service_details",
+    description:
+      "Look up a Kubernetes service by its cluster IP. Returns service name, namespace, IP, ports, and full service spec. Use when the user has a service IP and wants to identify the service. Requires only ip.",
+    parameters: { type: "object", properties: { ip: str("The IP address of the service to query") }, required: ["ip"] },
+  },
+  {
+    name: "get_cluster_traffic",
+    description:
+      "Get a summary of network traffic across the cluster. Returns per-pod counts (ingress/egress, allow/drop, unique peers) plus a cluster-wide total_drop_count — not raw records. Dropped flows (decision=DROP) come from the eBPF network-policy-drop probe, so this also answers 'what traffic is being blocked/dropped'. Accepts an optional namespace filter. Use for overall traffic patterns, 'what pods are communicating', or 'where is traffic being dropped'.",
+    parameters: { type: "object", properties: { namespace: str("Optional Kubernetes namespace to filter results. If omitted, returns a summary of all namespaces.") }, required: [] },
+  },
+  {
+    name: "get_cluster_pods",
+    description:
+      "List pods in the cluster with compact metadata (name, namespace, IP, node, status). Heavyweight fields like pod_obj are stripped. Accepts an optional namespace parameter to filter results. Use when the user asks 'what pods are running' or needs a pod inventory.",
+    parameters: { type: "object", properties: { namespace: str("Optional Kubernetes namespace to filter results. If omitted, returns pods from all namespaces.") }, required: [] },
+  },
+  {
+    name: "get_pod_details_by_name",
+    description:
+      "Look up a pod by its name. Returns identity (name, namespace, IP, node, workload selector labels) with the heavyweight pod_obj stripped. Use when the user names a pod (e.g. from a traffic record) and wants its details — prefer this over get_pod_details, which requires an IP.",
+    parameters: { type: "object", properties: { pod_name: str("The name of the pod to look up") }, required: ["pod_name"] },
+  },
+  {
+    name: "list_services",
+    description:
+      "List Kubernetes services in the cluster with compact metadata (name, namespace, cluster IP, selector, ports). Accepts an optional namespace parameter to filter results. Use when the user asks 'what services exist' or needs a service inventory — get_service_details only resolves a single known IP.",
+    parameters: { type: "object", properties: { namespace: str("Optional Kubernetes namespace to filter results. If omitted, returns services across all namespaces.") }, required: [] },
+  },
+  {
+    name: "get_pods_on_node",
+    description:
+      "List the pods recorded on a specific Kubernetes node (compact metadata: name, namespace, IP, node, workload labels; live pods only). Use for blast-radius / 'what runs on node X' / 'which workloads share a node' questions. Requires node.",
+    parameters: { type: "object", properties: { node: str("The name of the Kubernetes node to list pods for") }, required: ["node"] },
+  },
+  {
+    name: "get_audit_verdicts",
+    description:
+      "Get network-policy evaluation verdicts — flows the AuditNetworkPolicy/AuditClusterNetworkPolicy engine evaluated as Allow or WouldDeny. Returns source/destination pod+namespace, port, protocol, direction, the human-readable reason, and observed_at, newest first. All filters optional: policy, namespace (a single namespace; omit to span all, which includes cluster-scoped), cluster_scoped (true = ONLY cluster-scoped verdicts), verdict ('Allow'|'WouldDeny'), direction ('Ingress'|'Egress'), limit (default 100, max 500). Use for security questions like 'what traffic would be denied', 'why is this flow blocked', or 'show recent policy violations'.",
+    parameters: {
+      type: "object",
+      properties: {
+        policy: str("Optional policy name to filter by (matches an AuditNetworkPolicy or AuditClusterNetworkPolicy by name)."),
+        namespace: str("Optional policy namespace to filter to a single namespace's verdicts. Omit to span all namespaces."),
+        cluster_scoped: { type: "boolean", description: "Set true to return ONLY cluster-scoped verdicts. Takes precedence over namespace." },
+        verdict: str("Optional verdict filter: 'Allow' or 'WouldDeny'."),
+        direction: str("Optional direction filter: 'Ingress' or 'Egress'."),
+        limit: { type: "integer", description: "Max verdicts to return (default 100, max 500)." },
+      },
+      required: [],
+    },
+  },
+  {
+    name: "generate_network_policy",
+    description:
+      "Generate a least-privilege Kubernetes NetworkPolicy (or CiliumNetworkPolicy) for a pod from its observed traffic. Returns ready-to-apply YAML. Parameters: pod_name (required); policy_type ('kubernetes' for a standard NetworkPolicy — the default — or 'cilium'). Use when the user asks to 'generate/create a network policy', 'lock down this pod', or 'restrict traffic for X'. The policy is deterministically synthesised by the advisor from captured flows, not guessed.",
+    parameters: { type: "object", properties: { pod_name: str("The name of the pod to generate a least-privilege network policy for"), policy_type: str("Policy flavour: 'kubernetes' (standard NetworkPolicy, default) or 'cilium' (CiliumNetworkPolicy)") }, required: ["pod_name"] },
+  },
+  {
+    name: "generate_seccomp_profile",
+    description:
+      "Generate a least-privilege seccomp profile for a pod from its observed syscalls. Returns ready-to-use seccomp JSON (allow-lists the observed syscalls, denies the rest). Parameter: pod_name (required). Use when the user asks to 'generate/create a seccomp profile' or 'restrict syscalls for X'.",
+    parameters: { type: "object", properties: { pod_name: str("The name of the pod to generate a seccomp profile for") }, required: ["pod_name"] },
+  },
+];
+
+/** Build the system-prompt tool guide from the registry — one source of truth. */
+export function toolSelectionGuide(): string {
+  return TOOL_DEFS.map((t) => `- ${t.name}: ${t.description}`).join("\n");
+}


### PR DESCRIPTION
Task WS-B of SIMPLIFICATION-GOAL.md — the assistant merge. The assistant now runs all 12 tools **in-process** instead of proxying through the separate Go mcp-server over MCP transport. −1 deployment, −1 network hop, and the "tool path deployed-but-silently-off" failure class (the WS0 incident in the sibling charter) becomes structurally impossible.

## Parity is proven, not assumed
`llm-bridge/src/tools/parity.test.ts` replays the **same shared fixtures the Go G1 contract test uses** (`mcp-server/tools/testdata/contract`) through the in-process executor and asserts every one of the 12 tools reproduces the mcp-server's recorded output — broker tools compared as parsed JSON, advisor tools as exact text. All 12 pass. This is the G1 gate satisfied from the TS side.

## What changed
- **New `src/tools/`**: `registry.ts` (12 tool defs — single source, ported from `all_tools.go`), `compaction.ts` (faithful port of `filter.go`), `backendClient.ts` (direct broker/advisor HTTP + broker bearer token + audit query modes), `execute.ts` (dispatch).
- **`McpClient` internals only**: swapped MCP transport → in-process dispatch; public API (`executeTool`/`getToolsCached`/`getSystemPrompt`/`parseContext`) unchanged, so the four provider loops and the G3 SSE contract are untouched. `@modelcontextprotocol/sdk` dependency removed. (Class keeps its name for a focused diff; rename to `Assistant` is a trivial follow-up.)
- **Chart**: llm-bridge gets `BROKER_URL` + `ADVISOR_URL` (+ broker auth), no longer references the mcp-server Service.

## Canary-safe
The mcp-server stays deployable — the G5 canary rolls back by image pin. mcp-server retirement is a later step (task after the 7-day window holds).

Verified: tsc + eslint + **70 tests** green (12 parity + G3 SSE contract + provider/context suites); `helm lint` + render clean, zero `MCP_SERVER_URL` in the rendered llm-bridge.

https://claude.ai/code/session_019iDb3ymyUBM3NZPRd5M39U
