### PR TITLE
fix(chart): default llm-bridge image to 1.6.0 for the advisor-free assistant

### DIFF
--- a/charts/kguardian/README.md
+++ b/charts/kguardian/README.md
@@ -303,7 +303,7 @@ The following table lists the configurable parameters of the kguardian chart and
 | llmBridge.image.pullPolicy | string | `"IfNotPresent"` | LLM Bridge image pull policy |
 | llmBridge.image.repository | string | `"ghcr.io/kguardian-dev/kguardian/llm-bridge"` | LLM Bridge container image repository |
 | llmBridge.image.sha | string | `""` | Overrides the image tag using SHA digest |
-| llmBridge.image.tag | string | `"1.5.0"` | LLM Bridge version tag (auto-updated by release-please) |
+| llmBridge.image.tag | string | `"1.6.0"` | LLM Bridge version tag (auto-updated by release-please) |
 | llmBridge.imagePullSecrets | list | `[]` | List of image pull secrets for private registries |
 | llmBridge.metrics.serviceMonitor.enabled | bool | `false` | Create a ServiceMonitor for prometheus-operator. llm-bridge does not currently expose /metrics — forward-compatible toggle. |
 | llmBridge.metrics.serviceMonitor.interval | string | `"30s"` |  |

--- a/charts/kguardian/values.yaml
+++ b/charts/kguardian/values.yaml
@@ -813,7 +813,7 @@ llmBridge:
     # -- LLM Bridge image pull policy
     pullPolicy: IfNotPresent
     # -- LLM Bridge version tag (auto-updated by release-please)
-    tag: "1.5.0"
+    tag: "1.6.0"
     # -- Overrides the image tag using SHA digest
     sha: ""
 


### PR DESCRIPTION
Bumps the chart's default `llmBridge.image.tag` from 1.5.0 to **1.6.0**.

chart 1.17.0 retires the advisor-serve Deployment; the assistant only works advisor-free from llm-bridge **1.6.0** (in-process policy/seccomp generation, WS-C). 1.5.0 still proxies generation to the now-removed advisor, so shipping 1.17.0 with the 1.5.0 default would break generate tools on a fresh install.

Rolls into the pending chart 1.17.0 release.

https://claude.ai/code/session_019iDb3ymyUBM3NZPRd5M39U