### PR TITLE
feat: align policy generation with the cluster CNI

### DIFF
--- a/broker/src/lib.rs
+++ b/broker/src/lib.rs
@@ -16,7 +16,9 @@ pub use error::*;
 pub use retention::spawn as spawn_retention;
 pub use telemetry::*;
 pub use types::*;
-pub use version_check::{get_version, spawn as spawn_version_check, VersionCheckState};
+pub use version_check::{
+    get_cluster_environment, get_version, spawn as spawn_version_check, VersionCheckState,
+};
 mod conn;
 pub use conn::*;
 mod schema;

--- a/broker/src/main.rs
+++ b/broker/src/main.rs
@@ -5,10 +5,11 @@ use actix_web::middleware::from_fn;
 use actix_web::{get, web, App, HttpResponse, HttpServer};
 use api::{
     add_node_facts, add_pod_details, add_pods_batch, add_pods_syscalls, add_svc_details,
-    establish_connection, get_audit_verdicts, get_pod_by_ip, get_pod_by_name, get_pod_details,
-    get_pod_syscall_name, get_pod_traffic, get_pod_traffic_name, get_pods_by_node, get_svc_by_ip,
-    get_svc_details, get_version, mark_pod_dead, set_statement_timeout, spawn_retention,
-    spawn_version_check, AuditClient, StatementTimeoutCustomizer, VersionCheckState,
+    establish_connection, get_audit_verdicts, get_cluster_environment, get_pod_by_ip,
+    get_pod_by_name, get_pod_details, get_pod_syscall_name, get_pod_traffic, get_pod_traffic_name,
+    get_pods_by_node, get_svc_by_ip, get_svc_details, get_version, mark_pod_dead,
+    set_statement_timeout, spawn_retention, spawn_version_check, AuditClient,
+    StatementTimeoutCustomizer, VersionCheckState,
 };
 
 use diesel::r2d2;
@@ -362,6 +363,7 @@ async fn main() -> Result<(), std::io::Error> {
             .service(mark_pod_dead)
             .service(add_node_facts)
             .service(get_version)
+            .service(get_cluster_environment)
             .service(health_check)
             .service(metrics)
     })

--- a/broker/src/version_check.rs
+++ b/broker/src/version_check.rs
@@ -196,6 +196,53 @@ pub async fn get_version(state: web::Data<VersionCheckState>) -> impl Responder 
     })
 }
 
+/// Cluster-environment wire shape for GET /cluster/environment: the
+/// same coarse per-column aggregates the telemetry check-in sends
+/// (env_signals), exposed so the UI and assistant can align policy
+/// generation with the cluster CNI (issue #1413). `nodes` counts
+/// node_facts rows — 0 means no controller has reported yet, and every
+/// enum degrades to "unknown"; consumers MUST treat unknown as
+/// "behave exactly as before".
+#[derive(Serialize)]
+pub struct ClusterEnvironment {
+    pub cni: String,
+    pub ip_family: String,
+    pub provider: String,
+    pub distro: String,
+    pub node_os: String,
+    pub nodes: i64,
+}
+
+/// Always 200: DB trouble degrades to all-unknown/0 like env_signals —
+/// an environment hint must never break a page load.
+#[get("/cluster/environment")]
+pub async fn get_cluster_environment(pool: web::Data<DbPool>) -> impl Responder {
+    let p = pool.get_ref().clone();
+    let (signals, nodes) = tokio::task::spawn_blocking(move || {
+        let signals = env_signals(&p);
+        let nodes = node_fact_count(&p).unwrap_or(0);
+        (signals, nodes)
+    })
+    .await
+    .unwrap_or_else(|_| (EnvSignals::default(), 0));
+    HttpResponse::Ok().json(ClusterEnvironment {
+        cni: signals.cni,
+        ip_family: signals.ip_family,
+        provider: signals.provider,
+        distro: signals.distro,
+        node_os: signals.node_os,
+        nodes,
+    })
+}
+
+/// Rows in node_facts — how many controllers have reported facts.
+fn node_fact_count(pool: &DbPool) -> Result<i64, DbError> {
+    use crate::schema::node_facts::dsl as nf;
+    use diesel::prelude::*;
+    let mut conn = pool.get()?;
+    Ok(nf::node_facts.count().get_result::<i64>(&mut conn)?)
+}
+
 /// Read the install id, creating it on first run. Runs on the blocking
 /// pool (diesel is sync).
 fn get_or_create_install_id(pool: &DbPool) -> Result<String, DbError> {
@@ -624,6 +671,48 @@ mod tests {
             assert_eq!(map["features"], "none");
             assert_eq!(map["pods_bucket"], "unknown");
         });
