### PR TITLE
fix(deps): bump chart to the telemetry-v2 + dual-stack batch

### DIFF
--- a/charts/kguardian/README.md
+++ b/charts/kguardian/README.md
@@ -104,7 +104,7 @@ The following table lists the configurable parameters of the kguardian chart and
 | broker.image.pullPolicy | string | `"IfNotPresent"` | Broker image pull policy |
 | broker.image.repository | string | `"ghcr.io/kguardian-dev/kguardian/broker"` | Broker container image repository |
 | broker.image.sha | string | `""` | Overrides the image tag using SHA digest |
-| broker.image.tag | string | `"1.13.1"` | Broker version tag (auto-updated by release-please) |
+| broker.image.tag | string | `"1.14.0"` | Broker version tag (auto-updated by release-please) |
 | broker.imagePullSecrets | list | `[]` | List of image pull secrets for private registries |
 | broker.initContainer.image.pullPolicy | string | `"Always"` | Broker init container image pull policy |
 | broker.initContainer.image.repository | string | `"busybox"` | Broker init container image repository |
@@ -155,7 +155,7 @@ The following table lists the configurable parameters of the kguardian chart and
 | controller.image.pullPolicy | string | `"IfNotPresent"` | Controller image pull policy |
 | controller.image.repository | string | `"ghcr.io/kguardian-dev/kguardian/controller"` | Controller container image repository |
 | controller.image.sha | string | `""` | Overrides the image tag using SHA digest |
-| controller.image.tag | string | `"1.10.1"` | Controller version tag (auto-updated by release-please) |
+| controller.image.tag | string | `"1.11.0"` | Controller version tag (auto-updated by release-please) |
 | controller.imagePullSecrets | list | `[]` | List of image pull secrets for private registries |
 | controller.initContainer.image.pullPolicy | string | `"Always"` | Init container image pull policy |
 | controller.initContainer.image.repository | string | `"busybox"` | Init container image repository |
@@ -262,7 +262,7 @@ The following table lists the configurable parameters of the kguardian chart and
 | frontend.image.pullPolicy | string | `"IfNotPresent"` | Frontend image pull policy |
 | frontend.image.repository | string | `"ghcr.io/kguardian-dev/kguardian/frontend"` | Frontend container image repository |
 | frontend.image.sha | string | `""` | Overrides the image tag using SHA digest |
-| frontend.image.tag | string | `"1.13.1"` | Frontend version tag (auto-updated by release-please) |
+| frontend.image.tag | string | `"1.13.2"` | Frontend version tag (auto-updated by release-please) |
 | frontend.imagePullSecrets | list | `[]` | List of image pull secrets for private registries |
 | frontend.ingress.annotations | object | `{}` | Ingress annotations |
 | frontend.ingress.apiPath | bool | `true` | Also route /api on the same host to the Broker. The Broker serves bare paths (/pod/info, /pod/traffic), so this only works behind an ingress controller that strips the prefix, such as nginx with rewrite-target. Controllers that pass the path through unchanged (AWS ALB, for example) make every /api request a 404. The UI image proxies /api to the Broker itself, so setting this to false serves the whole application from the UI Service and works on any controller. |
@@ -320,7 +320,7 @@ The following table lists the configurable parameters of the kguardian chart and
 | llmBridge.image.pullPolicy | string | `"IfNotPresent"` | LLM Bridge image pull policy |
 | llmBridge.image.repository | string | `"ghcr.io/kguardian-dev/kguardian/llm-bridge"` | LLM Bridge container image repository |
 | llmBridge.image.sha | string | `""` | Overrides the image tag using SHA digest |
-| llmBridge.image.tag | string | `"1.8.0"` | LLM Bridge version tag (auto-updated by release-please) |
+| llmBridge.image.tag | string | `"1.8.1"` | LLM Bridge version tag (auto-updated by release-please) |
 | llmBridge.imagePullSecrets | list | `[]` | List of image pull secrets for private registries |
 | llmBridge.metrics.serviceMonitor.enabled | bool | `false` | Create a ServiceMonitor for prometheus-operator. llm-bridge does not currently expose /metrics — forward-compatible toggle. |
 | llmBridge.metrics.serviceMonitor.interval | string | `"30s"` |  |

--- a/charts/kguardian/templates/broker/deployment.yaml
+++ b/charts/kguardian/templates/broker/deployment.yaml
@@ -63,13 +63,17 @@ spec:
                   key: {{ .Values.database.passwordSecretKey }}
             - name: DATABASE_URL
               value: {{ include "kguardian.dbUrl" . | quote }}
-            # Wire chart's broker.container.port through to the Rust
-            # binary so changing the chart port doesn't require also
-            # setting LISTEN_ADDR by hand. The bind address is always
-            # 0.0.0.0 — clusters that need a different bind can set
-            # LISTEN_ADDR via env override.
+            {{- if ne (int .Values.broker.container.port) 9090 }}
+            # Non-default port: wire it through via LISTEN_ADDR. An
+            # explicit LISTEN_ADDR binds verbatim, so this pins an
+            # IPv4-only socket — on an IPv6-only cluster with a custom
+            # port, override to "[::]:<port>" instead. With the default
+            # port this env is intentionally OMITTED so the broker's
+            # dual-stack default bind ([::] with an IPv4 fallback)
+            # stays in effect.
             - name: LISTEN_ADDR
               value: "0.0.0.0:{{ .Values.broker.container.port }}"
+            {{- end }}
             {{- include "kguardian.brokerAuthEnv" . | nindent 12 }}
             {{- if .Values.evaluator.enabled }}
             - name: EVALUATOR_URL

--- a/charts/kguardian/values.yaml
+++ b/charts/kguardian/values.yaml
@@ -41,7 +41,7 @@ controller:
     # -- Controller image pull policy
     pullPolicy: IfNotPresent
     # -- Controller version tag (auto-updated by release-please)
-    tag: "1.10.1"
+    tag: "1.11.0"
     # -- Overrides the image tag using SHA digest
     sha: ""
   initContainer:
@@ -179,7 +179,7 @@ broker:
     # -- Broker image pull policy
     pullPolicy: IfNotPresent
     # -- Broker version tag (auto-updated by release-please)
-    tag: "1.13.1"
+    tag: "1.14.0"
     # -- Overrides the image tag using SHA digest
     sha: ""
   initContainer:
@@ -661,7 +661,7 @@ frontend:
     # -- Frontend image pull policy
     pullPolicy: IfNotPresent
     # -- Frontend version tag (auto-updated by release-please)
-    tag: "1.13.1"
+    tag: "1.13.2"
     # -- Overrides the image tag using SHA digest
     sha: ""
 
@@ -961,7 +961,7 @@ llmBridge:
     # -- LLM Bridge image pull policy
     pullPolicy: IfNotPresent
     # -- LLM Bridge version tag (auto-updated by release-please)
-    tag: "1.8.0"
+    tag: "1.8.1"
     # -- Overrides the image tag using SHA digest
     sha: ""
 


### PR DESCRIPTION
controller 1.11.0, broker 1.14.0, frontend 1.13.2, llm-bridge 1.8.1. lint-test's wait-for-images step absorbs the release-build race.