### PR TITLE
refactor(llm-bridge): generate seccomp profiles in-process

### DIFF
--- a/llm-bridge/src/tools/execute.ts
+++ b/llm-bridge/src/tools/execute.ts
@@ -4,6 +4,7 @@ import { brokerGetJSON, advisorGetText, auditVerdictsQuery } from "./backendClie
 import {
   filterByNamespace, compactTrafficSummary, compactPodsSummary, filterAlivePods, compactSvc,
 } from "./compaction.js";
+import { seccompFromBrokerSyscalls } from "./generators/seccomp.js";
 
 // In-process tool execution (WS-B). Each of the 12 tools is a fetch from the
 // broker or advisor followed by the exact compaction the mcp-server applied
@@ -48,7 +49,13 @@ const handlers: Record<string, Handler> = {
     const type = s(a.policy_type) || "kubernetes";
     return advisorGetText(`/generate/networkpolicy?pod=${enc(s(a.pod_name))}&type=${enc(type)}`);
   },
-  generate_seccomp_profile: (a) => advisorGetText(`/generate/seccomp?pod=${enc(s(a.pod_name))}`),
+  // Seccomp is generated in-process from the pod's observed syscalls — no
+  // advisor hop (WS-C). Returned as pretty JSON; the profile is G2-locked to
+  // the frontend and advisor-CLI generators.
+  generate_seccomp_profile: async (a) => {
+    const syscalls = await brokerGetJSON(`/pod/syscalls/${enc(s(a.pod_name))}`);
+    return JSON.stringify(seccompFromBrokerSyscalls(syscalls), null, 2);
+  },
 };
 
 const KNOWN = new Set(TOOL_DEFS.map((t) => t.name));

--- a/llm-bridge/src/tools/generators/seccomp.fixture.test.ts
+++ b/llm-bridge/src/tools/generators/seccomp.fixture.test.ts
@@ -1,0 +1,33 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { buildSeccompProfile } from "./seccomp.js";
+
+// G2 generator parity — seccomp, assistant side (SIMPLIFICATION-GOAL.md §3).
+// The assistant's in-process seccomp generator asserts the SAME shared
+// fixtures the frontend TS and advisor Go generators do, so the three cannot
+// diverge. Compared as parsed objects.
+
+const fixturesDir = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../../../../test/fixtures/generators/seccomp",
+);
+
+interface Fixture {
+  name: string;
+  input: { syscalls: string[]; arch: string };
+  expected: unknown;
+}
+
+const files = fs.readdirSync(fixturesDir).filter((f) => f.endsWith(".json"));
+
+test("assistant seccomp generator matches every shared fixture", () => {
+  assert.ok(files.length > 0, "no seccomp fixtures found");
+  for (const f of files) {
+    const fx = JSON.parse(fs.readFileSync(path.join(fixturesDir, f), "utf8")) as Fixture;
+    const got = buildSeccompProfile(fx.input.syscalls, fx.input.arch);
+    assert.deepEqual(JSON.parse(JSON.stringify(got)), fx.expected, `${f} (${fx.name})`);
+  }
+});

