### PR TITLE
fix(KICK-0000): stop a DashMap guard being held across await in the controller

### DIFF
--- a/controller/clippy.toml
+++ b/controller/clippy.toml
@@ -1,0 +1,21 @@
+# Make "read the container map only through models::lookup_pod" a compiler-
+# enforced rule rather than a comment.
+#
+# DashMap::get returns a Ref that holds the shard's read lock until dropped.
+# Held across an .await it deadlocks the whole controller, because every
+# subsystem is composed into one task by try_join! in main.rs and the pod
+# watcher's insert() then blocks the thread on that shard. That outage shipped
+# once already: a stalled controller, Running with zero restarts and silent
+# logs, and it took a production report to find.
+#
+# clippy::await_holding_lock does NOT catch it — dashmap wraps the parking_lot
+# guard in its own Ref type, which the lint cannot see through. Neither do the
+# unit tests, which can only exercise lookup_pod itself, not the call sites
+# where the mistake actually gets made. This is the only mechanism that fails
+# the build on a one-line reintroduction at a call site.
+#
+# models::lookup_pod carries the single audited #[allow] for this lint.
+disallowed-methods = [
+  { path = "dashmap::DashMap::get", reason = "returns a Ref holding the shard read lock; read the map via models::lookup_pod, which drops the guard before returning" },
+  { path = "dashmap::DashMap::get_mut", reason = "returns a RefMut holding the shard write lock; the container map is insert-only by design" },
+]

--- a/controller/src/main.rs
+++ b/controller/src/main.rs
@@ -13,7 +13,7 @@ use kguardian::syscall::{
     handle_syscall_events, send_syscall_cache_periodically, SyscallEventData,
 };
 use kguardian::{
-    error::Error, models::PodInspect, network::NetworkEventData,
+    error::Error, models::ContainerMap, network::NetworkEventData,
     pod_reconciler::reconcile_pods_task, pod_watcher::watch_pods,
 };
 
