### PR TITLE
test(chart): G4 values-compatibility gate

### DIFF
--- a/.github/workflows/charts-lint.yaml
+++ b/.github/workflows/charts-lint.yaml
@@ -44,6 +44,14 @@ jobs:
         if: steps.list-changed.outputs.changed == 'true'
         run: ct lint --config .github/ct.yaml --target-branch ${{ github.event.repository.default_branch }}
 
+      # G4 gate (SIMPLIFICATION-GOAL.md §3): render the chart with the value
+      # sets real operators run — legacy per-component AI flags, the ai.enabled
+      # umbrella, external DB, broker auth — and assert each still produces the
+      # expected workloads. Guards upgrade-compatibility; fast, no cluster.
+      - name: Values-compatibility check (G4)
+        if: steps.list-changed.outputs.changed == 'true'
+        run: ./test/helm-values-compat.sh
+
       - name: Create kind cluster
         if: steps.list-changed.outputs.changed == 'true'
         uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0

--- a/test/helm-values-compat.sh
+++ b/test/helm-values-compat.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# G4 chart values-compatibility gate (SIMPLIFICATION-GOAL.md §3).
+#
+# Renders the CURRENT chart with the value sets real operators are running —
+# especially the legacy per-component AI flags that predate the ai.enabled
+# umbrella — and asserts each still renders and produces the expected
+# workloads. This guards the charter's "upgrade for a year without a migration
+# guide" promise: a `helm upgrade` onto the new chart with an old values file
+# must never break. A fast template-render check (no cluster), complementing
+# the ct install-on-kind job.
+set -euo pipefail
+
+CHART="$(cd "$(dirname "$0")/../charts/kguardian" && pwd)"
+fail=0
+
+# render <name> <helm-args...> — template the chart, capture output or fail.
+render() {
+  local name="$1"; shift
+  if ! OUT="$(helm template compat "$CHART" "$@" 2>/dev/null)"; then
+    echo "FAIL [$name]: chart did not render with: $*"
+    fail=1
+    return 1
+  fi
+  return 0
+}
+
+# assert_has <label> <needle> — OUT must contain needle.
+assert_has() { grep -q "$2" <<<"$OUT" || { echo "FAIL [$1]: expected to find '$2'"; fail=1; }; }
+# assert_absent <label> <needle> — OUT must NOT contain needle.
+assert_absent() { grep -q "$2" <<<"$OUT" && { echo "FAIL [$1]: did not expect '$2'"; fail=1; } || true; }
+# assert_deploys <label> <n> — exactly n Deployment workloads.
+assert_deploys() {
+  local got; got="$(grep -c '^kind: Deployment' <<<"$OUT" || true)"
+  [ "$got" = "$2" ] || { echo "FAIL [$1]: expected $2 Deployments, got $got"; fail=1; }
+}
+
+echo "G4 chart values-compatibility check"
+
+# 1. Defaults: core only, no AI workloads.
+render "defaults" && {
+  assert_deploys "defaults" 4
+  assert_has     "defaults" "kguardian-broker"
+  assert_absent  "defaults" "kguardian-llm-bridge"
+  assert_absent  "defaults" "kguardian-mcp-server"
+}
+
+# 2. LEGACY per-component AI flags (pre-ai.enabled operators) must still work.
+render "legacy-ai-flags" \
+  --set llmBridge.enabled=true --set mcpServer.enabled=true --set advisor.enabled=true && {
+  assert_deploys "legacy-ai-flags" 7
+  assert_has     "legacy-ai-flags" "kguardian-llm-bridge"
+  assert_has     "legacy-ai-flags" "kguardian-mcp-server"
+  assert_has     "legacy-ai-flags" "kguardian-advisor"
+}
+
+# 3. New ai.enabled umbrella must render the SAME AI stack as the legacy flags.
+render "ai-umbrella" --set ai.enabled=true && {
+  assert_deploys "ai-umbrella" 7
+  assert_has     "ai-umbrella" "kguardian-llm-bridge"
+  assert_has     "ai-umbrella" "kguardian-mcp-server"
+  assert_has     "ai-umbrella" "kguardian-advisor"
+}
+
+# 4. External database (database.enabled=false) must render with no bundled DB.
+render "external-db" \
+  --set database.enabled=false --set database.external.host=pg.example.com && {
+  # External DB: core drops from 4 Deployments to 3 (no bundled postgres).
+  # The kguardian-db-credentials Secret still renders (it holds the external
+  # creds), so assert on the workload count, not the name string.
+  assert_deploys "external-db" 3
+  assert_has     "external-db" "kguardian-broker"
+}
+
+# 5. Broker bearer-token auth must render given the required existingSecret.
+render "broker-auth" \
+  --set broker.auth.enabled=true --set broker.auth.existingSecret=kg-broker-token && {
+  assert_has "broker-auth" "kguardian-broker"
+}
+
+if [ "$fail" -ne 0 ]; then
+  echo "G4 values-compatibility check FAILED"
+  exit 1
+fi
+echo "G4 values-compatibility check passed"


### PR DESCRIPTION
Task G4 of SIMPLIFICATION-GOAL.md (§3). A fast template-render check that renders the chart with the value sets real operators run and asserts each still produces the expected workloads:

- **defaults** → core only (4 Deployments, no AI)
- **legacy per-component AI flags** (`llmBridge/mcpServer/advisor.enabled`, pre-umbrella) → full 7-workload AI stack
- **`ai.enabled` umbrella** → the identical 7-workload stack (parity with legacy)
- **external DB** → 3 core Deployments, no bundled postgres
- **broker auth** → renders with the required existingSecret

Guards the charter's "upgrade for a year without a migration guide" promise — a `helm upgrade` onto the new chart with an old values file must never break. Wired into charts-lint (fast, no cluster) alongside the existing ct install-on-kind job. Verified all five scenarios pass locally. Test-only; cuts no release (freeze).

https://claude.ai/code/session_019iDb3ymyUBM3NZPRd5M39U