### PR TITLE
fix(llm-bridge): validate seccomp arch — no silent broken profile on unknown arch

### DIFF
--- a/llm-bridge/src/tools/generators/seccomp.test.ts
+++ b/llm-bridge/src/tools/generators/seccomp.test.ts
@@ -1,0 +1,44 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { seccompFromBrokerSyscalls, validateSeccompProfile } from "./seccomp.js";
+
+// Regression guard (fix): the assistant's in-process seccomp generator must
+// reproduce the advisor serve handler's build-then-validate behavior. An
+// unrecognized CPU arch produces `architectures: []`, which the advisor's
+// k8s.ValidateProfile rejects — porting the tools in-process originally dropped
+// that guard, so an exotic-arch pod would get a silently-broken profile.
+
+test("seccompFromBrokerSyscalls: unknown arch throws instead of a silent broken profile", () => {
+  assert.throws(
+    () => seccompFromBrokerSyscalls({ syscalls: "read,write", arch: "ppc64le" }),
+    /unrecognized architecture/,
+  );
+  // Missing/empty arch is the same failure mode.
+  assert.throws(() => seccompFromBrokerSyscalls({ syscalls: "read", arch: "" }), /unrecognized architecture/);
+  assert.throws(() => seccompFromBrokerSyscalls({ syscalls: "read" }), /unrecognized architecture/);
+});
+
+test("seccompFromBrokerSyscalls: known arch returns a valid, sorted profile", () => {
+  const x86 = seccompFromBrokerSyscalls({ syscalls: "write,read,openat", arch: "x86_64" });
+  assert.deepEqual(x86.architectures, ["SCMP_ARCH_X86_64"]);
+  assert.equal(x86.defaultAction, "SCMP_ACT_ERRNO");
+  assert.deepEqual(x86.syscalls[0].names, ["openat", "read", "write"]);
+
+  const arm = seccompFromBrokerSyscalls({ syscalls: "read", arch: "aarch64" });
+  assert.deepEqual(arm.architectures, ["SCMP_ARCH_ARM64"]);
+});
+
+test("validateSeccompProfile: mirrors advisor ValidateProfile conditions", () => {
+  assert.throws(
+    () => validateSeccompProfile({ defaultAction: "", architectures: ["SCMP_ARCH_X86_64"], syscalls: [{ names: ["read"], action: "SCMP_ACT_ALLOW" }] }),
+    /default action is required/,
+  );
+  assert.throws(
+    () => validateSeccompProfile({ defaultAction: "SCMP_ACT_ERRNO", architectures: [], syscalls: [{ names: ["read"], action: "SCMP_ACT_ALLOW" }] }),
+    /unrecognized architecture/,
+  );
+  assert.throws(
+    () => validateSeccompProfile({ defaultAction: "SCMP_ACT_ERRNO", architectures: ["SCMP_ARCH_X86_64"], syscalls: [] }),
+    /at least one syscall rule/,
+  );
+});

--- a/llm-bridge/src/tools/generators/seccomp.ts
+++ b/llm-bridge/src/tools/generators/seccomp.ts
@@ -29,12 +29,37 @@ export function buildSeccompProfile(syscalls: string[], arch: string): SeccompPr
   };
 }
 
+/** Reject a profile that would be unusable if applied — a faithful port of the
+ *  advisor's k8s.ValidateProfile (pkg/k8s/seccomp.go), which the retired
+ *  advisor serve handler ran after building. Without it an unrecognized `arch`
+ *  yields `architectures: []` and the generator would silently hand back a
+ *  broken profile (its own comment warned "the MCP generate_seccomp_profile
+ *  tool silently returns a broken profile"). Throw a clear, actionable error
+ *  instead so the tool surfaces it rather than emitting a no-op profile. */
+export function validateSeccompProfile(profile: SeccompProfile): void {
+  if (!profile.defaultAction) {
+    throw new Error("seccomp profile is invalid: default action is required");
+  }
+  if (profile.architectures.length === 0) {
+    throw new Error(
+      `seccomp profile is invalid: unrecognized architecture — no seccomp arch mapping (supported: ${Object.keys(SECCOMP_ARCHITECTURES).join(", ")})`,
+    );
+  }
+  if (profile.syscalls.length === 0) {
+    throw new Error("seccomp profile is invalid: at least one syscall rule is required");
+  }
+}
+
 /** Build a profile from a broker /pod/syscalls response ({ syscalls: "a,b,c",
- *  arch }). Comma-split matching the advisor, empty entries dropped. */
+ *  arch }). Comma-split matching the advisor, empty entries dropped. Validated
+ *  before return so an unknown arch errors instead of producing a silently
+ *  unusable profile (mirrors the advisor build-then-validate flow). */
 export function seccompFromBrokerSyscalls(data: unknown): SeccompProfile {
   const rec = (data ?? {}) as { syscalls?: unknown; arch?: unknown };
   const raw = typeof rec.syscalls === "string" ? rec.syscalls : "";
   const arch = typeof rec.arch === "string" ? rec.arch : "";
   const names = raw.split(",").map((s) => s.trim()).filter((s) => s.length > 0);
-  return buildSeccompProfile(names, arch);
+  const profile = buildSeccompProfile(names, arch);
+  validateSeccompProfile(profile);
+  return profile;
 }


### PR DESCRIPTION
## What
Restores the arch-validation guard the advisor serve handler ran (`k8s.ValidateProfile`) that was dropped when seccomp generation moved in-process (WS-C). An unrecognized CPU arch produced `architectures: []`; `generate_seccomp_profile` returned that silently-unusable profile as success. Now it throws a clear error.

## How
- New `validateSeccompProfile` mirrors the advisor's `ValidateProfile` (defaultAction + architectures + syscalls required).
- Called in `seccompFromBrokerSyscalls` (the tool path), mirroring the advisor's build-then-validate flow.
- `buildSeccompProfile` stays pure → shared **G2 fixtures unchanged**.
- Adds unknown-arch + happy-path tests.

## Verified
llm-bridge build + lint clean; **79/79 tests pass** (76 + 3 new). G1 parity (`generate_seccomp_profile`) and G2 seccomp fixtures both still green.

## Scope
Found by the post-release review team (reviewer-code, MEDIUM). Low reachability (non-amd64/arm64 nodes only) but a silent security-relevant regression new in the retirement diff. The frontend generator has the same pattern but that predates this work — flagged as an optional follow-up, not bundled here.

https://claude.ai/code/session_019iDb3ymyUBM3NZPRd5M39U