@@ -63,8 +63,11 @@ async fn main() -> Result<(), Error> {
 
     let (sender_ip, recv_ip) = mpsc::channel(1000); // Use tokio's mpsc channel
 
-    // Use DashMap for lock-free concurrent access (much faster than Mutex<BTreeMap>)
-    let container_map: Arc<DashMap<u64, PodInspect>> = Arc::new(DashMap::new());
+    // Shared inode -> pod map. NOTE: DashMap is sharded RwLocks, not lock-free.
+    // Every subsystem below is joined into ONE task by try_join!, so a shard
+    // guard held across an .await blocks the whole controller permanently.
+    // Read it only via models::lookup_pod. See ContainerMap for the detail.
+    let container_map: ContainerMap = Arc::new(DashMap::new());
     let pod_c = Arc::clone(&container_map);
     let network_map = Arc::clone(&container_map);
     let syscall_map = Arc::clone(&container_map);

--- a/controller/src/models.rs
+++ b/controller/src/models.rs
@@ -3,6 +3,42 @@ use serde::Serialize;
 use serde_derive::Deserialize;
 use std::collections::BTreeMap;
 
+/// Shared map from network-namespace inode to the pod occupying it.
+///
+/// The value is an `Arc` on purpose. `DashMap` is NOT lock-free despite what
+/// the call sites used to claim: it is an array of `RwLock`-guarded shards,
+/// and `get()` hands back a `Ref` that keeps that shard read-locked until it
+/// is dropped. Holding one across an `.await` deadlocks the controller,
+/// because every subsystem is joined into a single task by `try_join!` in
+/// main.rs — a sibling future calling `insert()` on the same shard blocks the
+/// thread, and the future holding the guard can then never be polled to
+/// release it. Nothing recovers; the process stays alive and silent.
+///
+/// Wrapping the value in `Arc` makes the safe pattern free: copy the handle
+/// out of the guard, let the guard drop, and only then await. See
+/// `lookup_pod`, which is the only sanctioned way to read this map.
+pub type ContainerMap = std::sync::Arc<dashmap::DashMap<u64, std::sync::Arc<PodInspect>>>;
+
+/// Read a pod out of the container map, releasing the shard guard before
+/// returning.
+///
+/// Callers must go through this rather than using `map.get(..)` inline: the
+/// temporary `Ref` lives to the end of the enclosing statement, so
+/// `if let Some(p) = map.get(&k) { something().await }` keeps the shard
+/// read-locked for the whole body. Returning an owned `Arc` makes that
+/// mistake impossible to express at the call site.
+/// The single audited use of `DashMap::get` in the crate. `clippy.toml`
+/// disallows that method everywhere else so a call site cannot reintroduce
+/// the guard-across-await outage; this is the one place it is correct,
+/// because the guard is dropped before the function returns.
+#[allow(clippy::disallowed_methods)]
+pub fn lookup_pod(
+    map: &dashmap::DashMap<u64, std::sync::Arc<PodInspect>>,
+    inum: u64,
+) -> Option<std::sync::Arc<PodInspect>> {
+    map.get(&inum).map(|entry| std::sync::Arc::clone(&entry))
+}
+
 #[derive(Debug, Default, Deserialize, Clone)]
 pub struct PodInspect {
     pub container_id: Option<String>,
@@ -97,4 +133,63 @@ pub struct SyscallData {
     pub syscalls: Vec<String>,
     pub arch: String,
     pub time_stamp: NaiveDateTime,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use dashmap::DashMap;
+    use std::sync::mpsc;
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    /// Documents `lookup_pod`'s contract: the shard's read guard is released
+    /// before it returns, so a caller may hold the result across an `.await`
+    /// without blocking a writer.
+    ///
+    /// Read what this does NOT do. It cannot fail if someone reintroduces the
+    /// outage, because the outage lived at a *call site* writing
+    /// `map.get(&k)` inline, not inside this function. Restoring that line in
+    /// network.rs leaves this test green and clippy clean. The real gate is
+    /// the `disallowed-methods` entry in controller/clippy.toml, which fails
+    /// the build on any `DashMap::get` outside the single audited use here.
+    /// This test only pins the contract that gate assumes.
+    ///
+    /// The writer runs on its own thread with a bounded wait rather than
+    /// calling `insert()` directly: a regression must fail in bounded time,
+    /// not hang CI forever.
+    #[test]
+    fn lookup_pod_releases_the_shard_guard_before_returning() {
+        let map: Arc<DashMap<u64, Arc<PodInspect>>> = Arc::new(DashMap::new());
+        map.insert(7, Arc::new(PodInspect::default()));
+
+        // Held for the rest of the test, exactly as a caller holds it across
+        // an await. This must NOT keep the shard locked.
+        let held = lookup_pod(&map, 7).expect("pod should be present");
+
+        let (tx, rx) = mpsc::channel();
+        let writer = Arc::clone(&map);
+        std::thread::spawn(move || {
+            writer.insert(7, Arc::new(PodInspect::default()));
+            let _ = tx.send(());
+        });
+
+        assert!(
+            rx.recv_timeout(Duration::from_secs(10)).is_ok(),
+            "insert blocked while the looked-up pod was still held: lookup_pod \
+             is keeping the shard guard past its return, which deadlocks the \
+             whole controller (see the ContainerMap docs)"
+        );
+
+        assert!(held.status.pod_name.is_empty());
+    }
+
+    /// A miss must not lock anything either.
+    #[test]
+    fn lookup_pod_returns_none_for_an_unknown_inode() {
+        let map: DashMap<u64, Arc<PodInspect>> = DashMap::new();
+        assert!(lookup_pod(&map, 1234).is_none());
+        map.insert(1234, Arc::new(PodInspect::default()));
+        assert!(lookup_pod(&map, 1234).is_some());
+    }
 }

--- a/controller/src/network.rs
+++ b/controller/src/network.rs
@@ -1,6 +1,6 @@
+use crate::models::{lookup_pod, ContainerMap};
 use crate::{api_post_call, Error, PodInspect, PodTraffic};
 use chrono::Utc;
-use dashmap::DashMap;
 use moka::future::Cache;
 use serde_json::json;
 use std::net::{IpAddr, Ipv4Addr};
@@ -79,7 +79,7 @@ pub struct PolicyDropEvent {
 
 pub async fn handle_network_events(
     mut event_receiver: tokio::sync::mpsc::Receiver<NetworkEventData>,
-    container_map: Arc<DashMap<u64, PodInspect>>,
+    container_map: ContainerMap,
 ) -> Result<(), Error> {
     // Batching configuration
     const BATCH_SIZE: usize = 100;
@@ -94,8 +94,12 @@ pub async fn handle_network_events(
 
         match event {
             Ok(Some(event)) => {
-                // DashMap provides lock-free reads - no need for explicit locking!
-                if let Some(pod_inspect) = container_map.get(&event.inum) {
+                // Resolve the pod BEFORE awaiting. Written inline as
+                // `if let Some(p) = container_map.get(..) { ...await }` this
+                // held the shard's read guard across build_traffic_event's
+                // await, which deadlocked the whole controller against the
+                // pod watcher's insert. See ContainerMap in models.rs.
+                if let Some(pod_inspect) = lookup_pod(&container_map, event.inum) {
                     if let Some(traffic) = build_traffic_event(&event, &pod_inspect).await {
                         batch.push(traffic);
                     }
@@ -298,7 +302,7 @@ fn proto_to_string(proto: u8) -> String {
 
 pub async fn handle_policy_drop_events(
     mut event_receiver: tokio::sync::mpsc::Receiver<PolicyDropEvent>,
-    container_map: Arc<DashMap<u64, PodInspect>>,
+    container_map: ContainerMap,
 ) -> Result<(), Error> {
     // Batching configuration
     const BATCH_SIZE: usize = 100;
@@ -315,7 +319,8 @@ pub async fn handle_policy_drop_events(
 
         match event {
             Ok(Some(event)) => {
-                if let Some(pod_inspect) = container_map.get(&event.inum) {
+                // Same guard-across-await hazard as handle_network_events.
+                if let Some(pod_inspect) = lookup_pod(&container_map, event.inum) {
                     if let Some(drop_event) = build_policy_drop_event(&event, &pod_inspect).await {
                         batch.push(drop_event);
                     }

--- a/controller/src/pod_watcher.rs
+++ b/controller/src/pod_watcher.rs
@@ -1,6 +1,6 @@
+use crate::models::ContainerMap;
 use crate::{api_post_call, Error, PodDetail, PodInfo, PodInspect};
 use chrono::Utc;
-use dashmap::DashMap;
 use futures::TryStreamExt;
 use k8s_openapi::api::apps::v1::{DaemonSet, Deployment, ReplicaSet, StatefulSet};
 use k8s_openapi::api::core::v1::Pod;
@@ -19,7 +19,7 @@ use tokio::sync::mpsc;
 pub async fn watch_pods(
     node_name: String,
     tx: mpsc::Sender<u64>,
-    container_map: Arc<DashMap<u64, PodInspect>>,
+    container_map: ContainerMap,
     excluded_namespaces: &[String],
     sender_ip: mpsc::Sender<String>,
     ignore_daemonset_traffic: bool,
@@ -105,7 +105,7 @@ async fn resync_pods(
     pods: Api<Pod>,
     node_name: String,
     tx: mpsc::Sender<u64>,
-    container_map: Arc<DashMap<u64, PodInspect>>,
+    container_map: ContainerMap,
     excluded_namespaces: Vec<String>,
     sender_ip: mpsc::Sender<String>,
     ignore_daemonset_traffic: bool,
@@ -151,7 +151,7 @@ async fn resync_pods(
 
 async fn process_pod(
     pod: &Pod,
-    container_map: Arc<DashMap<u64, PodInspect>>,
+    container_map: ContainerMap,
     excluded_namespaces: &[String],
     sender_ip: mpsc::Sender<String>,
     ignore_daemonset_traffic: bool,
@@ -310,7 +310,7 @@ async fn process_container_ids(
     con_ids: &[String],
     pod: &Pod,
     pod_ip: &str,
-    container_map: Arc<DashMap<u64, PodInspect>>,
+    container_map: ContainerMap,
 ) -> Option<u64> {
     for con_id in con_ids {
         let pod_info = create_pod_info(pod, pod_ip);
@@ -331,8 +331,10 @@ async fn process_container_ids(
                     "inode_num of pod {} is {}",
                     pod_inspect.status.pod_name, inode_num
                 );
-                // DashMap provides lock-free inserts!
-                container_map.insert(inode_num, pod_inspect.clone());
+                // Takes a write lock on this key's shard. It is only safe to
+                // block here because no reader holds a guard across an await
+                // any more — see ContainerMap and lookup_pod in models.rs.
+                container_map.insert(inode_num, Arc::new(pod_inspect));
                 return Some(inode_num);
             }
         }

--- a/controller/src/syscall.rs
+++ b/controller/src/syscall.rs
@@ -1,5 +1,5 @@
+use crate::models::{lookup_pod, ContainerMap};
 use chrono::Utc;
-use dashmap::DashMap;
 use libseccomp::{ScmpArch, ScmpSyscall};
 use moka::future::Cache;
 use serde_json::json;
@@ -33,11 +33,15 @@ pub struct SyscallEventData {
 
 pub async fn handle_syscall_events(
     mut event_receiver: tokio::sync::mpsc::Receiver<SyscallEventData>,
-    container_map: Arc<DashMap<u64, PodInspect>>,
+    container_map: ContainerMap,
 ) -> Result<(), Error> {
     while let Some(event) = event_receiver.recv().await {
-        // DashMap provides lock-free reads - no need for explicit locking!
-        if let Some(pod_inspect) = container_map.get(&event.inum) {
+        // Resolve before awaiting. This was the worst of the three sites: the
+        // inline `get()` held the shard's read guard across
+        // process_syscall_event, which itself awaits a tokio Mutex shared
+        // with the periodic sender — so the guard could be held for as long
+        // as that lock was contended. See ContainerMap in models.rs.
+        if let Some(pod_inspect) = lookup_pod(&container_map, event.inum) {
             process_syscall_event(&event, &pod_inspect).await?
         }
     }


### PR DESCRIPTION
`syscall.rs` held a DashMap shard read guard across an `.await`, which can deadlock the entire controller. `main.rs` composes every subsystem with `try_join!`, so they are futures in ONE task, not spawned tasks. DashMap is not lock-free despite what the comments claimed: it is an array of `RwLock`-guarded shards, and `get()` returns a `Ref` holding that shard's read lock until dropped. Written inline, the `Ref` lives to the end of the statement, so it is still alive across the await that follows. When that await yields, `try_join!` polls the pod watcher in the same round; it calls `container_map.insert()`, a blocking write lock. On a same-shard key the thread blocks, and the guard-holder can never be polled to release it. A task is polled by at most one worker at a time and is unstealable mid-poll, so a multi-threaded runtime does not rescue it. Every subsystem freezes together and nothing recovers.

The suspension is not a rare race. tokio's cooperative scheduling budget makes `Mutex::lock()` return `Pending` exactly one poll in 128 even uncontended, and because `try_join!` fuses all eight subsystems into one task they share a single budget, so the window opens constantly on a busy node.

**Scope, measured rather than assumed.** Only the syscall site can deadlock today. The two `network.rs` sites await moka's `Cache::insert`, which returns `Ready` on the first poll at any capacity and never consumes the coop budget, so they cannot suspend while the crate drives that cache from a single task. They are fixed here anyway as latent hazards, one dependency bump away from being live.

Fixed by copying out of the guard before awaiting. The map holds `Arc<PodInspect>` so the copy is a refcount bump rather than a deep clone on a hot path, and `lookup_pod`'s return type carries no lifetime from the map, which makes guard escape statically impossible.

**`clippy.toml` is the actual regression gate, and it is the more important half of this PR.** The unit tests cannot catch a reintroduction, because the mistake happens at a call site rather than inside `lookup_pod`: restoring the old line leaves the suite green and `-D warnings` clean. `clippy::await_holding_lock` is blind here too, since dashmap wraps the parking_lot guard in its own `Ref` type. Disallowing `DashMap::get` outside the one audited use is what actually fails the build.

Reproduced independently three times on the locked versions (dashmap 6.2.1, tokio 1.53.1, moka 0.12.16), with default shard count and realistic inode keys: the syscall pattern stalls in 40 of 40 trials, typically in under a second, and at the stall an independent OS thread cannot acquire that shard's write lock within 5 seconds. The fixed variant sustains tens of millions of events under the same load.

**This does not claim to fix the reported production stall.** Attribution is unproven and deliberately not asserted: time-to-stall for this mechanism has a coefficient of variation of 0.78 and a 53x spread, which does not obviously match a repeatable onset, and the reporter's log excerpt never established that the controller had actually gone quiet (the periodic lines are `debug!` and the daemonset pins `RUST_LOG=INFO`, so a healthy controller is also silent at that level). Separate follow-ups cover the other stall paths found while reviewing this, none of which this PR addresses.