### PR TITLE
chore(renovate): hold typescript at 6.x until typescript-eslint supports TS7

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -43,6 +43,17 @@
       "matchDepNames": ["slsa-framework/slsa-github-generator"],
       "pinDigests": false,
     },
+    {
+      // TypeScript 7 (the Go-native compiler) is GA on npm's `latest`, but
+      // typescript-eslint refuses to run against it — it throws
+      // "typescript-eslint does not support TS 7.0" at load, breaking
+      // `npm run lint` across frontend + llm-bridge. No typescript-eslint
+      // release supports TS7 yet; tracking: typescript-eslint/typescript-eslint#10940.
+      // Hold at 6.x until that lands, then lift this cap and take the major.
+      "description": "Hold typescript at 6.x until typescript-eslint supports TS7 (typescript-eslint#10940)",
+      "matchDepNames": ["typescript"],
+      "allowedVersions": "<7",
+    },
   ],
   "customManagers": [
     {


### PR DESCRIPTION
TypeScript 7 (native compiler) is GA on npm `latest` (7.0.2), but `typescript-eslint` throws `typescript-eslint does not support TS 7.0` at load — verified by installing TS7 locally and running lint. It breaks `npm run lint` across frontend + llm-bridge, and no typescript-eslint release supports TS7 yet (tracking: typescript-eslint/typescript-eslint#10940).

This caps `typescript` at `<7` so Renovate stops re-proposing the unmergeable major (#1044). Lift the cap once typescript-eslint ships TS≥7 support.

https://claude.ai/code/session_01MCVi1nqwNDBnDxo8UpZRj2