### PR TITLE
feat(chart): add the GitOps inputs consumers were patching by hand

### DIFF
--- a/charts/kguardian/README.md
+++ b/charts/kguardian/README.md
@@ -175,6 +175,7 @@ The following table lists the configurable parameters of the kguardian chart and
 | controller.serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
 | controller.serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template |
 | controller.tolerations | list | `[{"effect":"NoSchedule","key":"node-role.kubernetes.io/control-plane","operator":"Exists"}]` | Tolerations for the kguardian controller pod assignment |
+| controller.updateStrategy | object | `{}` | Rolling update strategy for the Controller DaemonSet. Kubernetes defaults to maxUnavailable 1 with maxSurge 0, which updates one node at a time. A node the kubelet refuses the pod on (DiskPressure, for example) never becomes Ready, so it holds that single slot indefinitely and no further node is updated. On a large cluster one unhealthy node can stall the rollout completely. A percentage lets the rest proceed:   updateStrategy:     rollingUpdate:       maxUnavailable: 20% |
 | database.affinity | object | `{}` | Affinity rules for database pod assignment |
 | database.autoscaling.enabled | bool | `false` | Enable horizontal pod autoscaling for database |
 | database.autoscaling.maxReplicas | int | `100` | Maximum number of database replicas |
@@ -264,6 +265,7 @@ The following table lists the configurable parameters of the kguardian chart and
 | frontend.image.tag | string | `"1.13.1"` | Frontend version tag (auto-updated by release-please) |
 | frontend.imagePullSecrets | list | `[]` | List of image pull secrets for private registries |
 | frontend.ingress.annotations | object | `{}` | Ingress annotations |
+| frontend.ingress.apiPath | bool | `true` | Also route /api on the same host to the Broker. The Broker serves bare paths (/pod/info, /pod/traffic), so this only works behind an ingress controller that strips the prefix, such as nginx with rewrite-target. Controllers that pass the path through unchanged (AWS ALB, for example) make every /api request a 404. The UI image proxies /api to the Broker itself, so setting this to false serves the whole application from the UI Service and works on any controller. |
 | frontend.ingress.className | string | `""` | Ingress class name |
 | frontend.ingress.enabled | bool | `false` | Enable ingress for frontend |
 | frontend.ingress.hosts | list | `[{"host":"kguardian.example.com","paths":[{"path":"/","pathType":"Prefix"}]}]` | Ingress hosts configuration |

--- a/charts/kguardian/README.md
+++ b/charts/kguardian/README.md
@@ -2,7 +2,7 @@
 
 This chart bootstraps the [kguardian]() controlplane onto a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
 