+    }
+
+    #[test]
+    fn cluster_environment_serializes_the_documented_shape() {
+        // Wire contract for GET /cluster/environment — the UI and
+        // assistant key on exactly these fields (docs/api-reference).
+        let env = ClusterEnvironment {
+            cni: "cilium".into(),
+            ip_family: "dual".into(),
+            provider: "baremetal".into(),
+            distro: "talos".into(),
+            node_os: "talos".into(),
+            nodes: 3,
+        };
+        let v: serde_json::Value = serde_json::to_value(&env).unwrap();
+        // serde_json::Value maps iterate in key order — compare as a
+        // sorted set; field presence is the contract, not order.
+        let keys: Vec<&str> = v.as_object().unwrap().keys().map(|k| k.as_str()).collect();
+        assert_eq!(
+            keys,
+            ["cni", "distro", "ip_family", "node_os", "nodes", "provider"]
+        );
+        assert_eq!(v["cni"], "cilium");
+        assert_eq!(v["nodes"], 3);
+    }
+
+    #[test]
+    fn env_signals_default_degrades_to_all_unknown() {
+        // The unknown-degradation pin: consumers treat "unknown" as
+        // "behave exactly as before", so the no-facts default must be
+        // unknown everywhere (features excepted — it is env-sourced).
+        let d = EnvSignals::default();
+        assert_eq!(
+            (
+                d.cni.as_str(),
+                d.ip_family.as_str(),
+                d.provider.as_str(),
+                d.distro.as_str(),
+                d.node_os.as_str()
+            ),
+            ("unknown", "unknown", "unknown", "unknown", "unknown")
+        );
     }
 
     #[test]

--- a/broker/src/version_check.rs
+++ b/broker/src/version_check.rs
@@ -213,6 +213,21 @@ pub struct ClusterEnvironment {
     pub nodes: i64,
 }
 
+/// Clamp a stored fact to a fixed whitelist before it leaves the API.
+/// node_facts rows come from the in-cluster (and by default
+/// unauthenticated) POST /node/facts, so a poisoned row must not flow
+/// verbatim to consumers — the assistant interpolates `cni` into a
+/// YAML comment, where an unexpected value (a newline, say) could
+/// inject lines. Anything off-list degrades to "unknown", the value
+/// every consumer already treats as "no signal".
+fn clamp_enum(value: String, allowed: &[&str]) -> String {
+    if allowed.contains(&value.as_str()) {
+        value
+    } else {
+        "unknown".to_string()
+    }
+}
+
 /// Always 200: DB trouble degrades to all-unknown/0 like env_signals —
 /// an environment hint must never break a page load.
 #[get("/cluster/environment")]
@@ -225,12 +240,64 @@ pub async fn get_cluster_environment(pool: web::Data<DbPool>) -> impl Responder 
     })
     .await
     .unwrap_or_else(|_| (EnvSignals::default(), 0));
+    // Whitelists mirror controller/src/node_facts.rs and the version
+    // service (docs/telemetry.mdx) — keep the three in lockstep.
     HttpResponse::Ok().json(ClusterEnvironment {
-        cni: signals.cni,
-        ip_family: signals.ip_family,
-        provider: signals.provider,
-        distro: signals.distro,
-        node_os: signals.node_os,
+        cni: clamp_enum(
+            signals.cni,
+            &[
+                "cilium", "calico", "flannel", "weave", "antrea", "kindnet", "unknown",
+            ],
+        ),
+        ip_family: clamp_enum(signals.ip_family, &["ipv4", "ipv6", "dual", "unknown"]),
+        provider: clamp_enum(
+            signals.provider,
+            &[
+                "aws",
+                "gcp",
+                "azure",
+                "digitalocean",
+                "hetzner",
+                "openstack",
+                "vsphere",
+                "oracle",
+                "ibm",
+                "baremetal",
+                "kind",
+                "unknown",
+            ],
+        ),
+        distro: clamp_enum(
+            signals.distro,
+            &[
+                "eks",
+                "gke",
+                "aks",
+                "k3s",
+                "rke2",
+                "talos",
+                "openshift",
+                "kind",
+                "vanilla",
+                "unknown",
+            ],
+        ),
+        node_os: clamp_enum(
+            signals.node_os,
+            &[
+                "talos",
+                "bottlerocket",
+                "flatcar",
+                "cos",
+                "ubuntu",
+                "debian",
+                "rhel",
+                "amazonlinux",
+                "alpine",
+                "other",
+                "unknown",
+            ],
+        ),
         nodes,
     })
 }
