### PR TITLE
feat(telemetry): accept contract v2 environment signals

### DIFF
--- a/cloudflare/version-service/src/index.js
+++ b/cloudflare/version-service/src/index.js
@@ -127,6 +127,40 @@ const K8S_VERSION = /^v\d+\.\d+\.\d+(?:[+-][0-9A-Za-z.-]{1,48})?$/;
 const ARCH = /^[A-Za-z0-9_]{1,16}$/;
 const MAX_NODES = 10_000;
 
+// Contract v2 (all optional — a v1 broker that sends none of these is
+// still accepted, and every value is whitelisted so the dataset stays
+// clean). Values are COARSE by design: enums and buckets, never names,
+// addresses, regions, or instance types. docs/telemetry.mdx lists every
+// field and is the consent surface — keep it in lockstep.
+const PROVIDERS = new Set([
+  "aws", "gcp", "azure", "digitalocean", "hetzner", "openstack",
+  "vsphere", "oracle", "ibm", "baremetal", "kind", "unknown",
+]);
+const DISTROS = new Set([
+  "eks", "gke", "aks", "k3s", "rke2", "talos", "openshift", "kind",
+  "vanilla", "unknown",
+]);
+const CNIS = new Set([
+  "cilium", "calico", "flannel", "weave", "antrea", "kindnet",
+  "unknown",
+]);
+const IP_FAMILIES = new Set(["ipv4", "ipv6", "dual", "unknown"]);
+const NODE_OS = new Set([
+  "talos", "bottlerocket", "flatcar", "cos", "ubuntu", "debian",
+  "rhel", "amazonlinux", "alpine", "other", "unknown",
+]);
+// Order-of-magnitude bucket for observed pods ("0", "1-9", "10-99", …).
+const BUCKET = /^(0|[1-9][0-9]*-[1-9][0-9]*|[1-9][0-9]*\+)$/;
+// Comma-separated feature-flag slugs the chart reports ("ai,audit").
+const FEATURES = /^[a-z0-9_]{1,24}(,[a-z0-9_]{1,24}){0,15}$/;
+
+/** Read an optional enum param: absent → "unknown", invalid → null (reject). */
+function optEnum(q, key, allowed) {
+  const v = q.get(key);
+  if (v === null || v === "") return "unknown";
+  return allowed.has(v) ? v : null;
+}
+
 function parseCheckin(q) {
   const install = q.get("install") ?? "";
   const broker = q.get("broker") ?? "";
@@ -144,7 +178,31 @@ function parseCheckin(q) {
   if (k8s !== "unknown" && !K8S_VERSION.test(k8s)) return null;
   if (!ARCH.test(arch)) return null;
   if (!Number.isInteger(nodes) || nodes < 0 || nodes > MAX_NODES) return null;
-  return { install, broker, chart, k8s, arch, nodes };
+
+  // v2 optional fields.
+  const provider = optEnum(q, "provider", PROVIDERS);
+  const distro = optEnum(q, "distro", DISTROS);
+  const cni = optEnum(q, "cni", CNIS);
+  const ipFamily = optEnum(q, "ip_family", IP_FAMILIES);
+  const nodeOs = optEnum(q, "node_os", NODE_OS);
+  if (provider === null || distro === null || cni === null || ipFamily === null || nodeOs === null) {
+    return null;
+  }
+  const podsBucketRaw = q.get("pods_bucket");
+  const podsBucket = podsBucketRaw === null || podsBucketRaw === ""
+    ? "unknown"
+    : (BUCKET.test(podsBucketRaw) ? podsBucketRaw : null);
+  if (podsBucket === null) return null;
+  const featuresRaw = q.get("features");
+  const features = featuresRaw === null || featuresRaw === ""
+    ? "none"
+    : (FEATURES.test(featuresRaw) ? featuresRaw : null);
+  if (features === null) return null;
+
+  return {
+    install, broker, chart, k8s, arch, nodes,
+    provider, distro, cni, ipFamily, nodeOs, podsBucket, features,
+  };
 }
 
 function recordCheckin(env, request, url) {
@@ -155,9 +213,15 @@ function recordCheckin(env, request, url) {
   if (!env.TELEMETRY) return; // dataset unbound in local dev
   const c = parseCheckin(url.searchParams);
   if (!c) return;
+  // Blob order is the Analytics Engine schema: APPEND-ONLY. blob1-5 are
+  // contract v1 and every existing query indexes them by position.
   env.TELEMETRY.writeDataPoint({
     indexes: [c.install],
-    blobs: [c.broker, c.chart, c.k8s, c.arch, request.cf?.country ?? "unknown"],
+    blobs: [
+      c.broker, c.chart, c.k8s, c.arch, request.cf?.country ?? "unknown",
+      c.provider, c.distro, c.cni, c.ipFamily, c.nodeOs, c.podsBucket,
+      c.features,
+    ],
     doubles: [c.nodes],
   });
 }

--- a/docs/telemetry.mdx
+++ b/docs/telemetry.mdx
@@ -16,7 +16,9 @@ you know exactly what it does and choose, than never notice it.
 ## Exactly what is sent
 
 One HTTPS `GET` per day to `https://version.kguardian.dev/v1/check` with
-these six query parameters — nothing else, ever:
+the query parameters below — nothing else, ever. The first six are the
+original contract; the rest were added in contract v2 and are optional
+(a broker that predates them is still accepted):
 
 | Field | Example | What it is |
 | --- | --- | --- |
@@ -26,6 +28,15 @@ these six query parameters — nothing else, ever:
 | `k8s` | `v1.33.1` | Kubernetes version, captured by the chart at install/upgrade time. |
 | `nodes` | `3` | Count of distinct live nodes the controller has observed — a coarse size signal, not an inventory. |
 | `arch` | `x86_64` | Broker CPU architecture. |
+| `provider` | `aws` | Cloud platform, derived from the node's `providerID` scheme. One of a fixed list (`aws`, `gcp`, `azure`, `digitalocean`, `hetzner`, `openstack`, `vsphere`, `oracle`, `ibm`, `baremetal`, `kind`) or `unknown`. Never an account, project, or region. |
+| `distro` | `k3s` | Kubernetes distribution flavor (`eks`, `gke`, `aks`, `k3s`, `rke2`, `talos`, `openshift`, `kind`, `vanilla`), derived from well-known node labels and version suffixes. |
+| `cni` | `cilium` | CNI plugin, derived from node annotations (`cilium`, `calico`, `flannel`, `weave`, `antrea`, `kindnet`). |
+| `ip_family` | `dual` | Cluster IP family (`ipv4`, `ipv6`, `dual`), derived from node pod CIDRs. |
+| `node_os` | `talos` | Node operating-system family from `nodeInfo.osImage`, coarsened to a fixed list. |
+| `pods_bucket` | `10-99` | Order-of-magnitude bucket of pods observed — never an exact inventory. |
+| `features` | `ai,audit` | Which optional kguardian features are enabled, as fixed slugs — no configuration values. |
+
+The v2 fields (everything below `arch`) are optional: older brokers that do not send them are still accepted, and every value is validated against a fixed whitelist server-side. All of them are coarse enums or buckets by design — the check-in never carries names, addresses, regions, instance types, or configuration contents.
 
 The exact field list is pinned by a unit test in the broker
 (`check_params_send_exactly_the_documented_fields`) — a change to the wire


### PR DESCRIPTION
First half of telemetry contract v2 (worker + docs; the broker/controller sender comes as a follow-up PR so the worker deploys first and no early check-ins are dropped).

**New optional fields** — `provider` (from the node `providerID` scheme), `distro`, `cni`, `ip_family`, `node_os`, `pods_bucket`, `features`. Each is validated against a fixed server-side whitelist; absent/empty resolves to `unknown`/`none`, so **v1 brokers remain accepted unchanged**. Analytics Engine blob order is append-only — blob1–5 keep their contract-v1 meaning, existing queries unaffected.

**Privacy posture** (documented in `docs/telemetry.mdx`, updated in this PR): coarse enums and order-of-magnitude buckets only — never account/project identifiers, regions, node names, addresses, instance types, or configuration contents.

**Validation**: parser behavior tested — v1-only check-in accepted, full v2 accepted, out-of-whitelist `provider` and malformed `features` rejected, absent v2 fields default correctly.