### PR TITLE
chore(deps): bump nanoid to 3.3.18 in frontend lockfile (security)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -5257,9 +5257,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.17",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
-      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
Clears the last open Dependabot alert: **nanoid < 3.3.18** (high) in `frontend/package-lock.json`.

Build-time transitive only (via postcss — not imported by the app, not in the shipped bundle), so `chore(deps)` and no component release. Lockfile-only; frontend build + lint + test pass, 0 vulnerabilities.

https://claude.ai/code/session_01MCVi1nqwNDBnDxo8UpZRj2