### PR TITLE
docs(chart): UPGRADING note for the ai.* one-line keys

### DIFF
--- a/SIMPLIFICATION-GOAL.md
+++ b/SIMPLIFICATION-GOAL.md
@@ -158,6 +158,20 @@ shipped — but the freeze stops the untidiness from here on.
 
 ## 7. Progress log
 
+- 2026-07-26 — **WS-D done; entering canary-wait.** ai.provider/ai.secret
+  one-line enablement (#1192) + UPGRADING note (#1193): assistant enabled with
+  one toggle + one provider + one secret, every legacy key still works (G4
+  covers both). All buildable, non-canary-gated restructure work is now landed
+  on main (no public release cut). What REMAINS is gated on the 7-day G5 canary
+  (day 1 of 7, holds ~2026-08-02): (1) remove mcp-server + advisor Deployment/
+  serve/chart-templates/advisor-image-release.yaml → the 8→6 workload DoD;
+  (2) WS-E release-units 8→6 in release-please-config; (3) merge the HELD chart
+  release PR as the ONE coherent release; (4) close-out (task #16). The values.yaml
+  boilerplate-shrink is deliberately DEFERRED (low value, high churn-risk against
+  a live chart during the freeze). Note: this loop is session-scoped; a 7-day
+  canary exceeds a session, so the removals+release will land in a later /loop
+  run — the task graph + this charter persist the state.
+
 - 2026-07-26 — **Assistant fully advisor-independent.** In-process NETWORK
   POLICY + Cilium generation (#1190): faithful TS port of the advisor Go
   generators (standard/cilium/types), all 5 paths (CIDR, service/pod

--- a/charts/kguardian/UPGRADING.md
+++ b/charts/kguardian/UPGRADING.md
@@ -1,5 +1,29 @@
 # Upgrading the kguardian Helm chart
 
+## AI assistant: one-line enablement (`ai.*`)
+
+The AI assistant is now enabled with a single value and a single secret.
+No existing values need to change — the previous per-component flags
+(`llmBridge.enabled`, `mcpServer.enabled`, `advisor.enabled`) and
+per-provider secret blocks (`llmBridge.secrets.*`) all still work exactly
+as before, so upgrades are a no-op unless you opt into the new keys.
+
+The one-line path:
+```bash
+kubectl -n <ns> create secret generic my-llm-key \
+  --from-literal=api-key="sk-..."
+```
+```yaml
+ai:
+  enabled: true          # renders llm-bridge + mcp-server + advisor
+  provider: anthropic    # openai | anthropic | gemini | copilot
+  secret: my-llm-key     # holds the key under `api-key`
+```
+`ai.enabled=true` is the umbrella for the whole assistant path;
+`ai.provider` + `ai.secret` wire the chosen provider's API key. To run
+several providers at once, keep using the per-provider
+`llmBridge.secrets.*` blocks (they are additive to `ai.provider`).
+
 ## Optional broker API authentication (opt-in)
 
 The broker API can now require a shared **bearer token**


### PR DESCRIPTION
WS-D of SIMPLIFICATION-GOAL.md. Documents the one-line ai.enabled/ai.provider/ai.secret enablement and reassures operators that every legacy key still works (no values changes needed to upgrade). Docs only.

https://claude.ai/code/session_019iDb3ymyUBM3NZPRd5M39U