### PR TITLE
chore: re-anchor release-please after history rewrite

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "last-release-sha": "0cf4c0ca601d36ce708c4bea5d43ae187de32a85",
   "include-v-in-tag": true,
   "separate-pull-requests": true,
   "tag-separator": "/",


### PR DESCRIPTION
The commit-date history rewrite detached every component's release tag from main, so release-please re-walked history and generated release PRs (#1360-1366) that re-include already-shipped commits.

This pins `last-release-sha` to `0cf4c0ca` — the on-main twin of the last release-batch commit (was `08d7ac08` pre-rewrite) — so release-please computes releases from the correct point. Only 2 chore(deps) commits are genuinely unreleased since then, so this will correct/close the bogus release PRs.

To be removed once a good release PR merges (per release-please docs).

https://claude.ai/code/session_01CP75nsXDQDmbwgrYrVsWrk