-![Version: 1.19.1](https://img.shields.io/badge/Version-1.19.1-informational?style=flat-square)
+![Version: 1.19.2](https://img.shields.io/badge/Version-1.19.2-informational?style=flat-square)
 
 ## Overview
 

--- a/charts/kguardian/templates/_helpers.tpl
+++ b/charts/kguardian/templates/_helpers.tpl
@@ -76,6 +76,16 @@ Usage: include "kguardian.imageTag" .Values.<component>.image.tag
 {{- end -}}
 
 {{/*
+Resolve a pod's priorityClassName: the component's own value first, falling
+back to global.priorityClassName. Both default to "" so nothing renders
+unless an operator asks for one.
+Usage: {{- with include "kguardian.priorityClassName" (dict "component" .Values.broker "global" .Values.global) }}
+*/}}
+{{- define "kguardian.priorityClassName" -}}
+{{- .component.priorityClassName | default .global.priorityClassName -}}
+{{- end -}}
+
+{{/*
 Name of the Secret holding the database password.
 Returns `database.existingSecret` if set, otherwise the chart-managed default.
 Usage: include "kguardian.dbSecretName" .

--- a/charts/kguardian/templates/broker/deployment.yaml
+++ b/charts/kguardian/templates/broker/deployment.yaml
@@ -176,3 +176,6 @@ spec:
       topologySpreadConstraints:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with include "kguardian.priorityClassName" (dict "component" .Values.broker "global" .Values.global) }}
+      priorityClassName: {{ . | quote }}
+      {{- end }}

--- a/charts/kguardian/templates/controller/daemonset.yaml
+++ b/charts/kguardian/templates/controller/daemonset.yaml
@@ -6,6 +6,10 @@ metadata:
   labels:
     {{- include "kguardian.labels" . | nindent 4 }}
 spec:
+  {{- with .Values.controller.updateStrategy }}
+  updateStrategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       app.kubernetes.io/name: kguardian
@@ -89,8 +93,8 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if .Values.controller.priorityClassName }}
-      priorityClassName: {{ .Values.controller.priorityClassName | quote }}
+      {{- with include "kguardian.priorityClassName" (dict "component" .Values.controller "global" .Values.global) }}
+      priorityClassName: {{ . | quote }}
       {{- end }}
       volumes:
       - name: bpffs

--- a/charts/kguardian/templates/database/deployment.yaml
+++ b/charts/kguardian/templates/database/deployment.yaml
@@ -192,4 +192,7 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with include "kguardian.priorityClassName" (dict "component" .Values.database "global" .Values.global) }}
+      priorityClassName: {{ . | quote }}
+      {{- end }}
 {{- end }}

--- a/charts/kguardian/templates/evaluator/deployment.yaml
+++ b/charts/kguardian/templates/evaluator/deployment.yaml
@@ -108,4 +108,7 @@ spec:
       topologySpreadConstraints:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with include "kguardian.priorityClassName" (dict "component" .Values.evaluator "global" .Values.global) }}
+      priorityClassName: {{ . | quote }}
+      {{- end }}
 {{- end }}

--- a/charts/kguardian/templates/frontend/deployment.yaml
+++ b/charts/kguardian/templates/frontend/deployment.yaml
@@ -87,3 +87,6 @@ spec:
       topologySpreadConstraints:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with include "kguardian.priorityClassName" (dict "component" .Values.frontend "global" .Values.global) }}
+      priorityClassName: {{ . | quote }}
+      {{- end }}

--- a/charts/kguardian/templates/frontend/ingress.yaml
+++ b/charts/kguardian/templates/frontend/ingress.yaml
@@ -36,6 +36,7 @@ spec:
                 name: {{ $.Values.frontend.service.name }}
                 port:
                   number: {{ $.Values.frontend.service.port }}
+          {{- if $.Values.frontend.ingress.apiPath }}
           # Proxy /api requests to broker
           - path: /api
             pathType: Prefix
@@ -44,5 +45,6 @@ spec:
                 name: {{ $.Values.broker.service.name }}
                 port:
                   number: {{ $.Values.broker.service.port }}
+          {{- end }}
     {{- end }}
 {{- end }}

--- a/charts/kguardian/templates/llm-bridge/deployment.yaml
+++ b/charts/kguardian/templates/llm-bridge/deployment.yaml
@@ -139,4 +139,7 @@ spec:
       topologySpreadConstraints:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with include "kguardian.priorityClassName" (dict "component" .Values.llmBridge "global" .Values.global) }}
+      priorityClassName: {{ . | quote }}
+      {{- end }}
 {{- end }}

--- a/charts/kguardian/values.yaml
+++ b/charts/kguardian/values.yaml
@@ -151,6 +151,17 @@ controller:
   # For k3s clusters, set to: /run/k3s/containerd/io.containerd.runtime.v2.task
   containerdBundlePath: /run/containerd/io.containerd.runtime.v2.task
 
+  # -- Rolling update strategy for the Controller DaemonSet. Kubernetes
+  # defaults to maxUnavailable 1 with maxSurge 0, which updates one node at a
+  # time. A node the kubelet refuses the pod on (DiskPressure, for example)
+  # never becomes Ready, so it holds that single slot indefinitely and no
+  # further node is updated. On a large cluster one unhealthy node can stall
+  # the rollout completely. A percentage lets the rest proceed:
+  #   updateStrategy:
+  #     rollingUpdate:
+  #       maxUnavailable: 20%
+  updateStrategy: {}
+
   # -- Namespaces to be excluded from monitoring (comma-separated list)
   excludedNamespaces:
     - kguardian
@@ -769,6 +780,14 @@ frontend:
     enabled: false
     # -- Ingress class name
     className: ""
+    # -- Also route /api on the same host to the Broker. The Broker serves
+    # bare paths (/pod/info, /pod/traffic), so this only works behind an
+    # ingress controller that strips the prefix, such as nginx with
+    # rewrite-target. Controllers that pass the path through unchanged (AWS
+    # ALB, for example) make every /api request a 404. The UI image proxies
+    # /api to the Broker itself, so setting this to false serves the whole
+    # application from the UI Service and works on any controller.
+    apiPath: true
     # -- Ingress annotations
     annotations: {}
       # kubernetes.io/ingress.class: nginx

--- a/test/helm-values-compat.sh
+++ b/test/helm-values-compat.sh
@@ -216,6 +216,47 @@ render "mcp-without-assistant" --set ai.mcp.enabled=true && {
   assert_absent  "mcp-without-assistant" "MCP_ENABLED"
 }
 
+# 9. GitOps inputs: values a kustomize/Argo CD consumer would otherwise have to
+# patch into the rendered output. Each defaults to today's behaviour, so an
+# existing values file keeps rendering identically.
+
+# 9a. Defaults render no priorityClassName anywhere and keep the /api ingress
+# path, so nothing changes for operators who never set these.
+render "gitops-defaults" --set frontend.ingress.enabled=true && {
+  assert_absent "gitops-defaults" "priorityClassName"
+  assert_absent "gitops-defaults" "updateStrategy"
+  assert_has    "gitops-defaults" "path: /api"
+}
+
+# 9b. global.priorityClassName reaches every workload, including the in-cluster
+# database and the assistant, and a per-component value wins over it.
+render "gitops-priorityclass" \
+  --set global.priorityClassName=medium-priority \
+  --set broker.priorityClassName=high-priority \
+  --set ai.enabled=true --set ai.provider=openai --set ai.secret=k && {
+  assert_has "gitops-priorityclass" "high-priority"
+  # 5 of the 6 workloads take the global; the Broker takes its override.
+  got="$(grep -c 'priorityClassName: "medium-priority"' <<<"$OUT" || true)"
+  [ "$got" = "5" ] || { echo "FAIL [gitops-priorityclass]: expected 5 global, got $got"; fail=1; }
+}
+
+# 9c. The Controller DaemonSet accepts an updateStrategy. Without one, Kubernetes
+# updates a single node at a time and a node that refuses the pod holds that slot
+# indefinitely, stalling the rollout for every remaining node.
+render "gitops-updatestrategy" \
+  --set controller.updateStrategy.rollingUpdate.maxUnavailable=20% && {
+  assert_has "gitops-updatestrategy" "maxUnavailable: 20%"
+}
+
+# 9d. apiPath=false drops the /api rule for ingress controllers that do not
+# rewrite the prefix. The UI image proxies /api to the Broker itself, so the
+# application still works end to end from the UI Service alone.
+render "gitops-no-apipath" \
+  --set frontend.ingress.enabled=true --set frontend.ingress.apiPath=false && {
+  assert_absent "gitops-no-apipath" "path: /api"
+  assert_has    "gitops-no-apipath" "path: /"
+}
+
 if [ "$fail" -ne 0 ]; then
   echo "G4 values-compatibility check FAILED"
   exit 1


### PR DESCRIPTION
Closes #1399.

Three additive chart inputs replacing the kustomize/Argo patches GitOps consumers carry against rendered output:

- **`controller.updateStrategy: {}`** — the DaemonSet previously shipped no strategy, so Kubernetes' `maxUnavailable: 1` let a single unschedulable node (observed: DiskPressure on a 47-node cluster) stall the whole controller rollout indefinitely. A percentage now lets the rest proceed.
- **`priorityClassName` honored everywhere** — it was declared in values for seven components and read by one. New `kguardian.priorityClassName` helper: per-component value wins, `global.priorityClassName` is the fallback, empty renders nothing.
- **`frontend.ingress.apiPath: true`** — the `/api` → Broker ingress rule is now toggleable. It only works behind prefix-stripping controllers (nginx rewrite-target); on pass-through controllers (AWS ALB) every `/api` request 404s — with the UI silently degrading to the `default`-namespace fallback. The UI image already proxies `/api` itself, so `false` serves everything via the UI Service on any controller.

## Validation

- Rebased onto current main; **default rendering is byte-identical to main** (`helm template` diff empty with the generated DB password pinned) — every default preserves current behavior.
- Each knob verified by rendering: `updateStrategy` emits; `global.priorityClassName=low` + `broker.priorityClassName=high` → broker gets `high`, all other rendered workloads `low`; `apiPath=false` removes exactly the `/api` path.
- `helm lint` clean; `test/helm-values-compat.sh` (with the four new cases) passes.