### PR TITLE
fix(deps): bump chart to frontend 1.13.1

### DIFF
--- a/charts/kguardian/README.md
+++ b/charts/kguardian/README.md
@@ -261,7 +261,7 @@ The following table lists the configurable parameters of the kguardian chart and
 | frontend.image.pullPolicy | string | `"IfNotPresent"` | Frontend image pull policy |
 | frontend.image.repository | string | `"ghcr.io/kguardian-dev/kguardian/frontend"` | Frontend container image repository |
 | frontend.image.sha | string | `""` | Overrides the image tag using SHA digest |
-| frontend.image.tag | string | `"1.13.0"` | Frontend version tag (auto-updated by release-please) |
+| frontend.image.tag | string | `"1.13.1"` | Frontend version tag (auto-updated by release-please) |
 | frontend.imagePullSecrets | list | `[]` | List of image pull secrets for private registries |
 | frontend.ingress.annotations | object | `{}` | Ingress annotations |
 | frontend.ingress.className | string | `""` | Ingress class name |

--- a/charts/kguardian/values.yaml
+++ b/charts/kguardian/values.yaml
@@ -650,7 +650,7 @@ frontend:
     # -- Frontend image pull policy
     pullPolicy: IfNotPresent
     # -- Frontend version tag (auto-updated by release-please)
-    tag: "1.13.0"
+    tag: "1.13.1"
     # -- Overrides the image tag using SHA digest
     sha: ""
 


### PR DESCRIPTION
Pins the chart to frontend 1.13.1 (graph focus-mode fixes from #1393). lint-test's new wait-for-images step (#1391) covers the release-build race.