### PR TITLE
fix: serve the frontend and broker on both IP families

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ Things to know:
 
 - **Dual-stack pods and Services are tracked on every address**, not just the primary one in `.status.podIP` / `.spec.clusterIP`. A peer is therefore resolved to a `podSelector` regardless of which family the traffic used.
 - **Nodes built with `CONFIG_IPV6=n`** are handled: the IPv6 socket fields are read behind a CO-RE existence guard, so the Controller loads and runs normally on such kernels — it simply never sees v6 flows there.
+- **Every service listener is dual-stack.** The broker, frontend, llm-bridge and evaluator bind the IPv6 unspecified address (accepting IPv4 as v4-mapped) and fall back to IPv4-only on kernels without IPv6 — so the stack serves IPv4-only, dual-stack, and IPv6-only clusters alike. The broker's `LISTEN_ADDR` env still binds verbatim when set.
 - **Kernels with IPv6 as a module but no module BTF** (kernels older than 5.11, or built with `CONFIG_DEBUG_INFO_BTF_MODULES=n` — Debian 11's 5.10 is the common case) can't attach the IPv6 UDP probes. The Controller detects this at startup, logs a warning, and runs with those probes disabled rather than failing; IPv6 TCP capture is unaffected.
 - **UDP flows are captured from connected sockets** (glibc's DNS resolver connects, so pod DNS is covered on both families). Unconnected `sendto()` datagrams carry no destination on the socket at the probe point and are not captured — the same behaviour IPv4 has always had, notable mainly for musl-based (Alpine) resolvers.
 

--- a/broker/src/main.rs
+++ b/broker/src/main.rs
@@ -166,21 +166,48 @@ fn effective_pool_size() -> u32 {
 /// the loop's 2-second sleep = ~20s of patience.
 const DEFAULT_DB_MIGRATION_MAX_RETRIES: u32 = 10;
 
-/// Default bind address for the broker HTTP server. Operators
+/// IPv4 fallback bind address for the broker HTTP server. Operators
 /// changing the chart's broker.container.port previously needed to
 /// know to ALSO set this — now wired via LISTEN_ADDR env.
 const DEFAULT_LISTEN_ADDR: &str = "0.0.0.0:9090";
 
+/// Dual-stack default: the IPv6 unspecified address, which on Linux
+/// (bindv6only=0, the default everywhere Kubernetes runs) also accepts
+/// IPv4 connections as v4-mapped. A literal 0.0.0.0 bind never accepts
+/// connections on the pod's IPv6 address, leaving the broker
+/// unreachable on IPv6-only clusters.
+const DEFAULT_LISTEN_ADDR_DUAL: &str = "[::]:9090";
+
 /// Read LISTEN_ADDR env var with trim + empty fallback. Same env
 /// trim defense as every other env reader in the broker (a pasted
 /// "0.0.0.0:9090\n" would otherwise fail bind with a confusing
-/// parse error far from the env read site).
-fn listen_addr() -> String {
+/// parse error far from the env read site). `None` means "no operator
+/// override" — the caller picks the dual-stack default.
+fn explicit_listen_addr() -> Option<String> {
     std::env::var("LISTEN_ADDR")
         .ok()
         .map(|s| s.trim().to_string())
         .filter(|s| !s.is_empty())
-        .unwrap_or_else(|| DEFAULT_LISTEN_ADDR.to_string())
+}
+
+/// Bind `addr` preferring dual-stack, falling back to `v4` on kernels
+/// without IPv6 — the same fallback Node and Go perform for an
+/// unspecified host, so all four kguardian services now behave alike.
+fn bind_dual_stack(dual: &str, v4: &str) -> std::io::Result<std::net::TcpListener> {
+    std::net::TcpListener::bind(dual).or_else(|_| std::net::TcpListener::bind(v4))
+}
+
+/// The broker's TCP listener. An explicit LISTEN_ADDR is bound
+/// verbatim — operator intent wins, including a deliberately
+/// single-family bind. Without one, prefer dual-stack.
+fn broker_listener() -> std::io::Result<std::net::TcpListener> {
+    let listener = match explicit_listen_addr() {
+        Some(addr) => std::net::TcpListener::bind(&*addr)?,
+        None => bind_dual_stack(DEFAULT_LISTEN_ADDR_DUAL, DEFAULT_LISTEN_ADDR)?,
+    };
+    // actix takes over polling; the std listener must not block accept.
+    listener.set_nonblocking(true)?;
+    Ok(listener)
 }
 
 /// Read DB_MIGRATION_MAX_RETRIES with trim + clamp. Extracted out
@@ -300,8 +327,8 @@ async fn main() -> Result<(), std::io::Error> {
     let version_state = web::Data::new(VersionCheckState::default());
     spawn_version_check(pool.clone(), version_state.clone());
 
-    let listen_addr = listen_addr();
-    info!(addr = %listen_addr, "broker HTTP server starting");
+    let listener = broker_listener()?;
+    info!(addr = %listener.local_addr()?, "broker HTTP server starting");
     HttpServer::new(move || {
         let cors = Cors::default()
             .allow_any_origin()
@@ -337,7 +364,7 @@ async fn main() -> Result<(), std::io::Error> {
             .service(health_check)
             .service(metrics)
     })
-    .bind(listen_addr)?
+    .listen(listener)?
     .run()
     .await
 }
@@ -784,43 +811,45 @@ mod tests {
         });
     }
 
-    // listen_addr is the bind-address env reader added in iteration
-    // 130 to wire the chart's broker.container.port through to the
-    // Rust binary. Same env-trim defense + default-fallback pattern.
+    // explicit_listen_addr is the bind-address env reader added in
+    // iteration 130 (as listen_addr) to wire the chart's
+    // broker.container.port through to the Rust binary; None now means
+    // "no override" and the caller binds the dual-stack default. Same
+    // env-trim defense pattern as every other env reader here.
 
     fn with_listen_env<F: FnOnce()>(value: Option<&str>, f: F) {
         with_env("LISTEN_ADDR", value, f);
     }
 
     #[test]
-    fn listen_addr_defaults_when_unset() {
+    fn listen_addr_unset_means_no_override() {
         with_listen_env(None, || {
-            assert_eq!(listen_addr(), DEFAULT_LISTEN_ADDR);
+            assert_eq!(explicit_listen_addr(), None);
         });
     }
 
     #[test]
     fn listen_addr_honors_override() {
         with_listen_env(Some("0.0.0.0:8080"), || {
-            assert_eq!(listen_addr(), "0.0.0.0:8080");
+            assert_eq!(explicit_listen_addr().as_deref(), Some("0.0.0.0:8080"));
         });
     }
 
     #[test]
-    fn listen_addr_empty_falls_back_to_default() {
+    fn listen_addr_empty_means_no_override() {
         // Operator setting LISTEN_ADDR="" (or set then unset back)
-        // shouldnt produce an empty bind string that .bind() rejects.
+        // shouldnt produce an empty bind string that bind() rejects.
         with_listen_env(Some(""), || {
-            assert_eq!(listen_addr(), DEFAULT_LISTEN_ADDR);
+            assert_eq!(explicit_listen_addr(), None);
         });
     }
 
     #[test]
-    fn listen_addr_whitespace_only_falls_back_to_default() {
+    fn listen_addr_whitespace_only_means_no_override() {
         // Same as empty — whitespace-only is operator-paste artefact,
         // treat as "use default".
         with_listen_env(Some("  \n"), || {
-            assert_eq!(listen_addr(), DEFAULT_LISTEN_ADDR);
+            assert_eq!(explicit_listen_addr(), None);
         });
     }
 
@@ -828,8 +857,29 @@ mod tests {
     fn listen_addr_trims_surrounding_whitespace() {
         // Pasted value with trailing newline round-trips clean.
         with_listen_env(Some("  0.0.0.0:9090\n"), || {
-            assert_eq!(listen_addr(), "0.0.0.0:9090");
+            assert_eq!(explicit_listen_addr().as_deref(), Some("0.0.0.0:9090"));
         });
+    }
+
+    #[test]
+    fn dual_stack_bind_prefers_ipv6_and_accepts_v4_fallback() {
+        // Port 0 keeps the test free of fixed-port flakiness. On a host
+        // with IPv6 the preferred bind must be the v6 unspecified
+        // address (which accepts IPv4 as v4-mapped); on a v6-less
+        // kernel the fallback path must still yield a listener.
+        let host_has_v6 = std::net::TcpListener::bind("[::]:0").is_ok();
+        let l = bind_dual_stack("[::]:0", "0.0.0.0:0").expect("must bind on any kernel");
+        assert_eq!(l.local_addr().unwrap().is_ipv6(), host_has_v6);
+    }
+
+    #[test]
+    fn dual_stack_bind_falls_back_when_preferred_is_unbindable() {
+        // An unbindable preferred address (port already taken on
+        // loopback) must fall through to the v4 address, not error.
+        let occupied = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let taken = format!("127.0.0.1:{}", occupied.local_addr().unwrap().port());
+        let l = bind_dual_stack(&taken, "0.0.0.0:0").expect("fallback must bind");
+        assert!(l.local_addr().unwrap().ip().is_unspecified());
     }
 
     #[test]

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -40,5 +40,9 @@ HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
 # Switch to non-root user
 USER 1337
 
-# Use vite preview for production
-CMD ["npx", "vite", "preview", "--host", "0.0.0.0", "--port", "5173"]
+# Use vite preview for production. Bare --host (no address) listens on
+# all addresses of both IP families: Node binds the IPv6 unspecified
+# address (accepting IPv4 as v4-mapped) and falls back to IPv4-only on
+# kernels without IPv6. An explicit 0.0.0.0 is IPv4-only and leaves the
+# pod unreachable on IPv6-only clusters.
+CMD ["npx", "vite", "preview", "--host", "--port", "5173"]

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -67,7 +67,12 @@ export default defineConfig({
   // Preview server configuration (for production)
   preview: {
     port: 5173,
-    host: '0.0.0.0',
+    // true, not '0.0.0.0': listen on all addresses of BOTH families.
+    // Node then binds the IPv6 unspecified address (accepting IPv4 as
+    // v4-mapped) and falls back to IPv4-only on kernels without IPv6 —
+    // a literal '0.0.0.0' never accepts connections on the pod's IPv6
+    // address, so probes and Service traffic fail on IPv6-only clusters.
+    host: true,
     strictPort: true,
     allowedHosts: true,
     proxy: {


### PR DESCRIPTION
Completes the IPv6 story for the serving path: the capture layer went dual-stack in #1370, but two listeners still bound a literal `0.0.0.0`, leaving the UI and its `/api` backend unreachable on IPv6-only clusters (v4-only sockets never accept on the pod's v6 address — probes fail, Services route nowhere).

- **frontend**: `vite preview` now uses bare `--host` / `host: true` (Dockerfile CMD + `vite.config.ts`) — Node binds the IPv6 unspecified address, accepting IPv4 as v4-mapped, and falls back to IPv4-only on kernels without IPv6. Verified live: the new invocation answers **200 on both `http://[::1]` and `http://127.0.0.1`**.
- **broker**: the default bind becomes `[::]:9090` with the same v4 fallback, via a real pre-bound listener (`.listen()`), and the startup log reports the actually-bound address. An explicit `LISTEN_ADDR` still binds verbatim — a deliberate single-family bind stays possible. Two new unit tests pin the prefer-v6/fallback behavior without fixed-port flakiness.
- **llm-bridge and evaluator already behave this way** (bare Node `listen(port)` / Go `:8082`) — audited, no change needed. README's IP-families section now documents the listener guarantee.

Validation: broker fmt/clippy `-D warnings`/170 tests green; frontend tsc clean; dual-family acceptance proven against the running preview server.