### PR TITLE
feat(telemetry): report environment signals in the check-in

### DIFF
--- a/broker/db/migrations/2026-09-02-090000_node_facts/down.sql
+++ b/broker/db/migrations/2026-09-02-090000_node_facts/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS node_facts;

--- a/broker/db/migrations/2026-09-02-090000_node_facts/up.sql
+++ b/broker/db/migrations/2026-09-02-090000_node_facts/up.sql
@@ -1,0 +1,14 @@
+-- One row per node: coarse environment facts the controller derives
+-- from its own Node object (provider/distro/CNI/IP family/OS family),
+-- aggregated into the anonymous telemetry check-in (contract v2, see
+-- docs/telemetry.mdx). Tiny table (node count rows), upserted on
+-- controller start. IF NOT EXISTS keeps re-runs harmless.
+CREATE TABLE IF NOT EXISTS node_facts (
+    node_name VARCHAR PRIMARY KEY,
+    provider VARCHAR NOT NULL,
+    distro VARCHAR NOT NULL,
+    cni VARCHAR NOT NULL,
+    ip_family VARCHAR NOT NULL,
+    node_os VARCHAR NOT NULL,
+    time_stamp TIMESTAMP NOT NULL
+);

--- a/broker/src/add.rs
+++ b/broker/src/add.rs
@@ -1014,3 +1014,46 @@ mod tests {
         assert_ne!(traffic_content_key(&a), traffic_content_key(&b));
     }
 }
+
+/// Upsert one node's coarse environment facts (see NodeFact). Called by
+/// the controller once per start; the telemetry check-in aggregates the
+/// table. Light validation only — the version service re-whitelists
+/// every value before anything is recorded upstream.
+#[post("/node/facts")]
+pub async fn add_node_facts(
+    pool: web::Data<DbPool>,
+    form: web::Json<crate::NodeFact>,
+) -> Result<HttpResponse, Error> {
+    let fact = form.into_inner();
+    if fact.node_name.trim().is_empty() {
+        return Ok(HttpResponse::BadRequest().body("node_name must not be empty"));
+    }
+    // Enum fields are short fixed strings; anything oversized is junk
+    // (the broker API is in-cluster but unauthenticated by default).
+    let fields = [
+        &fact.node_name,
+        &fact.provider,
+        &fact.distro,
+        &fact.cni,
+        &fact.ip_family,
+        &fact.node_os,
+    ];
+    if fields.iter().any(|f| f.len() > 253) {
+        return Ok(HttpResponse::BadRequest().body("field too long"));
+    }
+    web::block(move || -> Result<(), DbError> {
+        use schema::node_facts::dsl::*;
+        let mut conn = pool.get()?;
+        diesel::insert_into(node_facts)
+            .values(&fact)
+            .on_conflict(node_name)
+            .do_update()
+            .set(&fact)
+            .execute(&mut conn)?;
+        Ok(())
+    })
+    .await?
+    .map_err(actix_web::error::ErrorInternalServerError)?;
+    debug!("node facts upserted");
+    Ok(HttpResponse::Ok().json(()))
+}

--- a/broker/src/lib.rs
+++ b/broker/src/lib.rs
@@ -7,7 +7,10 @@ mod retention;
 mod telemetry;
 mod types;
 mod version_check;
-pub use add::{add_pod_details, add_pods_batch, add_pods_syscalls, add_svc_details, mark_pod_dead};
+pub use add::{
+    add_node_facts, add_pod_details, add_pods_batch, add_pods_syscalls, add_svc_details,
+    mark_pod_dead,
+};
 pub use audit::AuditClient;
 pub use error::*;
 pub use retention::spawn as spawn_retention;

--- a/broker/src/main.rs
+++ b/broker/src/main.rs
@@ -4,11 +4,11 @@ use actix_cors::Cors;
 use actix_web::middleware::from_fn;
 use actix_web::{get, web, App, HttpResponse, HttpServer};
 use api::{
-    add_pod_details, add_pods_batch, add_pods_syscalls, add_svc_details, establish_connection,
-    get_audit_verdicts, get_pod_by_ip, get_pod_by_name, get_pod_details, get_pod_syscall_name,
-    get_pod_traffic, get_pod_traffic_name, get_pods_by_node, get_svc_by_ip, get_svc_details,
-    get_version, mark_pod_dead, set_statement_timeout, spawn_retention, spawn_version_check,
-    AuditClient, StatementTimeoutCustomizer, VersionCheckState,
+    add_node_facts, add_pod_details, add_pods_batch, add_pods_syscalls, add_svc_details,
+    establish_connection, get_audit_verdicts, get_pod_by_ip, get_pod_by_name, get_pod_details,
+    get_pod_syscall_name, get_pod_traffic, get_pod_traffic_name, get_pods_by_node, get_svc_by_ip,
+    get_svc_details, get_version, mark_pod_dead, set_statement_timeout, spawn_retention,
+    spawn_version_check, AuditClient, StatementTimeoutCustomizer, VersionCheckState,
 };
 
 use diesel::r2d2;
