### PR TITLE
fix(frontend): seccomp arch guard parity + missing tool label

### DIFF
--- a/frontend/src/components/AIAssistant.tsx
+++ b/frontend/src/components/AIAssistant.tsx
@@ -26,6 +26,7 @@ function describeTool(name: string): string {
     list_services: 'service inventory',
     get_cluster_traffic: 'cluster traffic',
     get_cluster_pods: 'cluster pods',
+    get_pods_on_node: 'pods on node',
     get_audit_verdicts: 'policy verdicts',
     generate_network_policy: 'network policy',
     generate_seccomp_profile: 'seccomp profile',

--- a/frontend/src/components/NetworkPolicyEditor.tsx
+++ b/frontend/src/components/NetworkPolicyEditor.tsx
@@ -92,6 +92,7 @@ const NetworkPolicyEditor: React.FC<NetworkPolicyEditorProps> = ({ isOpen, onClo
   // Seccomp profile management
   const {
     seccompProfile,
+    generationWarning,
     isSyscallsExpanded,
     setIsSyscallsExpanded,
     syscallErrors,
@@ -1820,6 +1821,15 @@ const NetworkPolicyEditor: React.FC<NetworkPolicyEditorProps> = ({ isOpen, onClo
                         </div>
                       </div>
                     </div>
+
+                    {/* Non-fatal generation warning (e.g. unrecognized arch → no
+                        architectures selected). The profile still renders so the
+                        user can fix it below. */}
+                    {generationWarning && (
+                      <div className="bg-amber-500/10 border border-amber-500/40 text-amber-300 text-xs rounded-lg p-3">
+                        ⚠️ {generationWarning}
+                      </div>
+                    )}
 
                     {/* Architectures */}
                     <div className="bg-hubble-dark p-4 rounded-lg border border-hubble-border">

--- a/frontend/src/hooks/policyEditor/useSeccompProfileEditor.ts
+++ b/frontend/src/hooks/policyEditor/useSeccompProfileEditor.ts
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef } from 'react';
 import type { PodNodeData } from '../../types';
 import type { SeccompProfile, SeccompSyscall, SeccompAction } from '../../types/seccompProfile';
-import { generateSeccompProfile } from '../../utils/seccompProfileGenerator';
+import { generateSeccompProfile, validateSeccompProfile } from '../../utils/seccompProfileGenerator';
 import { isValidSyscall } from '../../utils/syscalls';
 
 interface UseSeccompProfileEditorProps {
@@ -27,6 +27,19 @@ export const useSeccompProfileEditor = ({ pod, isOpen }: UseSeccompProfileEditor
       setSeccompProfile(generatedProfile);
     }
   }, [isOpen, pod]);
+
+  // Derived, non-fatal warning when the current profile isn't directly usable
+  // (e.g. an unrecognized CPU arch → no architectures selected). Derived from
+  // the profile rather than stored, so it live-updates as the user edits and
+  // clears itself once they pick an architecture / add a syscall rule.
+  let generationWarning: string | null = null;
+  if (seccompProfile) {
+    try {
+      validateSeccompProfile(seccompProfile);
+    } catch (e) {
+      generationWarning = e instanceof Error ? e.message : String(e);
+    }
+  }
 
   const addSyscallRule = () => {
     if (!seccompProfile) return;
@@ -143,6 +156,7 @@ export const useSeccompProfileEditor = ({ pod, isOpen }: UseSeccompProfileEditor
   return {
     seccompProfile,
     setSeccompProfile,
+    generationWarning,
     isSyscallsExpanded,
     setIsSyscallsExpanded,
     syscallErrors,

--- a/frontend/src/utils/seccompProfileGenerator.test.ts
+++ b/frontend/src/utils/seccompProfileGenerator.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { buildSeccompProfile, validateSeccompProfile } from './seccompProfileGenerator';
+
+// Parity with the advisor's k8s.ValidateProfile and the llm-bridge assistant's
+// validateSeccompProfile: an unrecognized CPU arch must be rejected rather than
+// yielding a silently-unusable profile. buildSeccompProfile stays pure (the G2
+// fixtures assert its output); validation is a separate, explicit step.
+describe('validateSeccompProfile', () => {
+  it('accepts a well-formed profile', () => {
+    const p = buildSeccompProfile(['read', 'write'], 'x86_64');
+    expect(() => validateSeccompProfile(p)).not.toThrow();
+    expect(p.architectures).toEqual(['SCMP_ARCH_X86_64']);
+  });
+
+  it('rejects an unrecognized architecture (empty architectures)', () => {
+    const p = buildSeccompProfile(['read'], 'ppc64le');
+    expect(p.architectures).toEqual([]); // build stays pure
+    expect(() => validateSeccompProfile(p)).toThrow(/unrecognized architecture/);
+  });
+
+  it('rejects a missing default action', () => {
+    expect(() =>
+      validateSeccompProfile({ defaultAction: '', architectures: ['SCMP_ARCH_X86_64'], syscalls: [{ names: ['read'], action: 'SCMP_ACT_ALLOW' }] }),
+    ).toThrow(/default action is required/);
+  });
+
+  it('rejects no syscall rules', () => {
+    expect(() =>
+      validateSeccompProfile({ defaultAction: 'SCMP_ACT_ERRNO', architectures: ['SCMP_ARCH_X86_64'], syscalls: [] }),
+    ).toThrow(/at least one syscall rule/);
+  });
+});

--- a/frontend/src/utils/seccompProfileGenerator.ts
+++ b/frontend/src/utils/seccompProfileGenerator.ts
@@ -35,6 +35,28 @@ export function buildSeccompProfile(syscalls: string[], arch: string): SeccompPr
   };
 }
 
+/**
+ * Reject a profile that would be unusable if applied — parity port of the
+ * advisor's k8s.ValidateProfile and the llm-bridge assistant's
+ * validateSeccompProfile. An unrecognized `arch` yields `architectures: []`;
+ * without this the editor would present a silently-broken profile. Throws a
+ * clear message the caller can surface (the editor catches it and warns rather
+ * than crashing, since the user can pick an architecture manually).
+ */
+export function validateSeccompProfile(profile: SeccompProfile): void {
+  if (!profile.defaultAction) {
+    throw new Error('seccomp profile is invalid: default action is required');
+  }
+  if (!profile.architectures || profile.architectures.length === 0) {
+    throw new Error(
+      `seccomp profile is invalid: unrecognized architecture — no seccomp arch mapping (supported: ${Object.keys(SECCOMP_ARCHITECTURES).join(', ')}). Select an architecture below.`,
+    );
+  }
+  if (!profile.syscalls || profile.syscalls.length === 0) {
+    throw new Error('seccomp profile is invalid: at least one syscall rule is required');
+  }
+}
+
 export function generateSeccompProfile(pod: PodNodeData): SeccompProfile {
   // Collect all unique valid syscalls from the pod's observed behavior.
   const uniqueSyscalls = new Set<string>();


### PR DESCRIPTION
Post-release review follow-ups (reviewer-code + reviewer-frontend).

## Seccomp arch guard (parity with llm-bridge/advisor)
The frontend generator had the same `architectures: SECCOMP_ARCHITECTURES[arch] ?? []` gap — an unrecognized arch produced a silently-unusable profile. Added `validateSeccompProfile` (mirrors the advisor's `k8s.ValidateProfile` and the llm-bridge `validateSeccompProfile`). The editor **derives** a non-fatal warning from the current profile and shows a banner above the Architectures section (live-clears when the user picks an arch). `buildSeccompProfile` stays pure → **G2 fixtures unchanged**.

## Tool label
`describeTool` was missing `get_pods_on_node` (fell through to generic phrasing). Added.

## Verified
frontend `tsc -b && vite build` OK, `eslint` clean, **10/10 vitest** (adds validation tests). Behavior is UI-safe: generation never throws into the effect; the warning is derived state.

https://claude.ai/code/session_019iDb3ymyUBM3NZPRd5M39U