### PR TITLE
fix(frontend): list syscalls in a consistent order everywhere

### DIFF
--- a/frontend/src/components/DataTable.tsx
+++ b/frontend/src/components/DataTable.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useMemo, useCallback } from 'react';
 import type { PodInfo, PodNodeData, ServiceInfo } from '../types';
 import { ArrowRight, Activity, ChevronDown, ChevronRight, Filter, MousePointerClick, Inbox } from 'lucide-react';
 import { EmptyState } from './ui/EmptyState';
+import { displaySyscallList } from '../utils/syscalls';
 
 interface DataTableProps {
   selectedPod: PodNodeData | null;
@@ -709,7 +710,10 @@ const DataTable: React.FC<DataTableProps> = ({ selectedPod, allPodsLookup, servi
                 </thead>
                 <tbody>
                   {selectedPod.syscalls?.map((syscall, index) => {
-                    const syscallList = syscall.syscalls.split(',').filter(s => s.trim());
+                    // Sorted + de-duplicated: capture emits in observation
+                    // order, which varies between pods and refreshes; the
+                    // collapsed 10-chip preview must show a stable prefix.
+                    const syscallList = displaySyscallList(syscall.syscalls);
                     const isExpanded = expandedSyscalls.has(index);
                     const displayedSyscalls = isExpanded ? syscallList : syscallList.slice(0, 10);
 

--- a/frontend/src/components/FindingsView.tsx
+++ b/frontend/src/components/FindingsView.tsx
@@ -122,7 +122,9 @@ export function FindingsView({ pods, namespace, onSelectPod, onBuildPolicy, onOp
         });
         const calls = [...seen.entries()]
           .map(([name, severity]) => ({ name, severity }))
-          .sort((a, b) => SEVERITY_RANK[b.severity] - SEVERITY_RANK[a.severity]);
+          // Name tiebreak: equal severities otherwise keep Map insertion
+          // order, which is capture order — inconsistent across refreshes.
+          .sort((a, b) => SEVERITY_RANK[b.severity] - SEVERITY_RANK[a.severity] || a.name.localeCompare(b.name));
         const worst = calls.reduce<Severity | null>(
           (acc, c) => (acc === null || SEVERITY_RANK[c.severity] > SEVERITY_RANK[acc] ? c.severity : acc),
           null,
@@ -130,7 +132,11 @@ export function FindingsView({ pods, namespace, onSelectPod, onBuildPolicy, onOp
         return calls.length > 0 && worst ? { pod, worst, calls } : null;
       })
       .filter((f): f is SyscallFinding => f !== null)
-      .sort((a, b) => SEVERITY_RANK[b.worst] - SEVERITY_RANK[a.worst] || b.calls.length - a.calls.length);
+      // Pod-label tiebreak for the same reason as the per-call sort above.
+      .sort((a, b) =>
+        SEVERITY_RANK[b.worst] - SEVERITY_RANK[a.worst]
+        || b.calls.length - a.calls.length
+        || podLabel(a.pod).localeCompare(podLabel(b.pod)));
   }, [workloads]);
 
   const fanoutFindings = useMemo<FanoutFinding[]>(() => {

--- a/frontend/src/utils/syscalls.test.ts
+++ b/frontend/src/utils/syscalls.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { displaySyscallList } from './syscalls';
+
+// The capture layer emits syscalls in observation order, which differs
+// between pods and across refreshes. Every listing goes through
+// displaySyscallList so the same workload always reads the same way —
+// including the collapsed 10-chip preview, which must show a stable
+// alphabetical prefix rather than an arbitrary capture-order subset.
+describe('displaySyscallList', () => {
+  it('sorts alphabetically regardless of capture order', () => {
+    expect(displaySyscallList('write,open,close,read')).toEqual(['close', 'open', 'read', 'write']);
+    expect(displaySyscallList('read,close,write,open')).toEqual(['close', 'open', 'read', 'write']);
+  });
+
+  it('trims entries and drops empties', () => {
+    expect(displaySyscallList(' read , write ,, ,close')).toEqual(['close', 'read', 'write']);
+  });
+
+  it('de-duplicates repeated observations', () => {
+    expect(displaySyscallList('read,write,read,read')).toEqual(['read', 'write']);
+  });
+
+  it('returns empty for an empty record', () => {
+    expect(displaySyscallList('')).toEqual([]);
+    expect(displaySyscallList(' , ,')).toEqual([]);
+  });
+});

--- a/frontend/src/utils/syscalls.ts
+++ b/frontend/src/utils/syscalls.ts
@@ -232,3 +232,18 @@ export function parseSyscallString(syscallStr: string): {
 
   return { valid, invalid };
 }
+
+/**
+ * Split a comma-separated syscall record into a display-ready list:
+ * trimmed, empties dropped, de-duplicated, and sorted alphabetically.
+ *
+ * The capture layer emits syscalls in observation order, which differs
+ * between pods and across refreshes — every view that LISTS syscalls
+ * goes through this so the same workload always reads the same way.
+ * (Counts intentionally do not: they keep raw record semantics.)
+ */
+export function displaySyscallList(syscallStr: string): string[] {
+  return [...new Set(
+    syscallStr.split(',').map((s) => s.trim()).filter((s) => s.length > 0),
+  )].sort((a, b) => a.localeCompare(b));
+}


### PR DESCRIPTION
Syscalls were rendered in capture order — different between pods and across refreshes, so the workload panel's collapsed 10-chip preview showed an arbitrary shifting subset, and Findings ordered severity ties unpredictably.

- New `displaySyscallList` util: trim, drop empties, de-duplicate, alphabetical sort — used by the workload inspector panel.
- Findings: alphabetical name tiebreak within equal severities, pod-label tiebreak between workloads with identical severity/count.
- Counts intentionally keep raw record semantics; the seccomp profile generator already sorted its `names` (cross-language parity untouched).

tsc clean; vitest 71/71 (4 new unit tests for the helper).