@@ -695,6 +762,25 @@ mod tests {
         );
         assert_eq!(v["cni"], "cilium");
         assert_eq!(v["nodes"], 3);
+    }
+
+    #[test]
+    fn clamp_enum_rejects_off_list_values() {
+        // The injection guard: a poisoned node_facts row (the POST is
+        // in-cluster-unauthenticated by default) must never flow
+        // verbatim to consumers that interpolate these values.
+        assert_eq!(
+            clamp_enum("cilium".into(), &["cilium", "unknown"]),
+            "cilium"
+        );
+        assert_eq!(
+            clamp_enum("evil\n# injected".into(), &["cilium", "unknown"]),
+            "unknown"
+        );
+        assert_eq!(
+            clamp_enum("CILIUM".into(), &["cilium", "unknown"]),
+            "unknown"
+        );
     }
 
     #[test]

--- a/docs/api-reference/endpoints/environment.mdx
+++ b/docs/api-reference/endpoints/environment.mdx
@@ -1,0 +1,47 @@
+---
+title: "Cluster Environment Endpoint"
+description: "Coarse cluster-environment aggregates: CNI, IP family, platform"
+icon: "globe"
+---
+
+## Overview
+
+`GET /cluster/environment` exposes the same coarse environment
+aggregates the [telemetry check-in](/telemetry) reports — CNI, IP
+family, provider, distribution, and node OS — derived from per-node
+facts each controller reports at startup. The UI and the AI assistant
+use it to align policy generation with the cluster: a
+`CiliumNetworkPolicy` is only applicable where Cilium runs, so the
+Policy Builder badges the Cilium option and the assistant annotates
+its output when the detected CNI is something else.
+
+Every value is a fixed enum. `"unknown"` means "no signal" — the CNI
+does not annotate nodes (kindnet), no controller has reported yet, or
+the controller predates fact reporting — and consumers treat it as
+"behave exactly as before". Mixed-CNI clusters resolve to the most
+common per-node value.
+
+## GET /cluster/environment
+
+Requires bearer auth when `BROKER_AUTH_TOKEN` is set. Always returns
+`200` — database trouble degrades to all-`unknown`, never an error.
+
+```json
+{
+  "cni": "cilium",
+  "ip_family": "dual",
+  "provider": "baremetal",
+  "distro": "talos",
+  "node_os": "talos",
+  "nodes": 3
+}
+```
+
+| Field | Values |
+| --- | --- |
+| `cni` | `cilium`, `calico`, `flannel`, `weave`, `antrea`, `unknown` |
+| `ip_family` | `ipv4`, `ipv6`, `dual`, `unknown` |
+| `provider` | `aws`, `gcp`, `azure`, `digitalocean`, `hetzner`, `openstack`, `vsphere`, `oracle`, `ibm`, `baremetal`, `kind`, `unknown` |
+| `distro` | `eks`, `gke`, `aks`, `k3s`, `rke2`, `talos`, `openshift`, `kind`, `vanilla`, `unknown` |
+| `node_os` | `talos`, `bottlerocket`, `flatcar`, `cos`, `ubuntu`, `debian`, `rhel`, `amazonlinux`, `alpine`, `other`, `unknown` |
+| `nodes` | Count of nodes that have reported facts; `0` = none yet |

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -92,7 +92,8 @@
               "api-reference/endpoints/syscalls",
               "api-reference/endpoints/services",
               "api-reference/endpoints/audit-verdicts",
-              "api-reference/endpoints/version"
+              "api-reference/endpoints/version",
+              "api-reference/endpoints/environment"
             ]
           }
         ]

--- a/frontend/src/components/NetworkPolicyEditor.tsx
+++ b/frontend/src/components/NetworkPolicyEditor.tsx
@@ -5,6 +5,8 @@ import type { SeccompAction } from '../types/seccompProfile';
 import { policyToYAML } from '../utils/networkPolicyGenerator';
 import { ciliumPolicyToYAML } from '../utils/ciliumPolicyGenerator';
 import { profileToYAML } from '../utils/seccompProfileGenerator';
+import { useClusterEnvironment } from '../hooks/useClusterEnvironment';
+import { CniMismatchNotice } from './PolicyEditor/CniMismatchNotice';
 import { SECCOMP_ACTIONS, ARCHITECTURES, SECCOMP_ACTION_DESCRIPTIONS } from '../types/seccompProfile';
 import { PolicyHeader } from './PolicyEditor';
 import { Modal } from './ui/Modal';