@@ -333,6 +333,7 @@ async fn main() -> Result<(), std::io::Error> {
             .service(get_pods_by_node)
             .service(get_audit_verdicts)
             .service(mark_pod_dead)
+            .service(add_node_facts)
             .service(get_version)
             .service(health_check)
             .service(metrics)

--- a/broker/src/schema.rs
+++ b/broker/src/schema.rs
@@ -91,10 +91,26 @@ diesel::table! {
     }
 }
 
+diesel::table! {
+    // One row per node: coarse environment facts the controller derives
+    // from its own Node object, aggregated into the telemetry check-in
+    // (contract v2). Values are fixed enum strings, never identifiers.
+    node_facts (node_name) {
+        node_name -> Varchar,
+        provider -> Varchar,
+        distro -> Varchar,
+        cni -> Varchar,
+        ip_family -> Varchar,
+        node_os -> Varchar,
+        time_stamp -> Timestamp,
+    }
+}
+
 diesel::allow_tables_to_appear_in_same_query!(
     pod_details,
     pod_traffic,
     svc_details,
     pod_syscalls,
     audit_verdicts,
+    node_facts,
 );

--- a/broker/src/types.rs
+++ b/broker/src/types.rs
@@ -139,3 +139,29 @@ pub struct AuditVerdict {
     pub observed_at: NaiveDateTime,
     pub verdict: String, // "Allow" | "WouldDeny"
 }
+
+/// One node's coarse environment facts, POSTed by the controller at
+/// startup (controller/src/node_facts.rs) and aggregated into the
+/// anonymous telemetry check-in (version_check.rs). Fixed enum strings
+/// only — the wire values are re-whitelisted by the version service.
+#[derive(
+    Debug, Clone, Serialize, Deserialize, Queryable, Insertable, AsChangeset, Identifiable,
+)]
+#[diesel(table_name = crate::schema::node_facts)]
+#[diesel(primary_key(node_name))]
+pub struct NodeFact {
+    pub node_name: String,
+    pub provider: String,
+    pub distro: String,
+    pub cni: String,
+    pub ip_family: String,
+    pub node_os: String,
+    #[serde(default = "chrono_now")]
+    pub time_stamp: NaiveDateTime,
+}
+
+/// Serde default for rows arriving without a timestamp (the controller
+/// doesn't send one; the broker stamps arrival time).
+fn chrono_now() -> NaiveDateTime {
+    chrono::Utc::now().naive_utc()
+}

--- a/broker/src/version_check.rs
+++ b/broker/src/version_check.rs
@@ -240,10 +240,158 @@ fn live_node_count(pool: &DbPool) -> Result<i64, DbError> {
     Ok(row.n)
 }
 
