### PR TITLE
fix(deps): bump chart to controller 1.10.1 and broker 1.13.1

### DIFF
--- a/charts/kguardian/README.md
+++ b/charts/kguardian/README.md
@@ -104,7 +104,7 @@ The following table lists the configurable parameters of the kguardian chart and
 | broker.image.pullPolicy | string | `"IfNotPresent"` | Broker image pull policy |
 | broker.image.repository | string | `"ghcr.io/kguardian-dev/kguardian/broker"` | Broker container image repository |
 | broker.image.sha | string | `""` | Overrides the image tag using SHA digest |
-| broker.image.tag | string | `"1.13.0"` | Broker version tag (auto-updated by release-please) |
+| broker.image.tag | string | `"1.13.1"` | Broker version tag (auto-updated by release-please) |
 | broker.imagePullSecrets | list | `[]` | List of image pull secrets for private registries |
 | broker.initContainer.image.pullPolicy | string | `"Always"` | Broker init container image pull policy |
 | broker.initContainer.image.repository | string | `"busybox"` | Broker init container image repository |
@@ -155,7 +155,7 @@ The following table lists the configurable parameters of the kguardian chart and
 | controller.image.pullPolicy | string | `"IfNotPresent"` | Controller image pull policy |
 | controller.image.repository | string | `"ghcr.io/kguardian-dev/kguardian/controller"` | Controller container image repository |
 | controller.image.sha | string | `""` | Overrides the image tag using SHA digest |
-| controller.image.tag | string | `"1.10.0"` | Controller version tag (auto-updated by release-please) |
+| controller.image.tag | string | `"1.10.1"` | Controller version tag (auto-updated by release-please) |
 | controller.imagePullSecrets | list | `[]` | List of image pull secrets for private registries |
 | controller.initContainer.image.pullPolicy | string | `"Always"` | Init container image pull policy |
 | controller.initContainer.image.repository | string | `"busybox"` | Init container image repository |

--- a/charts/kguardian/values.yaml
+++ b/charts/kguardian/values.yaml
@@ -41,7 +41,7 @@ controller:
     # -- Controller image pull policy
     pullPolicy: IfNotPresent
     # -- Controller version tag (auto-updated by release-please)
-    tag: "1.10.0"
+    tag: "1.10.1"
     # -- Overrides the image tag using SHA digest
     sha: ""
   initContainer:
@@ -168,7 +168,7 @@ broker:
     # -- Broker image pull policy
     pullPolicy: IfNotPresent
     # -- Broker version tag (auto-updated by release-please)
-    tag: "1.13.0"
+    tag: "1.13.1"
     # -- Overrides the image tag using SHA digest
     sha: ""
   initContainer:


### PR DESCRIPTION
Pins the chart to the releases carrying the TCP direction-classification fix (#1386). Bare semver is correct for the v-prefixing imageTag helper.