### PR TITLE
fix(frontend): exit focus mode when the focused node disappears; keep the focus button on the card

### DIFF
--- a/frontend/src/components/NetworkGraph.tsx
+++ b/frontend/src/components/NetworkGraph.tsx
@@ -391,6 +391,17 @@ const NetworkGraphInner: React.FC<NetworkGraphProps> = ({
     return [...visiblePods, ...externalNodes];
   }, [pods, externalNodes, showTraffic]);
 
+  // Focus is only meaningful while the focused node exists in the current
+  // node set. Switching namespace (or the pod being deleted) used to leave
+  // the stale focus filtering EVERYTHING out — an empty graph with the
+  // focus pill still up. Self-heal instead of threading the namespace down:
+  // any change that removes the focused node exits focus mode.
+  useEffect(() => {
+    if (focusedNodeId && !allDisplayPods.some((p) => p.id === focusedNodeId)) {
+      setFocusedNodeId(null);
+    }
+  }, [focusedNodeId, allDisplayPods]);
+
   // Build React Flow nodes with placeholder positions (ELK will reposition)
   const baseNodes: Node[] = useMemo(() => {
     return allDisplayPods.map((pod) => {

--- a/frontend/src/components/PodNode.tsx
+++ b/frontend/src/components/PodNode.tsx
@@ -52,7 +52,12 @@ const PodNode: React.FC<PodNodeProps> = React.memo(({ data, selected }) => {
       <Handle type="target" position={targetPosition} />
 
       <div className="flex items-start justify-between gap-2">
-        <div className="flex items-center gap-2 flex-1">
+        {/* min-w-0 is load-bearing: without it this flex level's automatic
+            minimum is the full nowrap width of a long pod/service name, the
+            row overflows the card, and the focus button renders out on the
+            graph canvas. Truncation only works when every nested flex level
+            may shrink. */}
+        <div className="flex items-center gap-2 flex-1 min-w-0">
           {/* External endpoints aggregate traffic only — they have no syscalls
               or policy to reveal (their toggle is a no-op), so no expander. */}
           {!isExternal && (
@@ -76,7 +81,7 @@ const PodNode: React.FC<PodNodeProps> = React.memo(({ data, selected }) => {
               {identityName}
             </div>
             {data.externalNamespace && data.externalNamespace !== 'internet' && data.externalNamespace !== 'cluster' && (
-              <div className="text-xs text-tertiary">
+              <div className="text-xs text-tertiary truncate" title={data.externalNamespace}>
                 ns: {data.externalNamespace}
               </div>
             )}


### PR DESCRIPTION
Two graph focus-mode bugs, both reproduced and verified fixed against the live cluster:

**1. Stale focus across namespace switches.** Focusing a node then changing namespace left the focus filter active with a node id that no longer exists — every node filtered out, empty graph, pill still up (reproduced: 29 pods, 0 rendered). Focus now self-heals: any change that removes the focused node from the display set (namespace switch, pod deletion) exits focus mode. Verified: same sequence now renders all 71 nodes with the pill cleared, and focus toggle still isolates/restores correctly (71 → 3 → 71).

**2. Focus button drifting off the card for long names.** Long unbroken pod/service names (`kopia-maint-daily-8e89d76a…`, `rook-ceph.cephfs.csi.ceph.com-ctrlplugin`) pushed the header row wider than the card — the focus button rendered up to **154px past the card edge**, out on the canvas (measured on live data). Root cause: the row's left flex group lacked `min-w-0`, so its automatic flex minimum was the full nowrap label width; truncation only works when every nested flex level can shrink. Also truncates the `ns:` secondary line. Verified: zero overflowing buttons across all 71 nodes including the former worst offenders.

tsc clean, vitest 67/67.