--- a/llm-bridge/src/tools/generators/seccomp.ts
+++ b/llm-bridge/src/tools/generators/seccomp.ts
@@ -1,0 +1,40 @@
+// In-process seccomp profile generator (WS-C). The assistant generates seccomp
+// profiles itself instead of proxying to the advisor service, so the advisor
+// Deployment can be retired. This is the same pure function as the frontend's
+// buildSeccompProfile (frontend/src/utils/seccompProfileGenerator.ts) and the
+// advisor Go BuildSeccompProfile — all three are locked to the shared G2
+// fixtures (test/fixtures/generators/seccomp), which is what guarantees one
+// behavior everywhere without a shared build (the per-package Docker contexts
+// make a monorepo workspace deploy-risky).
+
+export interface SeccompProfile {
+  defaultAction: string;
+  architectures: string[];
+  syscalls: { names: string[]; action: string }[];
+}
+
+// Rust std::env::consts::ARCH (controller/src/syscall.rs) → seccomp arch tokens.
+const SECCOMP_ARCHITECTURES: Record<string, string[]> = {
+  x86_64: ["SCMP_ARCH_X86_64"],
+  aarch64: ["SCMP_ARCH_ARM64"],
+};
+
+/** Allow-list exactly the observed syscalls, deny the rest. Pure; the allow
+ *  rule is always emitted so the shape is stable even with no syscalls. */
+export function buildSeccompProfile(syscalls: string[], arch: string): SeccompProfile {
+  return {
+    defaultAction: "SCMP_ACT_ERRNO",
+    architectures: SECCOMP_ARCHITECTURES[arch] ?? [],
+    syscalls: [{ names: [...syscalls].sort(), action: "SCMP_ACT_ALLOW" }],
+  };
+}
+
+/** Build a profile from a broker /pod/syscalls response ({ syscalls: "a,b,c",
+ *  arch }). Comma-split matching the advisor, empty entries dropped. */
+export function seccompFromBrokerSyscalls(data: unknown): SeccompProfile {
+  const rec = (data ?? {}) as { syscalls?: unknown; arch?: unknown };
+  const raw = typeof rec.syscalls === "string" ? rec.syscalls : "";
+  const arch = typeof rec.arch === "string" ? rec.arch : "";
+  const names = raw.split(",").map((s) => s.trim()).filter((s) => s.length > 0);
+  return buildSeccompProfile(names, arch);
+}

--- a/llm-bridge/src/tools/parity.test.ts
+++ b/llm-bridge/src/tools/parity.test.ts
@@ -39,7 +39,11 @@ const CALLS: Record<string, Record<string, unknown>> = {
   generate_seccomp_profile: { pod_name: "web-1" },
 };
 
-const ADVISOR_TOOLS = new Set(["generate_network_policy", "generate_seccomp_profile"]);
+// generate_network_policy is still an advisor text passthrough (compared
+// exactly). generate_seccomp_profile now generates in-process (WS-C), so its
+// output is canonical JS-formatted JSON rather than the advisor's text — the
+// PROFILE is identical, so it is compared semantically like the broker tools.
+const ADVISOR_TEXT_TOOLS = new Set(["generate_network_policy"]);
 
 let server: http.Server;
 
@@ -71,7 +75,7 @@ for (const [tool, args] of Object.entries(CALLS)) {
     assert.equal(got.isError, false, `${tool} errored: ${got.text}`);
 
     const goldenText = golden[tool].content[0].text;
-    if (ADVISOR_TOOLS.has(tool)) {
+    if (ADVISOR_TEXT_TOOLS.has(tool)) {
       assert.equal(got.text, goldenText, `${tool} advisor text drift`);
     } else {
       assert.deepEqual(JSON.parse(got.text), JSON.parse(goldenText), `${tool} broker data drift`);


### PR DESCRIPTION
WS-C of SIMPLIFICATION-GOAL.md — first slice of moving policy generation off the advisor service so its Deployment can be retired.

- The assistant builds seccomp profiles **in-process** from the pod's observed syscalls (broker `/pod/syscalls`); no advisor hop.
- `src/tools/generators/seccomp.ts` is the same pure `buildSeccompProfile` as the frontend and advisor-CLI generators, **locked to the shared G2 fixtures** (new fixture test). This is how "one behavior" is guaranteed — via G2, not a shared build (per-package Docker contexts make a monorepo workspace deploy-risky).
- Profile is semantically identical to the advisor's; only serialization is now canonical JS JSON, so the WS-B parity test compares this tool as a parsed object (like the broker tools) instead of exact advisor text.
- `generate_network_policy` still proxies to the advisor until its in-process port lands; advisor stays deployed for the canary regardless.

tsc + eslint + 71 tests green. `refactor` — no release cut (freeze).

https://claude.ai/code/session_019iDb3ymyUBM3NZPRd5M39U