+/// Contract-v2 environment signals: coarse enums aggregated from the
+/// per-node facts the controller reports, plus a pods bucket and the
+/// chart's feature-flag list. Every value is a fixed enum/bucket string
+/// — the version service re-whitelists them all (docs/telemetry.mdx).
+pub(crate) struct EnvSignals {
+    provider: String,
+    distro: String,
+    cni: String,
+    ip_family: String,
+    node_os: String,
+    pods_bucket: String,
+    features: String,
+}
+
+impl Default for EnvSignals {
+    fn default() -> Self {
+        Self {
+            provider: "unknown".into(),
+            distro: "unknown".into(),
+            cni: "unknown".into(),
+            ip_family: "unknown".into(),
+            node_os: "unknown".into(),
+            pods_bucket: "unknown".into(),
+            features: "none".into(),
+        }
+    }
+}
+
+/// Most frequent value in a column, ties broken alphabetically for
+/// determinism; "unknown" when the table is empty.
+fn mode(values: &[String]) -> String {
+    use std::collections::BTreeMap;
+    let mut counts: BTreeMap<&str, usize> = BTreeMap::new();
+    for v in values {
+        *counts.entry(v.as_str()).or_default() += 1;
+    }
+    counts
+        .into_iter()
+        .max_by_key(|(_, n)| *n)
+        .map(|(v, _)| v.to_string())
+        .unwrap_or_else(|| "unknown".to_string())
+}
+
+/// Cluster IP family from per-node families: any node dual — or a mix
+/// of v4-only and v6-only nodes — means the cluster speaks both.
+fn aggregate_ip_family(values: &[String]) -> String {
+    let dual = values.iter().any(|v| v == "dual");
+    let v4 = values.iter().any(|v| v == "ipv4");
+    let v6 = values.iter().any(|v| v == "ipv6");
+    if dual || (v4 && v6) {
+        "dual".to_string()
+    } else {
+        mode(values)
+    }
+}
+
+/// Order-of-magnitude bucket for the pods count. Must stay within the
+/// version service's BUCKET pattern.
+pub(crate) fn bucketize(n: i64) -> String {
+    match n {
+        i64::MIN..=0 => "0".to_string(),
+        1..=9 => "1-9".to_string(),
+        10..=99 => "10-99".to_string(),
+        100..=999 => "100-999".to_string(),
+        1000..=9999 => "1000-9999".to_string(),
+        _ => "10000+".to_string(),
+    }
+}
+
+/// FEATURES env: comma-separated flag slugs the chart injects
+/// ("ai,audit"). Anything outside [a-z0-9_,] disables the field to
+/// "none" rather than shipping junk upstream.
+fn features() -> String {
+    features_from(std::env::var("FEATURES").ok().as_deref())
+}
+
+fn features_from(raw: Option<&str>) -> String {
+    let Some(v) = raw.map(str::trim).filter(|v| !v.is_empty()) else {
+        return "none".to_string();
+    };
+    if v.len() <= 400
+        && v.bytes()
+            .all(|b| b.is_ascii_lowercase() || b.is_ascii_digit() || b == b'_' || b == b',')
+    {
+        v.to_string()
+    } else {
+        "none".to_string()
+    }
+}
+
+/// Aggregate the node_facts table (plus pod count + FEATURES env) into
+/// the check-in's environment signals. Any DB error degrades to
+/// defaults — telemetry must never fail the check-in.
+fn env_signals(pool: &DbPool) -> EnvSignals {
+    use crate::schema::node_facts::dsl as nf;
+    use crate::schema::pod_details::dsl as pd;
+    use diesel::prelude::*;
+
+    let mut out = EnvSignals {
+        features: features(),
+        ..EnvSignals::default()
+    };
+    let Ok(mut conn) = pool.get() else {
+        return out;
+    };
+    if let Ok(rows) = nf::node_facts
+        .select((
+            nf::provider,
+            nf::distro,
+            nf::cni,
+            nf::ip_family,
+            nf::node_os,
+        ))
+        .load::<(String, String, String, String, String)>(&mut conn)
+    {
+        if !rows.is_empty() {
+            let col = |i: usize| -> Vec<String> {
+                rows.iter()
+                    .map(|r| match i {
+                        0 => r.0.clone(),
+                        1 => r.1.clone(),
+                        2 => r.2.clone(),
+                        3 => r.3.clone(),
+                        _ => r.4.clone(),
+                    })
+                    .collect()
+            };
+            out.provider = mode(&col(0));
+            out.distro = mode(&col(1));
+            out.cni = mode(&col(2));
+            out.ip_family = aggregate_ip_family(&col(3));
+            out.node_os = mode(&col(4));
+        }
+    }
+    if let Ok(n) = pd::pod_details
+        .filter(pd::is_dead.eq(false))
+        .count()
+        .get_result::<i64>(&mut conn)
+    {
+        out.pods_bucket = bucketize(n);
+    }
+    out
+}
+
 /// The full query-parameter set for a check-in. Pure so the tests can
 /// pin exactly what leaves the process — this list and docs/telemetry
 /// must stay in lockstep.
