### PR TITLE
fix(KICK-0000): drain the pod-watcher queues instead of taking one per poll

### DIFF
--- a/controller/src/bpf.rs
+++ b/controller/src/bpf.rs
@@ -363,8 +363,38 @@ pub fn ebpf_handle(
             }
             consecutive_poll_errors = 0;
 
-            // Process any incoming messages from the pod watcher
-            if let Ok(inum) = rx.try_recv() {
+            // Drain the pod watcher's queues, don't sip from them.
+            //
+            // These were `if let`, taking ONE item per loop iteration. The
+            // iteration rate is tied to ring_buffer.poll() returning, and poll
+            // only returns once its callbacks have pushed every pending record
+            // through blocking_send into bounded(1000) channels. Under event
+            // load the poll thread spends most of its time parked in those
+            // sends, so iterations become rare and the intake rate collapses
+            // toward zero.
+            //
+            // Meanwhile resync_pods re-sends an inode for EVERY on-node pod
+            // every 60s unconditionally, so a 234-pod node offers ~234/min
+            // forever. Once intake falls below that, the bounded(1000) channel
+            // fills and the pod watcher parks on `send().await`. Nothing then
+            // registers a new pod again, and because the eBPF programs gate on
+            // the inode_num map (syscall.bpf.c: unknown netns returns early),
+            // unregistered pods emit nothing at all. On a node dominated by
+            // short-lived Jobs the registered set is soon entirely dead pods
+            // and telemetry decays to zero. The process stays healthy-looking
+            // throughout: Running, no restarts, flat memory.
+            //
+            // Bounded rather than a bare `while let` on purpose: an unbounded
+            // drain against a producer that can outrun us would keep us out of
+            // poll() and starve the ring buffers instead, trading one
+            // starvation for its mirror image. The cap is far above the real
+            // arrival rate (~234/min) yet still returns us to poll() promptly.
+            const MAX_DRAIN_PER_ITERATION: usize = 128;
+
+            let mut drained = 0;
+            while drained < MAX_DRAIN_PER_ITERATION {
+                let Ok(inum) = rx.try_recv() else { break };
+                drained += 1;
                 let _ = network_sk
                     .maps
                     .inode_num
@@ -382,7 +412,13 @@ pub fn ebpf_handle(
                     .map_err(|e| eprintln!("Failed to update netpolicy inode map: {}", e));
             }
             if ignore_daemonset_traffic {
-                if let Ok(ip) = ignore_ips.try_recv() {
+                // Same starvation, same bound: one IP per iteration meant the
+                // daemonset ignore-list lagged behind the pods it describes,
+                // so their traffic was recorded until the backlog caught up.
+                let mut ips_drained = 0;
+                while ips_drained < MAX_DRAIN_PER_ITERATION {
+                    let Ok(ip) = ignore_ips.try_recv() else { break };
+                    ips_drained += 1;
                     if let Ok(parsed_ip) = ip.parse::<Ipv4Addr>() {
                         let ip_u32 = u32::from(parsed_ip).to_be(); // Ensure the IP is in network byte order
                         let _ = network_sk


### PR DESCRIPTION
`bpf.rs` took a single item per loop iteration from both channels the pod watcher feeds (`if let Ok(inum) = rx.try_recv()`, and the same for the daemonset ignore list). Intake was therefore tied to how often `ring_buffer.poll()` returns, and poll only returns once its callbacks have pushed every pending record through `blocking_send` into bounded(1000) channels. Under event load the poll thread spends most of its time parked in those sends, so iterations become rare and intake collapses toward zero.

Production does not collapse with it. `resync_pods` re-sends an inode for every on-node pod every 60s unconditionally, so a 234-pod node offers ~234/min indefinitely. Once intake drops below that, the bounded(1000) channel fills and the pod watcher parks on `send().await`, after which no new pod is ever registered.

That is worse than it sounds, because the eBPF programs gate on the `inode_num` map: `syscall.bpf.c` returns early for any netns not present, so an unregistered pod emits nothing at all. On a node dominated by short-lived Jobs the registered set becomes entirely dead pods within minutes while every live pod is invisible, and telemetry decays to zero permanently. Throughout, the process looks healthy: Running, no restarts, flat memory, and the queues are 1000 x 8 bytes so nothing grows.

Bounded rather than a bare `while let`, deliberately. An unbounded drain against a producer that can outrun the loop would keep us out of `poll()` and starve the ring buffers instead, trading one starvation for its mirror image. 128 per iteration sits far above the real arrival rate while still returning to `poll()` promptly.

**Scope.** This fixes the intake starvation only. It does not address the head-of-line coupling behind it, where all three ring buffers share one `poll()` call so a saturated consumer stalls the other two streams, nor `blocking_send` having no timeout. Those are #1345 and #1346.

**On attribution.** This is a bug on its own terms and is worth fixing regardless. Whether it is the cause of the reported production stall is plausible but unconfirmed: the mechanism is deterministic and would produce a repeatable onset, which fits the report better than the deadlock in #1343 (whose time-to-stall is exponentially distributed and should vary widely between restarts). The observation that would settle it is whether the controller's periodic `GET /pod/list/<node>` to the broker continues during the stall. If it does, the task is still being polled and #1343 is refuted; if it stops at the same instant traffic inserts stop, the whole task is wedged and #1343 is implicated. That evidence has not been gathered yet, so neither PR claims to fix the report.

Verified with `cargo fmt`, `cargo clippy --all-targets --all-features -- -D warnings` and the full test suite in a container matching the CI toolchain.