### PR TITLE
chore(controller): replace unbounded range loop with idiomatic loop

### DIFF
--- a/controller/src/syscall.rs
+++ b/controller/src/syscall.rs
@@ -84,7 +84,7 @@ pub async fn process_syscall_event(
 pub async fn send_syscall_cache_periodically() -> Result<(), Error> {
     // Reduced from 60s to 10s for faster visibility of syscall data
     let interval_duration = std::time::Duration::from_secs(10);
-    for _ in 0.. {
+    loop {
         let mut batch = Vec::new();
         // Track which (pod, snapshot) pairs to mark as last_sent
         // AFTER the POST succeeds. The pre-fix code eagerly updated
@@ -150,8 +150,6 @@ pub async fn send_syscall_cache_periodically() -> Result<(), Error> {
         }
         tokio::time::sleep(interval_duration).await;
     }
-
-    Ok(())
 }
 
 fn get_syscall_name(syscall_number: i32) -> Option<String> {


### PR DESCRIPTION
Rust 1.98 clippy introduced `for_unbounded_range`, which fails `test-controller` under `-D warnings` on every PR touching the controller (currently blocking #1316). The syscall cache sender in `controller/src/syscall.rs` is an intentional infinite loop, so this replaces `for _ in 0..` with the idiomatic `loop` and drops the now-unreachable trailing `Ok(())`.

Validated locally: `cargo fmt --check`, `cargo clippy --all-targets` (clean), `cargo test --all-features` (73 passed).

https://claude.ai/code/session_013qP1zZqe4MLzXDUsuFmArE