### PR TITLE
ci: make PR workflows fork-aware

### DIFF
--- a/.github/workflows/charts-docs.yaml
+++ b/.github/workflows/charts-docs.yaml
@@ -17,6 +17,12 @@ jobs:
   chart-readme:
     name: Update README
     runs-on: ubuntu-latest
+    # Same-repo PRs only: this job checks out the head branch by name
+    # from THIS repo and commits the regenerated README back to it —
+    # a fork's branch is unreachable that way and unwritable with the
+    # read-only fork-PR token. Maintainers regenerate the README when
+    # the change lands.
+    if: github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -126,6 +126,9 @@ jobs:
   push-controller:
     runs-on: ubuntu-latest
     needs: build-controller
+    # Fork PRs cannot push packages or comment (read-only GITHUB_TOKEN);
+    # build-controller has already validated the binaries there.
+    if: github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -309,7 +312,12 @@ jobs:
           context: broker/
           file: broker/Dockerfile
           platforms: ${{ matrix.platform }}
-          push: true
+          # Fork PRs run with a read-only GITHUB_TOKEN, so pushing the
+          # pr-N preview tag is denied. Build (and load locally for the
+          # smoke test) instead — the Dockerfile and binary are still
+          # fully exercised, only publication is skipped.
+          push: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+          load: ${{ github.event.pull_request.head.repo.full_name != github.repository }}
           tags: |
             ghcr.io/kguardian-dev/kguardian/broker:pr-${{ github.event.pull_request.number }}-${{ matrix.arch }}
           cache-from: type=gha,scope=broker-${{ matrix.arch }}
@@ -336,6 +344,8 @@ jobs:
   push-broker:
     runs-on: ubuntu-latest
     needs: build-broker
+    # Fork PRs: no per-arch tags were pushed, so there is nothing to merge.
+    if: github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - name: Login to GHCR
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
@@ -494,7 +504,8 @@ jobs:
           context: frontend/
           file: frontend/Dockerfile
           platforms: ${{ matrix.platform }}
-          push: true
+          # Read-only token on fork PRs — build without publishing there.
+          push: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
           tags: |
             ghcr.io/kguardian-dev/kguardian/frontend:pr-${{ github.event.pull_request.number }}-${{ matrix.arch }}
           cache-from: type=gha,scope=frontend-${{ matrix.arch }}
@@ -503,6 +514,8 @@ jobs:
   push-frontend:
     runs-on: ubuntu-latest
     needs: build-frontend
+    # Fork PRs: no per-arch tags were pushed, so there is nothing to merge.
+    if: github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - name: Login to GHCR
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
@@ -599,7 +612,8 @@ jobs:
           context: llm-bridge/
           file: llm-bridge/Dockerfile
           platforms: ${{ matrix.platform }}
-          push: true
+          # Read-only token on fork PRs — build without publishing there.
+          push: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
           tags: |
             ghcr.io/kguardian-dev/kguardian/llm-bridge:pr-${{ github.event.pull_request.number }}-${{ matrix.arch }}
           cache-from: type=gha,scope=llm-bridge-${{ matrix.arch }}
@@ -608,6 +622,8 @@ jobs:
   push-llm-bridge:
     runs-on: ubuntu-latest
     needs: build-llm-bridge
+    # Fork PRs: no per-arch tags were pushed, so there is nothing to merge.
+    if: github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - name: Login to GHCR
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
@@ -752,7 +768,8 @@ jobs:
           context: evaluator/
           file: evaluator/Dockerfile
           platforms: ${{ matrix.platform }}
-          push: true
+          # Read-only token on fork PRs — build without publishing there.
+          push: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
           tags: |
             ghcr.io/kguardian-dev/kguardian/evaluator:pr-${{ github.event.pull_request.number }}-${{ matrix.arch }}
           cache-from: type=gha,scope=evaluator-${{ matrix.arch }}
@@ -761,6 +778,8 @@ jobs:
   push-evaluator:
     runs-on: ubuntu-latest
     needs: build-evaluator
+    # Fork PRs: no per-arch tags were pushed, so there is nothing to merge.
+    if: github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - name: Login to GHCR
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
@@ -851,13 +870,18 @@ jobs:
           cd charts
           helm package kguardian
 
+      # Fork PRs run with a read-only GITHUB_TOKEN: the chart still gets
+      # packaged above (validating it), but publication and the PR
+      # comment are skipped.
       - name: Push Helm Chart to GHCR
+        if: github.event.pull_request.head.repo.full_name == github.repository
         run: |
           cd charts
           CHART_FILE=$(ls kguardian-*.tgz)
           helm push "${CHART_FILE}" oci://ghcr.io/kguardian-dev/charts
 
       - name: Update or create Helm chart comment
+        if: github.event.pull_request.head.repo.full_name == github.repository
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
@@ -888,11 +912,13 @@ jobs:
               });
             }
 
-  # Summary comment with testing instructions
+  # Summary comment with testing instructions. Skipped on fork PRs: no
+  # preview images were published there and the read-only GITHUB_TOKEN
+  # cannot create comments anyway.
   pr-summary:
     runs-on: ubuntu-latest
     needs: [detect-changes, push-controller, build-broker, push-broker, build-frontend, push-frontend, build-llm-bridge, push-llm-bridge, build-evaluator, push-evaluator, build-helm-chart]
-    if: always()
+    if: always() && github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - name: Update or create summary comment
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9


### PR DESCRIPTION
## Summary

Fork PRs run with a read-only `GITHUB_TOKEN` and no org secrets, so every CI job that **writes** fails while all validation passes — seen on #1370, where the per-arch image pushes died with `denied: installation not allowed to Write organization package`, the chart push got a 403, and the README updater couldn't fetch the fork's branch from this repo.

This gates the writes on `github.event.pull_request.head.repo.full_name == github.repository`:

- **Per-arch component builds**: push the `pr-N-<arch>` preview tags only on same-repo PRs; on forks, build without publishing. Broker additionally `load:`s the image locally so its smoke test (binary-must-exec) still runs on both architectures.
- **push-\* manifest-merge jobs and push-controller**: skipped on forks — no per-arch tags exist to merge, and PR comments need write.
- **build-helm-chart**: the chart is still packaged (validated) on forks; only the GHCR push and PR comment are skipped.
- **pr-summary**: same-repo only (comment creation needs write).
- **charts-docs README updater**: same-repo only — it checks out the head branch by name from this repo and commits back to it, which is impossible for a fork branch.

Fork PRs keep the full validation surface: tests, lint, CodeQL, Trivy, per-arch docker builds, controller cross-builds, and chart packaging. Only publication and comments become maintainer-repo-only.

## Validation

This PR is itself raised from a fork, but it only touches workflow files, so the path-filtered build jobs skip on its own run either way. The full fork-path demonstration comes from re-running #1370 once this lands: its per-arch builds should complete without pushing, the chart should package without pushing, and pr-summary / Update README should show as skipped.

`actionlint` is clean on both files (the only reports are pre-existing shellcheck infos in untouched controller build scripts).

Unblocks #1370.
