### PR TITLE
docs: horizontal table of contents in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,25 +26,17 @@ _Least-privilege Kubernetes security policies, generated from what your pods act
 
 </div>
 
+<div align="center">
+
+[Overview](#-overview) · [Features](#-features) · [Architecture](#️-architecture) · [Quick Start](#-quick-start) · [Usage](#️-usage) · [AI Assistant](#-ai-assistant) · [Compatibility](#-compatibility) · [Performance](#-performance) · [Telemetry](#-telemetry) · [Contributing](#-contributing) · [License](#-license)
+
+</div>
+
 # 🔭 Overview
 
 kguardian watches pod traffic and syscalls with eBPF, then writes Kubernetes `NetworkPolicy`, `CiliumNetworkPolicy`, and seccomp profiles from what it sees — no hand-authored rules.
 
 It's built for platform and security teams who want policy-as-code without writing rules by hand: the Controller (an eBPF DaemonSet) captures every TCP/UDP connection and syscall on each node, the Broker stores the per-pod baseline in PostgreSQL, and the `kubectl kguardian` plugin turns that baseline into least-privilege policy YAML for any pod, namespace, or the whole cluster.
-
-## 📖 Table of contents
-
-- [🔭 Overview](#-overview)
-- [✨ Features](#-features)
-- [🏗️ Architecture](#️-architecture)
-- [🚀 Quick Start](#-quick-start)
-- [🛠️ Usage](#️-usage)
-- [🤖 AI Assistant](#-ai-assistant)
-- [🧩 Compatibility](#-compatibility)
-- [📊 Performance](#-performance)
-- [📡 Telemetry](#-telemetry)
-- [🤝 Contributing](#-contributing)
-- [📄 License](#-license)
 
 ## ✨ Features
 


### PR DESCRIPTION
Turns the README's table of contents into a horizontal nav and moves it up under the badges — the section links are now the first thing after the hero, instead of a vertical bullet list buried below the Overview heading.

- Removed the `## 📖 Table of contents` bullet list
- Added a centered horizontal nav (`Overview · Features · … · License`) right after the badge block
- Anchors are the same slugs as before, so every link still resolves

Preview of the rendered result: https://claude.ai/code/artifact/ce2e2680-7754-4e5b-a991-d8c0f3766897

_Note: the preview shows the nav in a bordered strip; GitHub sanitizes CSS in READMEs, so the shipped version is the centered links with `·` separators (no box)._

https://claude.ai/code/session_01MCVi1nqwNDBnDxo8UpZRj2