### PR TITLE
fix(deps): update controller image tag to 1.9.2

### DIFF
--- a/charts/kguardian/README.md
+++ b/charts/kguardian/README.md
@@ -148,7 +148,7 @@ The following table lists the configurable parameters of the kguardian chart and
 | controller.image.pullPolicy | string | `"IfNotPresent"` | Controller image pull policy |
 | controller.image.repository | string | `"ghcr.io/kguardian-dev/kguardian/controller"` | Controller container image repository |
 | controller.image.sha | string | `""` | Overrides the image tag using SHA digest |
-| controller.image.tag | string | `"1.9.1"` | Controller version tag (auto-updated by release-please) |
+| controller.image.tag | string | `"1.9.2"` | Controller version tag (auto-updated by release-please) |
 | controller.imagePullSecrets | list | `[]` | List of image pull secrets for private registries |
 | controller.initContainer.image.pullPolicy | string | `"Always"` | Init container image pull policy |
 | controller.initContainer.image.repository | string | `"busybox"` | Init container image repository |

--- a/charts/kguardian/values.yaml
+++ b/charts/kguardian/values.yaml
@@ -41,7 +41,7 @@ controller:
     # -- Controller image pull policy
     pullPolicy: IfNotPresent
     # -- Controller version tag (auto-updated by release-please)
-    tag: "1.9.1"
+    tag: "1.9.2"
     # -- Overrides the image tag using SHA digest
     sha: ""
   initContainer:


### PR DESCRIPTION
Pins the chart's controller image to the freshly-released 1.9.2 (libbpf-rs 0.27.0 + debian-13 runtime). Brings the chart in line with the latest released component versions ahead of cutting the chart release.

https://claude.ai/code/session_01MCVi1nqwNDBnDxo8UpZRj2