-pub(crate) fn check_params(install: &str, nodes: i64) -> Vec<(&'static str, String)> {
+pub(crate) fn check_params(
+    install: &str,
+    nodes: i64,
+    env: &EnvSignals,
+) -> Vec<(&'static str, String)> {
     vec![
         ("install", install.to_string()),
         ("broker", env!("CARGO_PKG_VERSION").to_string()),
@@ -251,6 +399,13 @@ pub(crate) fn check_params(install: &str, nodes: i64) -> Vec<(&'static str, Stri
         ("k8s", kube_version()),
         ("nodes", nodes.to_string()),
         ("arch", std::env::consts::ARCH.to_string()),
+        ("provider", env.provider.clone()),
+        ("distro", env.distro.clone()),
+        ("cni", env.cni.clone()),
+        ("ip_family", env.ip_family.clone()),
+        ("node_os", env.node_os.clone()),
+        ("pods_bucket", env.pods_bucket.clone()),
+        ("features", env.features.clone()),
     ]
 }
 
@@ -265,10 +420,12 @@ async fn run_check(
     let nodes = tokio::task::spawn_blocking(move || live_node_count(&p))
         .await?
         .unwrap_or(0);
+    let p = pool.clone();
+    let env = tokio::task::spawn_blocking(move || env_signals(&p)).await?;
 
     let response = client
         .get(endpoint)
-        .query(&check_params(&install, nodes))
+        .query(&check_params(&install, nodes, &env))
         .send()
         .await?
         .error_for_status()?
@@ -434,16 +591,79 @@ mod tests {
         // added or removed here, the docs page MUST change in the same
         // commit — this test is the tripwire.
         with_env("CHART_VERSION", Some("9.9.9"), || {
-            let params = check_params("abc-123", 4);
+            let params = check_params("abc-123", 4, &EnvSignals::default());
             let keys: Vec<&str> = params.iter().map(|(k, _)| *k).collect();
-            assert_eq!(keys, ["install", "broker", "chart", "k8s", "nodes", "arch"]);
+            assert_eq!(
+                keys,
+                [
+                    "install",
+                    "broker",
+                    "chart",
+                    "k8s",
+                    "nodes",
+                    "arch",
+                    "provider",
+                    "distro",
+                    "cni",
+                    "ip_family",
+                    "node_os",
+                    "pods_bucket",
+                    "features",
+                ]
+            );
             let map: HashMap<_, _> = params.into_iter().collect();
             assert_eq!(map["install"], "abc-123");
             assert_eq!(map["broker"], env!("CARGO_PKG_VERSION"));
             assert_eq!(map["chart"], "9.9.9");
             assert_eq!(map["nodes"], "4");
             assert_eq!(map["arch"], std::env::consts::ARCH);
+            // v2 defaults: coarse "unknown"/"none" — never absent, so
+            // the wire shape is identical whether or not the controller
+            // ever reported node facts.
+            assert_eq!(map["provider"], "unknown");
+            assert_eq!(map["features"], "none");
+            assert_eq!(map["pods_bucket"], "unknown");
         });
+    }
+
+    #[test]
+    fn bucketize_matches_the_worker_pattern() {
+        assert_eq!(bucketize(0), "0");
+        assert_eq!(bucketize(-3), "0");
+        assert_eq!(bucketize(1), "1-9");
+        assert_eq!(bucketize(99), "10-99");
+        assert_eq!(bucketize(100), "100-999");
+        assert_eq!(bucketize(9999), "1000-9999");
+        assert_eq!(bucketize(50_000), "10000+");
+    }
+
+    #[test]
+    fn ip_family_aggregation_detects_dual_from_mixed_nodes() {
+        let v = |xs: &[&str]| xs.iter().map(|s| s.to_string()).collect::<Vec<_>>();
+        assert_eq!(aggregate_ip_family(&v(&["ipv4", "ipv4"])), "ipv4");
+        assert_eq!(aggregate_ip_family(&v(&["ipv4", "dual"])), "dual");
+        assert_eq!(aggregate_ip_family(&v(&["ipv4", "ipv6"])), "dual");
+        assert_eq!(aggregate_ip_family(&v(&["ipv6"])), "ipv6");
+        assert_eq!(aggregate_ip_family(&[]), "unknown");
+    }
+
+    #[test]
+    fn features_env_is_whitelisted_or_none() {
+        assert_eq!(features_from(None), "none");
+        assert_eq!(features_from(Some("  ")), "none");
+        assert_eq!(features_from(Some("ai,audit")), "ai,audit");
+        assert_eq!(features_from(Some("AI;DROP TABLE")), "none");
+    }
+
+    #[test]
+    fn mode_breaks_ties_deterministically() {
+        let v = |xs: &[&str]| xs.iter().map(|s| s.to_string()).collect::<Vec<_>>();
+        assert_eq!(mode(&v(&["aws", "gcp", "aws"])), "aws");
+        // Equal counts: the max_by_key over a BTreeMap keeps the LAST
+        // maximal entry in key order — pinned so status output can't
+        // flap between runs.
+        assert_eq!(mode(&v(&["aws", "gcp"])), "gcp");
+        assert_eq!(mode(&[]), "unknown");
     }
 
     /// Real-network proof that the reqwest `rustls` feature gives a

--- a/charts/kguardian/README.md
+++ b/charts/kguardian/README.md
@@ -2,7 +2,7 @@
 
 This chart bootstraps the [kguardian]() controlplane onto a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
 
-![Version: 1.19.1](https://img.shields.io/badge/Version-1.19.1-informational?style=flat-square)
+![Version: 1.19.2](https://img.shields.io/badge/Version-1.19.2-informational?style=flat-square)
 
 ## Overview
 

--- a/charts/kguardian/templates/broker/deployment.yaml
+++ b/charts/kguardian/templates/broker/deployment.yaml
@@ -128,6 +128,16 @@ spec:
               value: {{ .Chart.Version | quote }}
             - name: KUBE_VERSION
               value: {{ .Capabilities.KubeVersion.Version | quote }}
+            # Which optional features are on, as fixed slugs — part of
+            # the telemetry check-in (contract v2, docs/telemetry.mdx).
+            # Flag names only, never configuration values.
+            - name: FEATURES
+              {{- $features := list }}
+              {{- if or .Values.ai.enabled .Values.llmBridge.enabled }}{{- $features = append $features "ai" }}{{- end }}
+              {{- if .Values.evaluator.enabled }}{{- $features = append $features "audit" }}{{- end }}
+              {{- if .Values.broker.networkPolicy.enabled }}{{- $features = append $features "netpol" }}{{- end }}
+              {{- if .Values.frontend.sso.enabled }}{{- $features = append $features "sso" }}{{- end }}
+              value: {{ join "," $features | quote }}
           {{- with .Values.broker.startupProbe }}
           startupProbe:
             {{- toYaml . | nindent 12 }}

--- a/charts/kguardian/templates/clusterrole.yaml
+++ b/charts/kguardian/templates/clusterrole.yaml
@@ -12,6 +12,14 @@ rules:
     - get
     - watch
     - list
+# The controller reads its OWN Node object once at startup to derive
+# coarse environment facts (provider/distro/CNI/IP family/OS) for the
+# anonymous telemetry check-in (docs/telemetry.mdx). get only — no
+# list/watch over nodes.
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs:
+    - get
 - apiGroups: ["apps"]
   resources:
   - deployments

--- a/controller/src/lib.rs
+++ b/controller/src/lib.rs
@@ -15,3 +15,4 @@ use client::*;
 
 pub mod bpf;
 pub mod log;
+pub mod node_facts;

--- a/controller/src/main.rs
+++ b/controller/src/main.rs
@@ -43,6 +43,15 @@ async fn main() -> Result<(), Error> {
         .filter(|s| !s.is_empty())
         .ok_or_else(|| Error::Custom("API_ENDPOINT environment variable not set".to_string()))?;
 
+    // One-shot, fire-and-forget: derive this node's environment facts
+    // (provider/distro/CNI/IP family/OS) and report them to the broker
+    // for the anonymous telemetry check-in. Deliberately NOT part of
+    // the try_join! fabric — telemetry must never take capture down.
+    tokio::spawn(kguardian::node_facts::report_node_facts(
+        node_name.clone(),
+        broker_url.clone(),
+    ));
+
     let excluded_namespaces: Vec<String> = kguardian::pod_watcher::parse_excluded_namespaces(
         &env::var("EXCLUDED_NAMESPACES").unwrap_or_else(|_| "kube-system,kguardian".to_string()),
     );

--- a/controller/src/node_facts.rs
+++ b/controller/src/node_facts.rs
@@ -1,0 +1,413 @@
+//! Environment facts about the node this controller runs on, derived
+//! from its own Node object and reported to the broker once at startup.
+//!
+//! The broker aggregates one row per node and folds the result into the
+//! anonymous daily telemetry check-in (contract v2 — see
+//! docs/telemetry.mdx). Everything here is deliberately COARSE: fixed
+//! enum strings that match the version service's server-side
+//! whitelists, never names, addresses, regions, or instance types.
+//!
+//! Reporting is telemetry-grade: any failure (missing RBAC on an older
+//! chart, API hiccup, broker unreachable) logs at debug/warn and gives
+//! up — it must never affect capture.
+
+use k8s_openapi::api::core::v1::Node;
+use kube::{Api, Client};
+use serde::Serialize;
+use tracing::{debug, warn};
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct NodeFacts {
+    pub node_name: String,
+    pub provider: String,
+    pub distro: String,
+    pub cni: String,
+    pub ip_family: String,
+    pub node_os: String,
+}
+
+/// Map a `spec.providerID` scheme to the telemetry provider enum.
+/// The scheme is the part before "://" — `aws://…`, `gce://…`, etc.
+/// No providerID at all is how bare-metal (and Talos-on-metal) nodes
+/// present.
+fn provider_from_id(provider_id: Option<&str>) -> &'static str {
+    let Some(id) = provider_id.filter(|s| !s.trim().is_empty()) else {
+        return "baremetal";
+    };
+    match id.split("://").next().unwrap_or("") {
+        "aws" => "aws",
+        "gce" => "gcp",
+        "azure" => "azure",
+        "digitalocean" => "digitalocean",
+        "hcloud" => "hetzner",
+        "openstack" => "openstack",
+        "vsphere" => "vsphere",
+        "oci" => "oracle",
+        "ibm" | "ibmpowervs" => "ibm",
+        "kind" => "kind",
+        _ => "unknown",
+    }
+}
+
+fn has_label_prefix(node: &Node, prefix: &str) -> bool {
+    node.metadata
+        .labels
+        .as_ref()
+        .is_some_and(|l| l.keys().any(|k| k.starts_with(prefix)))
+}
+
+fn has_annotation_prefix(node: &Node, prefix: &str) -> bool {
+    node.metadata
+        .annotations
+        .as_ref()
+        .is_some_and(|a| a.keys().any(|k| k.starts_with(prefix)))
+}
+
+fn kubelet_version(node: &Node) -> &str {
+    node.status
+        .as_ref()
+        .and_then(|s| s.node_info.as_ref())
+        .map(|i| i.kubelet_version.as_str())
+        .unwrap_or("")
+}
+
+fn os_image(node: &Node) -> String {
+    node.status
+        .as_ref()
+        .and_then(|s| s.node_info.as_ref())
+        .map(|i| i.os_image.to_lowercase())
+        .unwrap_or_default()
+}
+
+/// Kubernetes distribution flavor from well-known labels, kubelet
+/// version suffixes, and the OS image. Order matters: managed-offering
+/// labels are the strongest signal, version suffixes next, OS last.
+fn distro(node: &Node, provider: &str) -> &'static str {
+    if has_label_prefix(node, "eks.amazonaws.com/") {
+        return "eks";
+    }
+    if has_label_prefix(node, "cloud.google.com/gke") {
+        return "gke";
+    }
+    if has_label_prefix(node, "kubernetes.azure.com/") {
+        return "aks";
+    }
+    if has_label_prefix(node, "node.openshift.io/") {
+        return "openshift";
+    }
+    let kubelet = kubelet_version(node);
+    if kubelet.contains("+k3s") {
+        return "k3s";
+    }
+    if kubelet.contains("+rke2") {
+        return "rke2";
+    }
+    if os_image(node).contains("talos") {
+        return "talos";
+    }
+    if provider == "kind" {
+        return "kind";
+    }
+    "vanilla"
+}
+
+/// CNI plugin from the annotations each CNI's node agent stamps on the
+/// Node. Not every CNI annotates (kindnet doesn't) — "unknown" is an
+/// honest answer.
+fn cni(node: &Node) -> &'static str {
+    if has_annotation_prefix(node, "io.cilium") || has_annotation_prefix(node, "network.cilium.io/")
+    {
+        return "cilium";
+    }
+    if has_annotation_prefix(node, "projectcalico.org/") {
+        return "calico";
+    }
+    if has_annotation_prefix(node, "flannel.alpha.coreos.com/") {
+        return "flannel";
+    }
+    if has_annotation_prefix(node, "node.antrea.io/") {
+        return "antrea";
+    }
+    if has_annotation_prefix(node, "weave.works/") {
+        return "weave";
+    }
+    "unknown"
+}
+
+/// IP family of the node's pod CIDRs: ipv4 / ipv6 / dual.
+fn ip_family(node: &Node) -> &'static str {
+    let mut v4 = false;
+    let mut v6 = false;
+    let spec = node.spec.as_ref();
+    let cidrs: Vec<&String> = spec
+        .and_then(|s| s.pod_cidrs.as_ref())
+        .map(|c| c.iter().collect())
+        .or_else(|| spec.and_then(|s| s.pod_cidr.as_ref()).map(|c| vec![c]))
+        .unwrap_or_default();
+    for cidr in cidrs {
+        if cidr.contains(':') {
+            v6 = true;
+        } else if cidr.contains('.') {
+            v4 = true;
+        }
+    }
+    match (v4, v6) {
+        (true, true) => "dual",
+        (true, false) => "ipv4",
+        (false, true) => "ipv6",
+        (false, false) => "unknown",
+    }
+}
+
+/// Node OS family from `nodeInfo.osImage`, coarsened to the telemetry
+/// enum. Anything recognizable-but-unlisted is "other", absent info is
+/// "unknown".
+fn node_os(node: &Node) -> &'static str {
+    let img = os_image(node);
+    if img.is_empty() {
+        return "unknown";
+    }
+    if img.contains("talos") {
+        "talos"
+    } else if img.contains("bottlerocket") {
+        "bottlerocket"
+    } else if img.contains("flatcar") {
+        "flatcar"
+    } else if img.contains("container-optimized") {
+        "cos"
+    } else if img.contains("ubuntu") {
+        "ubuntu"
+    } else if img.contains("debian") {
+        "debian"
+    } else if img.contains("red hat") || img.contains("rhel") {
+        "rhel"
+    } else if img.contains("amazon linux") {
+        "amazonlinux"
+    } else if img.contains("alpine") {
+        "alpine"
+    } else {
+        "other"
+    }
+}
+
+/// Derive every fact from a Node object. Pure — the whole mapping is
+/// unit-tested below against representative Node shapes.
+pub fn derive_facts(node_name: &str, node: &Node) -> NodeFacts {
+    let provider_id = node.spec.as_ref().and_then(|s| s.provider_id.as_deref());
+    let provider = provider_from_id(provider_id);
+    NodeFacts {
+        node_name: node_name.to_string(),
+        provider: provider.to_string(),
+        distro: distro(node, provider).to_string(),
+        cni: cni(node).to_string(),
+        ip_family: ip_family(node).to_string(),
+        node_os: node_os(node).to_string(),
+    }
+}
+
+/// Fetch this node's object, derive facts, and POST them to the broker.
+/// Fire-and-forget: every failure path logs and returns.
+pub async fn report_node_facts(node_name: String, broker_url: String) {
+    let client = match Client::try_default().await {
+        Ok(c) => c,
+        Err(e) => {
+            debug!(error = %e, "no kube client for node facts");
+            return;
+        }
+    };
+    let nodes: Api<Node> = Api::all(client);
+    let node = match nodes.get(&node_name).await {
+        Ok(n) => n,
+        Err(e) => {
+            // Older charts don't grant `nodes get` — degrade silently
+            // rather than nagging on every start.
+            warn!(
+                node = %node_name,
+                error = %e,
+                "could not read own Node object (missing RBAC on an older chart?); \
+                 environment telemetry facts will report as unknown"
+            );
+            return;
+        }
+    };
+    let facts = derive_facts(&node_name, &node);
+    debug!(?facts, "derived node environment facts");
+    let url = format!("{}/node/facts", broker_url.trim_end_matches('/'));
+    match reqwest::Client::new().post(&url).json(&facts).send().await {
+        Ok(resp) if resp.status().is_success() => {
+            debug!(node = %node_name, "node facts reported");
+        }
+        Ok(resp) => {
+            // An older broker without the endpoint 404s — expected
+            // during mixed-version rollouts.
+            debug!(status = %resp.status(), "broker did not accept node facts");
+        }
+        Err(e) => {
+            debug!(error = %e, "node facts POST failed");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use k8s_openapi::api::core::v1::{NodeSpec, NodeStatus, NodeSystemInfo};
+    use std::collections::BTreeMap;
+
+    fn node(
+        provider_id: Option<&str>,
+        labels: &[(&str, &str)],
+        annotations: &[(&str, &str)],
+        kubelet: &str,
+        os: &str,
+        cidrs: &[&str],
+    ) -> Node {
+        let mut n = Node::default();
+        n.metadata.labels = Some(
+            labels
+                .iter()
+                .map(|(k, v)| (k.to_string(), v.to_string()))
+                .collect::<BTreeMap<_, _>>(),
+        );
+        n.metadata.annotations = Some(
+            annotations
+                .iter()
+                .map(|(k, v)| (k.to_string(), v.to_string()))
+                .collect::<BTreeMap<_, _>>(),
+        );
+        n.spec = Some(NodeSpec {
+            provider_id: provider_id.map(String::from),
+            pod_cidrs: if cidrs.is_empty() {
+                None
+            } else {
+                Some(cidrs.iter().map(|c| c.to_string()).collect())
+            },
+            ..Default::default()
+        });
+        n.status = Some(NodeStatus {
+            node_info: Some(NodeSystemInfo {
+                kubelet_version: kubelet.to_string(),
+                os_image: os.to_string(),
+                ..Default::default()
+            }),
+            ..Default::default()
+        });
+        n
+    }
+
+    #[test]
+    fn eks_node_derives_aws_eks() {
+        let n = node(
+            Some("aws:///us-east-1a/i-0abc"),
+            &[("eks.amazonaws.com/nodegroup", "ng-1")],
+            &[],
+            "v1.29.0-eks-abc",
+            "Amazon Linux 2",
+            &["10.0.0.0/24"],
+        );
+        let f = derive_facts("n1", &n);
+        assert_eq!(
+            (
+                f.provider.as_str(),
+                f.distro.as_str(),
+                f.ip_family.as_str(),
+                f.node_os.as_str()
+            ),
+            ("aws", "eks", "ipv4", "amazonlinux")
+        );
+    }
+
+    #[test]
+    fn talos_cilium_dual_stack_on_metal() {
+        let n = node(
+            None,
+            &[],
+            &[("network.cilium.io/ipv4-pod-cidr", "10.244.11.0/24")],
+            "v1.35.6",
+            "Talos (v1.13.4)",
+            &["10.244.11.0/24", "fd00:10:244::/64"],
+        );
+        let f = derive_facts("n1", &n);
+        assert_eq!(
+            (
+                f.provider.as_str(),
+                f.distro.as_str(),
+                f.cni.as_str(),
+                f.ip_family.as_str(),
+                f.node_os.as_str()
+            ),
+            ("baremetal", "talos", "cilium", "dual", "talos")
+        );
+    }
+
+    #[test]
+    fn gke_node_derives_gcp_gke_cos() {
+        let n = node(
+            Some("gce://proj/zone/instance"),
+            &[("cloud.google.com/gke-nodepool", "default")],
+            &[],
+            "v1.30.1-gke.100",
+            "Container-Optimized OS from Google",
+            &["10.4.0.0/24"],
+        );
+        let f = derive_facts("n1", &n);
+        assert_eq!(
+            (f.provider.as_str(), f.distro.as_str(), f.node_os.as_str()),
+            ("gcp", "gke", "cos")
+        );
+    }
+
+    #[test]
+    fn k3s_suffix_beats_vanilla_and_calico_annotation_wins() {
+        let n = node(
+            Some("k3s://node"),
+            &[],
+            &[("projectcalico.org/IPv4Address", "10.0.0.5/24")],
+            "v1.29.4+k3s1",
+            "Ubuntu 22.04.4 LTS",
+            &["10.42.0.0/24"],
+        );
+        let f = derive_facts("n1", &n);
+        assert_eq!(
+            (
+                f.provider.as_str(),
+                f.distro.as_str(),
+                f.cni.as_str(),
+                f.node_os.as_str()
+            ),
+            ("unknown", "k3s", "calico", "ubuntu")
+        );
+    }
+
+    #[test]
+    fn empty_node_degrades_to_unknowns_not_panics() {
+        let f = derive_facts("n1", &Node::default());
+        assert_eq!(
+            (
+                f.provider.as_str(),
+                f.distro.as_str(),
+                f.cni.as_str(),
+                f.ip_family.as_str(),
+                f.node_os.as_str()
+            ),
+            ("baremetal", "vanilla", "unknown", "unknown", "unknown")
+        );
+    }
+
+    #[test]
+    fn ipv6_only_pod_cidr_derives_ipv6() {
+        let n = node(
+            None,
+            &[],
+            &[],
+            "v1.30.0",
+            "Debian GNU/Linux 12",
+            &["fd00::/64"],
+        );
+        let f = derive_facts("n1", &n);
+        assert_eq!(
+            (f.ip_family.as_str(), f.node_os.as_str()),
+            ("ipv6", "debian")
+        );
+    }
+}


### PR DESCRIPTION
Second half of telemetry contract v2 (sender side; the worker accepting these fields is #1411 and should merge/deploy first so no early check-ins lose data — though ordering is safe either way).

**Controller** — reads its own Node object once at startup (`nodes: get` RBAC only) and derives coarse facts: `provider` from the `providerID` scheme, `distro` from managed-offering labels / kubelet suffixes / OS image, `cni` from node annotations, `ip_family` from pod CIDRs, `node_os` from `osImage`. POSTs them to the broker, fire-and-forget: missing RBAC (older chart), API hiccups, or an older broker 404 all degrade silently — telemetry can never affect capture. 6 unit tests over representative Node shapes (EKS, GKE, Talos+Cilium dual-stack, k3s+Calico, empty).

**Broker** — new tiny `node_facts` table (row per node, upserted), aggregated into the daily check-in: per-column mode, `ip_family` folded to `dual` when nodes disagree by family, `pods_bucket` as an order-of-magnitude bucket, `features` from a chart-injected env (whitelisted slugs or `none`). Fields are always present with `unknown`/`none` defaults so the wire shape is stable. The pinned wire-contract test (`check_params_send_exactly_the_documented_fields`) grows in lockstep with `docs/telemetry.mdx` (updated in #1411).

**Chart** — `nodes: get` on the viewer ClusterRole, and a `FEATURES` env computed from values (`ai`, `audit`, `netpol`, `sso`) — flag names only, never configuration contents.

**This also lays the exact rails the P1 node-infra identity work needs** (controller→broker node reporting).

Validation: controller 110 tests + clippy `-D warnings` + fmt; broker 172 tests + clippy + fmt; helm lint + G4 values-compat green; FEATURES rendering verified for defaults (`audit`) and combined flags (`ai,audit,netpol`).