@@ -27,6 +29,17 @@ interface NetworkPolicyEditorProps {
 const NetworkPolicyEditor: React.FC<NetworkPolicyEditorProps> = ({ isOpen, onClose, pod }) => {
   const [policyType, setPolicyType] = useState<PolicyType>('network');
   const [yamlView, setYamlView] = useState(true); // Default to YAML view
+
+  // Align with the cluster CNI (issue #1413): when the detected CNI is
+  // real and not cilium, badge the Cilium tab and show a notice on it.
+  // 'unknown' (no facts yet, older broker, non-annotating CNI) keeps
+  // the editor pixel-identical to its pre-detection behavior, and the
+  // async fetch never gates rendering.
+  const { cni } = useClusterEnvironment();
+  const cniMismatch = cni !== 'unknown' && cni !== 'cilium' ? cni : null;
+  const ciliumWarning = cniMismatch
+    ? `Cluster CNI detected as ${cniMismatch} — CiliumNetworkPolicy is likely not applicable here`
+    : null;
 
   // Network policy management
   const {
@@ -158,7 +171,10 @@ const NetworkPolicyEditor: React.FC<NetworkPolicyEditorProps> = ({ isOpen, onClo
             onClose={onClose}
             podName={pod.pod.pod_name}
             podNamespace={pod.pod.pod_namespace}
+            ciliumWarning={ciliumWarning}
           />
+
+          {policyType === 'cilium' && cniMismatch && <CniMismatchNotice cni={cniMismatch} />}
 
           {/* Content */}
           <div className="flex-1 overflow-hidden flex">

--- a/frontend/src/components/PolicyEditor/CniMismatchNotice.test.tsx
+++ b/frontend/src/components/PolicyEditor/CniMismatchNotice.test.tsx
@@ -1,0 +1,25 @@
+// @vitest-environment jsdom
+import { afterEach, expect, test } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { CniMismatchNotice } from './CniMismatchNotice';
+
+afterEach(cleanup);
+
+// The notice backs CNI-aligned policy generation (issue #1413): shown
+// only on a REAL mismatch (callers gate on cni !== unknown/cilium), it
+// names the detected CNI, warns about both failure modes (CRD absent →
+// apply fails; CRD present but unenforced → silently inert), and is
+// dismissible without disabling export.
+
+test('names the detected CNI and both failure modes', () => {
+  render(<CniMismatchNotice cni="calico" />);
+  expect(screen.getByRole('note').textContent).toContain('calico');
+  expect(screen.getByRole('note').textContent).toContain('CiliumNetworkPolicy CRD');
+  expect(screen.getByRole('note').textContent).toContain('only Cilium enforces it');
+});
+
+test('dismiss removes the notice', () => {
+  render(<CniMismatchNotice cni="flannel" />);
+  fireEvent.click(screen.getByLabelText('Dismiss CNI notice'));
+  expect(screen.queryByRole('note')).toBeNull();
+});

--- a/frontend/src/components/PolicyEditor/CniMismatchNotice.tsx
+++ b/frontend/src/components/PolicyEditor/CniMismatchNotice.tsx
@@ -1,0 +1,40 @@
+import React, { useState } from 'react';
+import { AlertTriangle, X } from 'lucide-react';
+
+interface CniMismatchNoticeProps {
+  /** The detected cluster CNI (never 'unknown' or 'cilium' here —
+   *  callers only render this on a real mismatch). */
+  cni: string;
+}
+
+/**
+ * Dismissible notice shown on the Cilium Policy tab when the cluster's
+ * detected CNI is something else: the CiliumNetworkPolicy CRD is
+ * likely absent (apply fails), or — worse — present but unenforced
+ * (policy applies and is silently inert). Export stays enabled: the
+ * YAML may be destined for a different cluster.
+ */
+export const CniMismatchNotice: React.FC<CniMismatchNoticeProps> = ({ cni }) => {
+  const [dismissed, setDismissed] = useState(false);
+  if (dismissed) return null;
+  return (
+    <div
+      role="note"
+      className="flex items-start gap-2 px-4 py-2.5 bg-hubble-warning/10 border-b border-hubble-warning/30 text-xs text-secondary"
+    >
+      <AlertTriangle className="w-4 h-4 text-hubble-warning shrink-0 mt-0.5" />
+      <p className="flex-1">
+        Cluster CNI detected as <span className="font-mono text-primary">{cni}</span> — the
+        CiliumNetworkPolicy CRD is likely not installed here, and even if it is, only Cilium
+        enforces it. A standard Network Policy works on any CNI.
+      </p>
+      <button
+        onClick={() => setDismissed(true)}
+        aria-label="Dismiss CNI notice"
+        className="text-tertiary hover:text-primary transition-colors"
+      >
+        <X className="w-3.5 h-3.5" />
+      </button>
+    </div>
+  );
+};

--- a/frontend/src/components/PolicyEditor/PolicyHeader.tsx
+++ b/frontend/src/components/PolicyEditor/PolicyHeader.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { X, Copy, Download, Shield, Lock, Network } from 'lucide-react';
+import { X, Copy, Download, Shield, Lock, Network, AlertTriangle } from 'lucide-react';
 import type { PolicyType } from '../../hooks/policyEditor';
 
 interface PolicyHeaderProps {
@@ -13,6 +13,9 @@ interface PolicyHeaderProps {
   onClose: () => void;
   podName: string;
   podNamespace: string | null;
+  /** Non-null when the cluster CNI makes CiliumNetworkPolicy unlikely
+   *  to be applicable; shown as a badge on the Cilium tab. */
+  ciliumWarning?: string | null;
 }
 
 export const PolicyHeader: React.FC<PolicyHeaderProps> = ({
@@ -26,6 +29,7 @@ export const PolicyHeader: React.FC<PolicyHeaderProps> = ({
   onClose,
   podName,
   podNamespace,
+  ciliumWarning,
 }) => {
   return (
     <div className="flex items-center justify-between px-6 py-4 border-b border-hubble-border">
@@ -72,6 +76,11 @@ export const PolicyHeader: React.FC<PolicyHeaderProps> = ({
           >
             <Network className="w-3 h-3" />
             Cilium Policy
+            {ciliumWarning && (
+              <span title={ciliumWarning} aria-label={ciliumWarning}>
+                <AlertTriangle className="w-3 h-3 text-hubble-warning" />
+              </span>
+            )}
           </button>
           <button
             onClick={() => onPolicyTypeChange('seccomp')}

--- a/frontend/src/hooks/useClusterEnvironment.test.tsx
+++ b/frontend/src/hooks/useClusterEnvironment.test.tsx
@@ -1,0 +1,37 @@
+// @vitest-environment jsdom
+import { afterEach, expect, test, vi } from 'vitest';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import { useClusterEnvironment } from './useClusterEnvironment';
+import api from '../services/api';
+import { UNKNOWN_CLUSTER_ENVIRONMENT } from '../types';
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+function Probe() {
+  const { cni } = useClusterEnvironment();
+  return <span data-testid="cni">{cni}</span>;
+}
+
+// Contract: starts 'unknown' (never gates rendering), resolves to the
+// broker's answer, and any failure stays 'unknown' — "behave exactly
+// as before".
+
+test('starts unknown and resolves to the broker value', async () => {
+  vi.spyOn(api, 'getClusterEnvironment').mockResolvedValue({
+    ...UNKNOWN_CLUSTER_ENVIRONMENT,
+    cni: 'calico',
+    nodes: 3,
+  });
+  render(<Probe />);
+  expect(screen.getByTestId('cni').textContent).toBe('unknown');
+  await waitFor(() => expect(screen.getByTestId('cni').textContent).toBe('calico'));
+});
+
+test('stays unknown when the service resolves the fallback', async () => {
+  vi.spyOn(api, 'getClusterEnvironment').mockResolvedValue(UNKNOWN_CLUSTER_ENVIRONMENT);
+  render(<Probe />);
+  await waitFor(() => expect(screen.getByTestId('cni').textContent).toBe('unknown'));
+});

--- a/frontend/src/hooks/useClusterEnvironment.ts
+++ b/frontend/src/hooks/useClusterEnvironment.ts
@@ -1,0 +1,24 @@
+import { useEffect, useState } from 'react';
+import api from '../services/api';
+import { UNKNOWN_CLUSTER_ENVIRONMENT, type ClusterEnvironment } from '../types';
+
+/**
+ * The cluster's coarse environment (CNI et al.) from the broker.
+ * Starts — and on any failure remains — all-'unknown', which every
+ * consumer must treat as "behave exactly as before": the fetch must
+ * never gate rendering. Memoized in the api service, so many mounts
+ * cost one request.
+ */
+export function useClusterEnvironment(): ClusterEnvironment {
+  const [env, setEnv] = useState<ClusterEnvironment>(UNKNOWN_CLUSTER_ENVIRONMENT);
+  useEffect(() => {
+    let cancelled = false;
+    api.getClusterEnvironment().then((e) => {
+      if (!cancelled) setEnv(e);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+  return env;
+}

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,6 +1,7 @@
 import axios from 'axios';
 import type { AxiosInstance } from 'axios';
-import type { PodInfo, NetworkTraffic, SyscallInfo, ServiceInfo, AuditVerdict } from '../types';
+import type { PodInfo, NetworkTraffic, SyscallInfo, ServiceInfo, AuditVerdict, ClusterEnvironment } from '../types';
+import { UNKNOWN_CLUSTER_ENVIRONMENT } from '../types';
 
 class BrokerAPIClient {
   private client: AxiosInstance;
@@ -142,6 +143,30 @@ class BrokerAPIClient {
       console.error('Error fetching service by IP:', error);
       return null;
     }
+  }
+
+  /**
+   * Cluster environment (coarse CNI/IP-family/platform aggregates from
+   * the broker's node_facts). Memoized for the page lifetime — the CNI
+   * cannot change mid-session — and every failure path degrades to
+   * all-'unknown', which consumers MUST treat as "behave exactly as
+   * before" (older brokers 404 this endpoint).
+   */
+  private clusterEnvPromise: Promise<ClusterEnvironment> | null = null;
+
+  async getClusterEnvironment(): Promise<ClusterEnvironment> {
+    if (!this.clusterEnvPromise) {
+      this.clusterEnvPromise = this.client
+        .get<ClusterEnvironment>('/cluster/environment')
+        .then((r) => r.data)
+        .catch(() => UNKNOWN_CLUSTER_ENVIRONMENT);
+    }
+    return this.clusterEnvPromise;
+  }
+
+  /** Test hook: clear the memoized environment. */
+  resetClusterEnvironmentCache(): void {
+    this.clusterEnvPromise = null;
   }
 
   /**

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -91,3 +91,26 @@ export interface AuditVerdict {
   observed_at: string; // ISO 8601
   verdict: AuditVerdictKind | string;
 }
+
+/**
+ * Coarse cluster-environment aggregates from the broker (GET
+ * /cluster/environment, backed by controller-reported node facts).
+ * 'unknown' anywhere means "no signal — behave exactly as before".
+ */
+export interface ClusterEnvironment {
+  cni: string;
+  ip_family: string;
+  provider: string;
+  distro: string;
+  node_os: string;
+  nodes: number;
+}
+
+export const UNKNOWN_CLUSTER_ENVIRONMENT: ClusterEnvironment = {
+  cni: 'unknown',
+  ip_family: 'unknown',
+  provider: 'unknown',
+  distro: 'unknown',
+  node_os: 'unknown',
+  nodes: 0,
+};

--- a/llm-bridge/src/tools/backendClient.ts
+++ b/llm-bridge/src/tools/backendClient.ts
@@ -58,3 +58,33 @@ export function auditVerdictsQuery(args: {
   const s = q.toString();
   return s ? `?${s}` : "";
 }
+
+// --- cluster environment -------------------------------------------
+
+/**
+ * The cluster's detected CNI from GET /cluster/environment, cached
+ * (success ~5min, failure ~60s). Every failure — older broker 404,
+ * timeout, junk — resolves to "unknown", which callers MUST treat as
+ * "no signal, behave as before". Never throws.
+ */
+const CNI_TTL_OK_MS = 5 * 60_000;
+const CNI_TTL_ERR_MS = 60_000;
+let cniCache: { value: string; expires: number } | null = null;
+
+export async function clusterCni(): Promise<string> {
+  const now = Date.now();
+  if (cniCache && now < cniCache.expires) return cniCache.value;
+  try {
+    const env = (await brokerGetJSON("/cluster/environment")) as { cni?: unknown };
+    const cni = typeof env.cni === "string" && env.cni.length > 0 ? env.cni : "unknown";
+    cniCache = { value: cni, expires: now + CNI_TTL_OK_MS };
+  } catch {
+    cniCache = { value: "unknown", expires: now + CNI_TTL_ERR_MS };
+  }
+  return cniCache.value;
+}
+
+/** Test hook: clear the CNI cache. */
+export function resetClusterCniCache(): void {
+  cniCache = null;
+}

--- a/llm-bridge/src/tools/clusterCni.test.ts
+++ b/llm-bridge/src/tools/clusterCni.test.ts
@@ -1,0 +1,57 @@
+import { test, before, after, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+import { clusterCni, resetClusterCniCache } from "./backendClient.js";
+
+// clusterCni backs the CNI-aligned policy generation (issue #1413).
+// The contract under test: cached, and EVERY failure degrades to
+// "unknown" — which callers treat as "no signal, behave as before".
+
+let server: http.Server;
+let responses: Array<{ status: number; body?: unknown }> = [];
+let hits = 0;
+
+before(async () => {
+  server = http.createServer((_req, res) => {
+    hits += 1;
+    const next = responses.shift() ?? { status: 404 };
+    if (next.body !== undefined) {
+      res.writeHead(next.status, { "Content-Type": "application/json" });
+      res.end(JSON.stringify(next.body));
+    } else {
+      res.writeHead(next.status);
+      res.end();
+    }
+  });
+  await new Promise<void>((r) => server.listen(0, "127.0.0.1", r));
+  const port = (server.address() as AddressInfo).port;
+  process.env.BROKER_URL = `http://127.0.0.1:${port}`;
+});
+
+after(async () => {
+  await new Promise<void>((r) => server.close(() => r()));
+});
+
+beforeEach(() => {
+  resetClusterCniCache();
+  responses = [];
+  hits = 0;
+});
+
+test("returns the broker's cni and caches the success", async () => {
+  responses = [{ status: 200, body: { cni: "calico", nodes: 3 } }];
+  assert.equal(await clusterCni(), "calico");
+  assert.equal(await clusterCni(), "calico"); // served from cache
+  assert.equal(hits, 1);
+});
+
+test("older broker 404 degrades to unknown, never throws", async () => {
+  responses = [{ status: 404 }];
+  assert.equal(await clusterCni(), "unknown");
+});
+
+test("malformed body degrades to unknown", async () => {
+  responses = [{ status: 200, body: { nodes: 3 } }];
+  assert.equal(await clusterCni(), "unknown");
+});

--- a/llm-bridge/src/tools/cniMismatch.test.ts
+++ b/llm-bridge/src/tools/cniMismatch.test.ts
@@ -1,0 +1,101 @@
+import { test, before, after, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import http from "node:http";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import type { AddressInfo } from "node:net";
+import { executeInProcessTool } from "./execute.js";
+import { resetClusterCniCache } from "./backendClient.js";
+
+// The CNI-mismatch annotation (issue #1413): generate_network_policy
+// with policy_type=cilium on a non-Cilium cluster prepends a WARNING
+// comment; kubernetes output and unknown-CNI output stay untouched
+// (the parity/G2 fixtures pin the untouched case byte-for-byte).
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const contractDir = path.resolve(here, "../../../test/fixtures/contract");
+const fixtures = JSON.parse(
+  fs.readFileSync(path.join(contractDir, "backend_fixtures.json"), "utf8"),
+) as Record<string, unknown>;
+
+let server: http.Server;
+let cniResponse: { status: number; body?: unknown } = { status: 404 };
+
+before(async () => {
+  server = http.createServer((req, res) => {
+    const urlPath = (req.url || "").split("?")[0];
+    if (urlPath === "/cluster/environment") {
+      if (cniResponse.body !== undefined) {
+        res.writeHead(cniResponse.status, { "Content-Type": "application/json" });
+        res.end(JSON.stringify(cniResponse.body));
+      } else {
+        res.writeHead(cniResponse.status);
+        res.end();
+      }
+      return;
+    }
+    const body = fixtures[urlPath];
+    if (body === undefined) {
+      res.writeHead(404);
+      res.end();
+      return;
+    }
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify(body));
+  });
+  await new Promise<void>((r) => server.listen(0, "127.0.0.1", r));
+  const port = (server.address() as AddressInfo).port;
+  process.env.BROKER_URL = `http://127.0.0.1:${port}`;
+});
+
+after(async () => {
+  await new Promise<void>((r) => server.close(() => r()));
+});
+
+beforeEach(() => {
+  resetClusterCniCache();
+});
+
+test("cilium policy on a calico cluster is annotated, not altered", async () => {
+  cniResponse = { status: 200, body: { cni: "calico" } };
+  const res = await executeInProcessTool("generate_network_policy", {
+    pod_name: "web-1",
+    policy_type: "cilium",
+  });
+  assert.equal(res.isError, false, res.text);
+  assert.ok(res.text.startsWith("# WARNING: cluster CNI detected as 'calico'"), res.text.slice(0, 120));
+  // The YAML itself is intact after the one comment line.
+  assert.ok(res.text.includes("kind: CiliumNetworkPolicy"));
+});
+
+test("cilium policy on a cilium cluster is untouched", async () => {
+  cniResponse = { status: 200, body: { cni: "cilium" } };
+  const res = await executeInProcessTool("generate_network_policy", {
+    pod_name: "web-1",
+    policy_type: "cilium",
+  });
+  assert.equal(res.isError, false, res.text);
+  assert.ok(!res.text.startsWith("# WARNING"));
+});
+
+test("unknown CNI (older broker 404) leaves output untouched", async () => {
+  cniResponse = { status: 404 };
+  const res = await executeInProcessTool("generate_network_policy", {
+    pod_name: "web-1",
+    policy_type: "cilium",
+  });
+  assert.equal(res.isError, false, res.text);
+  assert.ok(!res.text.startsWith("# WARNING"));
+});
+
+test("kubernetes policy is never annotated regardless of CNI", async () => {
+  cniResponse = { status: 200, body: { cni: "calico" } };
+  const res = await executeInProcessTool("generate_network_policy", {
+    pod_name: "web-1",
+    policy_type: "kubernetes",
+  });
+  assert.equal(res.isError, false, res.text);
+  assert.ok(!res.text.startsWith("# WARNING"));
+  assert.ok(res.text.includes("kind: NetworkPolicy"));
+});

--- a/llm-bridge/src/tools/execute.ts
+++ b/llm-bridge/src/tools/execute.ts
@@ -1,6 +1,6 @@
 import { log } from "../logger.js";
 import { TOOL_DEFS } from "./registry.js";
-import { brokerGetJSON, auditVerdictsQuery } from "./backendClient.js";
+import { brokerGetJSON, auditVerdictsQuery, clusterCni } from "./backendClient.js";
 import {
   filterByNamespace, compactTrafficSummary, compactPodsSummary, filterAlivePods, compactSvc,
 } from "./compaction.js";
@@ -98,7 +98,21 @@ const handlers: Record<string, Handler> = {
     const policy = type === "cilium"
       ? await generateCiliumPolicy(pod, traffic, brokerPeerResolver)
       : await generateNetworkPolicy(pod, traffic, brokerPeerResolver);
-    return policyToYAML(policy);
+    const yaml = policyToYAML(policy);
+    // Align with the cluster CNI (issue #1413): never refuse and never
+    // silently switch kinds — annotate, so the model (or a scripted
+    // caller) sees the mismatch in the result and can self-correct.
+    // clusterCni() degrades to "unknown" on any failure, which leaves
+    // the output byte-identical to pre-detection behavior (the parity
+    // and G2 fixtures pin exactly that).
+    if (type === "cilium") {
+      const cni = await clusterCni();
+      if (cni !== "unknown" && cni !== "cilium") {
+        return `# WARNING: cluster CNI detected as '${cni}' — the CiliumNetworkPolicy CRD is likely unavailable here, and only Cilium enforces it. Use policy_type 'kubernetes' for a policy any CNI enforces.
+${yaml}`;
+      }
+    }
+    return yaml;
   },
   // Seccomp is generated in-process from the pod's observed syscalls — no
   // advisor hop. Returned as pretty JSON; the profile is G2-locked to


### PR DESCRIPTION
Closes #1413. Team-reviewed (validation + design lenses) before implementation.

**The problem (validated with evidence):** the Cilium policy option was offered identically on every cluster across all three surfaces — UI tab, assistant `policy_type`, CLI `--type` — with zero CNI/CRD awareness anywhere. On a non-Cilium cluster the exported CiliumNetworkPolicy either fails to apply (`ensure CRDs are installed first`) or, worse, applies and is **silently inert** if the CRDs happen to exist without Cilium enforcing.

**The solution** (reuses the CNI signal shipped with telemetry v2 — no new detection):

- **broker**: `GET /cluster/environment` — the node_facts aggregates (CNI, IP family, provider, distro, node OS, reporting-node count). Always 200; degrades to all-`unknown`.
- **frontend**: amber badge on the Cilium tab + a dismissible notice naming the detected CNI and both failure modes. Nothing hidden, export stays enabled (the YAML may target another cluster). `unknown` → pixel-identical to today; the fetch never gates the editor.
- **assistant**: `policy_type=cilium` output gains one `# WARNING` comment line on a real mismatch — never refuses, never silently switches kinds; scripted callers get what they asked for and the model self-corrects from the tool result.
- **advisor CLI**: deliberately out of scope (explicit `--type` flag = stated intent); noted as follow-up on the issue.

**Degradation contract** (the core safety property): older broker 404, empty node_facts, or a non-annotating CNI (kindnet) all resolve to `unknown` → byte-identical behavior everywhere. Pinned three ways: parity + G2 fixtures pass **unchanged**, dedicated unknown-path unit tests, and a **live check** — ran the new frontend against the current production broker (which 404s the endpoint): editor renders identically, no badge, no notice.

**Validation:** broker 176 tests + clippy `-D warnings` + fmt · frontend tsc + 75/75 (4 new) · llm-bridge tsc + 148/148 (7 new) · docs page + nav added. No chart changes needed (nodes RBAC already granted by telemetry v2).