### PR TITLE
feat(frontend): map toggle to hide DaemonSet and host-network peers by default

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -36,7 +36,8 @@ import { UI_DIMENSIONS } from './constants/ui';
 const ROUTES = ['map', 'findings', 'seccomp'] as const;
 
 function App() {
-  const { settings, updateSettings } = useSettings();
+  const { settings, updateSettings, toggleSetting } = useSettings();
+  const toggleDaemonSetNodes = useCallback(() => toggleSetting('showDaemonSetNodes'), [toggleSetting]);
   const { activeCluster } = useCluster();
 
   // The whole location — view, namespace, selected workload — lives in the URL
@@ -432,6 +433,8 @@ function App() {
                 services={services}
                 showExternalNodes={settings.showExternalNodes}
                 onToggleExternalNodes={() => updateSettings({ showExternalNodes: !settings.showExternalNodes })}
+                showDaemonSetNodes={settings.showDaemonSetNodes}
+                onToggleDaemonSetNodes={toggleDaemonSetNodes}
                 showTraffic={settings.showTraffic}
                 onToggleTraffic={() => updateSettings({ showTraffic: !settings.showTraffic })}
                 layoutDirection={settings.layoutDirection}

--- a/frontend/src/components/GraphControls.test.tsx
+++ b/frontend/src/components/GraphControls.test.tsx
@@ -1,0 +1,45 @@
+// @vitest-environment jsdom
+import { afterEach, expect, test, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { DAEMONSET_TOGGLE_TOOLTIP, GraphControls } from './GraphControls';
+
+afterEach(cleanup);
+
+const props = (over: Partial<Parameters<typeof GraphControls>[0]> = {}) => ({
+  showTraffic: true, onToggleTraffic: vi.fn(),
+  showExternalNodes: true, onToggleExternalNodes: vi.fn(), externalCount: 3,
+  showDaemonSetNodes: false, onToggleDaemonSetNodes: vi.fn(), daemonSetCount: 5,
+  layoutDirection: 'LR' as const, onToggleLayoutDirection: vi.fn(),
+  ...over,
+});
+
+test('DaemonSets toggle sits next to External, off by default, reports the hidden count, and fires its callback', () => {
+  const p = props();
+  render(<GraphControls {...p} />);
+  const btn = screen.getByTitle(DAEMONSET_TOGGLE_TOOLTIP);
+  expect(btn.textContent).toBe('DaemonSets (5 hidden)');
+  expect(btn.getAttribute('aria-pressed')).toBe('false');
+  // Ordering: Traffic, External, DaemonSets, Layout.
+  const labels = screen.getAllByRole('button').map((b) => b.textContent);
+  expect(labels).toEqual(['Traffic', 'External (3)', 'DaemonSets (5 hidden)', 'Layout']);
+  fireEvent.click(btn);
+  expect(p.onToggleDaemonSetNodes).toHaveBeenCalledTimes(1);
+  expect(p.onToggleExternalNodes).not.toHaveBeenCalled();
+});
+
+test('when on, the count is shown without the hidden hint', () => {
+  render(<GraphControls {...props({ showDaemonSetNodes: true })} />);
+  const btn = screen.getByTitle(DAEMONSET_TOGGLE_TOOLTIP);
+  expect(btn.textContent).toBe('DaemonSets (5)');
+  expect(btn.getAttribute('aria-pressed')).toBe('true');
+});
+
+test('no count suffix when there is nothing to hide', () => {
+  render(<GraphControls {...props({ daemonSetCount: 0 })} />);
+  expect(screen.getByTitle(DAEMONSET_TOGGLE_TOOLTIP).textContent).toBe('DaemonSets');
+});
+
+test('the toggle is only offered while external nodes are shown', () => {
+  render(<GraphControls {...props({ showExternalNodes: false })} />);
+  expect(screen.queryByTitle(DAEMONSET_TOGGLE_TOOLTIP)).toBeNull();
+});

--- a/frontend/src/components/GraphControls.test.tsx
+++ b/frontend/src/components/GraphControls.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { afterEach, expect, test, vi } from 'vitest';
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
-import { DAEMONSET_TOGGLE_TOOLTIP, GraphControls } from './GraphControls';
+import { DAEMONSET_ACTIVE, DAEMONSET_TOGGLE_TOOLTIP, EXTERNAL_ACTIVE, GraphControls, TRAFFIC_ACTIVE } from './GraphControls';
 
 afterEach(cleanup);
 
@@ -32,6 +32,28 @@ test('when on, the count is shown without the hidden hint', () => {
   const btn = screen.getByTitle(DAEMONSET_TOGGLE_TOOLTIP);
   expect(btn.textContent).toBe('DaemonSets (5)');
   expect(btn.getAttribute('aria-pressed')).toBe('true');
+});
+
+test('each toggle has its own hue: Traffic indigo, External amber, DaemonSets teal', () => {
+  render(<GraphControls {...props({ showDaemonSetNodes: true })} />);
+  const [traffic, external, daemonSets] = screen.getAllByRole('button');
+  expect(traffic.className).toContain(TRAFFIC_ACTIVE);
+  expect(external.className).toContain(EXTERNAL_ACTIVE);
+  expect(daemonSets.className).toContain(DAEMONSET_ACTIVE);
+  // Three distinct tokens — none shares another's colour.
+  expect(DAEMONSET_ACTIVE).toContain('hubble-info');
+  expect(DAEMONSET_ACTIVE).not.toContain('hubble-warning');
+  expect(DAEMONSET_ACTIVE).not.toContain('hubble-accent');
+  expect(EXTERNAL_ACTIVE).not.toContain('hubble-info');
+  expect(TRAFFIC_ACTIVE).not.toContain('hubble-info');
+  expect(daemonSets.className).not.toContain('hubble-warning');
+});
+
+test('while off, the hidden-count hint still carries the DaemonSets hue', () => {
+  render(<GraphControls {...props()} />);
+  const btn = screen.getByTitle(DAEMONSET_TOGGLE_TOOLTIP);
+  expect(btn.className).not.toContain('hubble-info');
+  expect(btn.querySelector('span.text-hubble-info')?.textContent).toBe('(5 hidden)');
 });
 
 test('no count suffix when there is nothing to hide', () => {

--- a/frontend/src/components/GraphControls.tsx
+++ b/frontend/src/components/GraphControls.tsx
@@ -21,6 +21,12 @@ export interface GraphControlsProps {
 const base = 'flex items-center gap-2 h-8 px-3 rounded-control border text-xs font-medium transition-colors';
 const off = 'bg-hubble-card border-hubble-border text-tertiary hover:border-hubble-border-strong hover:text-secondary';
 
+// Each toggle owns a hue so the three read apart at a glance:
+// Traffic = brand indigo, External = amber, DaemonSets = teal (hubble-info).
+export const TRAFFIC_ACTIVE = 'bg-hubble-accent/15 border-hubble-accent/50 text-hubble-accent hover:bg-hubble-accent/25';
+export const EXTERNAL_ACTIVE = 'bg-hubble-warning/15 border-hubble-warning/50 text-hubble-warning hover:bg-hubble-warning/25';
+export const DAEMONSET_ACTIVE = 'bg-hubble-info/15 border-hubble-info/50 text-hubble-info hover:bg-hubble-info/25';
+
 export const DAEMONSET_TOGGLE_TOOLTIP = 'Show DaemonSet and host-network peers such as node-exporter, CNI and CSI agents';
 
 export function GraphControls({
@@ -35,12 +41,11 @@ export function GraphControls({
   layoutDirection,
   onToggleLayoutDirection,
 }: GraphControlsProps) {
-  const daemonSetSuffix = daemonSetCount > 0 ? ` (${daemonSetCount}${showDaemonSetNodes ? '' : ' hidden'})` : '';
   return (
     <div className="flex gap-2">
       <button
         onClick={onToggleTraffic}
-        className={`${base} ${showTraffic ? 'bg-hubble-accent/15 border-hubble-accent/50 text-hubble-accent hover:bg-hubble-accent/25' : off}`}
+        className={`${base} ${showTraffic ? TRAFFIC_ACTIVE : off}`}
         title={showTraffic ? 'Hide traffic edges' : 'Show traffic edges'}
       >
         {showTraffic ? <Eye className="w-3.5 h-3.5" /> : <EyeOff className="w-3.5 h-3.5" />}
@@ -49,7 +54,7 @@ export function GraphControls({
       {showTraffic && (
         <button
           onClick={onToggleExternalNodes}
-          className={`${base} ${showExternalNodes ? 'bg-hubble-warning/15 border-hubble-warning/50 text-hubble-warning hover:bg-hubble-warning/25' : off}`}
+          className={`${base} ${showExternalNodes ? EXTERNAL_ACTIVE : off}`}
           title={showExternalNodes ? 'Hide external namespace nodes' : 'Show external namespace nodes'}
         >
           {showExternalNodes ? <Eye className="w-3.5 h-3.5" /> : <EyeOff className="w-3.5 h-3.5" />}
@@ -60,11 +65,19 @@ export function GraphControls({
         <button
           onClick={onToggleDaemonSetNodes}
           aria-pressed={showDaemonSetNodes}
-          className={`${base} ${showDaemonSetNodes ? 'bg-hubble-warning/15 border-hubble-warning/50 text-hubble-warning hover:bg-hubble-warning/25' : off}`}
+          className={`${base} ${showDaemonSetNodes ? DAEMONSET_ACTIVE : off}`}
           title={DAEMONSET_TOGGLE_TOOLTIP}
         >
-          {showDaemonSetNodes ? <Layers className="w-3.5 h-3.5" /> : <EyeOff className="w-3.5 h-3.5" />}
-          DaemonSets{daemonSetSuffix}
+          {showDaemonSetNodes ? <Layers className="w-3.5 h-3.5" /> : <EyeOff className="w-3.5 h-3.5 text-hubble-info" />}
+          DaemonSets
+          {daemonSetCount > 0 && ' '}
+          {daemonSetCount > 0 && (
+            // The hidden-count hint keeps the toggle's hue even while off, so
+            // the user can see what the teal toggle is holding back.
+            <span className={showDaemonSetNodes ? '' : 'text-hubble-info'}>
+              ({daemonSetCount}{showDaemonSetNodes ? '' : ' hidden'})
+            </span>
+          )}
         </button>
       )}
       {showTraffic && (

--- a/frontend/src/components/GraphControls.tsx
+++ b/frontend/src/components/GraphControls.tsx
@@ -1,0 +1,82 @@
+import { ArrowDown, ArrowRight, Eye, EyeOff, Layers } from 'lucide-react';
+
+// The Network Map toolbar (top-right). Extracted from NetworkGraph so the
+// toggles can be rendered and tested without ReactFlow/ELK.
+
+export interface GraphControlsProps {
+  showTraffic: boolean;
+  onToggleTraffic: () => void;
+  showExternalNodes: boolean;
+  onToggleExternalNodes: () => void;
+  /** Visible external nodes (after the DaemonSets filter). */
+  externalCount: number;
+  showDaemonSetNodes: boolean;
+  onToggleDaemonSetNodes: () => void;
+  /** DaemonSet / host-network peers: shown when the toggle is on, hidden otherwise. */
+  daemonSetCount: number;
+  layoutDirection: 'LR' | 'TB';
+  onToggleLayoutDirection: () => void;
+}
+
+const base = 'flex items-center gap-2 h-8 px-3 rounded-control border text-xs font-medium transition-colors';
+const off = 'bg-hubble-card border-hubble-border text-tertiary hover:border-hubble-border-strong hover:text-secondary';
+
+export const DAEMONSET_TOGGLE_TOOLTIP = 'Show DaemonSet and host-network peers such as node-exporter, CNI and CSI agents';
+
+export function GraphControls({
+  showTraffic,
+  onToggleTraffic,
+  showExternalNodes,
+  onToggleExternalNodes,
+  externalCount,
+  showDaemonSetNodes,
+  onToggleDaemonSetNodes,
+  daemonSetCount,
+  layoutDirection,
+  onToggleLayoutDirection,
+}: GraphControlsProps) {
+  const daemonSetSuffix = daemonSetCount > 0 ? ` (${daemonSetCount}${showDaemonSetNodes ? '' : ' hidden'})` : '';
+  return (
+    <div className="flex gap-2">
+      <button
+        onClick={onToggleTraffic}
+        className={`${base} ${showTraffic ? 'bg-hubble-accent/15 border-hubble-accent/50 text-hubble-accent hover:bg-hubble-accent/25' : off}`}
+        title={showTraffic ? 'Hide traffic edges' : 'Show traffic edges'}
+      >
+        {showTraffic ? <Eye className="w-3.5 h-3.5" /> : <EyeOff className="w-3.5 h-3.5" />}
+        Traffic
+      </button>
+      {showTraffic && (
+        <button
+          onClick={onToggleExternalNodes}
+          className={`${base} ${showExternalNodes ? 'bg-hubble-warning/15 border-hubble-warning/50 text-hubble-warning hover:bg-hubble-warning/25' : off}`}
+          title={showExternalNodes ? 'Hide external namespace nodes' : 'Show external namespace nodes'}
+        >
+          {showExternalNodes ? <Eye className="w-3.5 h-3.5" /> : <EyeOff className="w-3.5 h-3.5" />}
+          External{externalCount > 0 ? ` (${externalCount})` : ''}
+        </button>
+      )}
+      {showTraffic && showExternalNodes && (
+        <button
+          onClick={onToggleDaemonSetNodes}
+          aria-pressed={showDaemonSetNodes}
+          className={`${base} ${showDaemonSetNodes ? 'bg-hubble-warning/15 border-hubble-warning/50 text-hubble-warning hover:bg-hubble-warning/25' : off}`}
+          title={DAEMONSET_TOGGLE_TOOLTIP}
+        >
+          {showDaemonSetNodes ? <Layers className="w-3.5 h-3.5" /> : <EyeOff className="w-3.5 h-3.5" />}
+          DaemonSets{daemonSetSuffix}
+        </button>
+      )}
+      {showTraffic && (
+        <button
+          onClick={onToggleLayoutDirection}
+          className={`${base} bg-hubble-card border-hubble-border text-secondary hover:border-hubble-border-strong hover:text-primary`}
+          title={`Switch to ${layoutDirection === 'LR' ? 'vertical' : 'horizontal'} layout`}
+        >
+          {layoutDirection === 'LR' ? <ArrowRight className="w-3.5 h-3.5" /> : <ArrowDown className="w-3.5 h-3.5" />}
+          Layout
+        </button>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/NetworkGraph.tsx
+++ b/frontend/src/components/NetworkGraph.tsx
@@ -14,7 +14,7 @@ import ELK from 'elkjs/lib/elk.bundled.js';
 import { Activity, ShieldAlert, Server, Crosshair, X } from 'lucide-react';
 import PodNode from './PodNode';
 import { shouldExitFocus } from '../utils/graphFocus';
-import { partitionDaemonSetPeers, shouldAutoShowDaemonSets } from '../utils/daemonSetPeers';
+import { EDGE_COLOR_DAEMONSET, edgeStrokeColor, isDaemonSetPeer, partitionDaemonSetPeers, shouldAutoShowDaemonSets } from '../utils/daemonSetPeers';
 import { GraphControls } from './GraphControls';
 import { buildPeerIndex, resolvePeer, type PeerResolution } from '../utils/peerResolution';
 import { buildExternalNodes, remoteNodeForRow } from '../utils/externalPeers';
@@ -284,6 +284,8 @@ const NetworkGraphInner: React.FC<NetworkGraphProps> = ({
     const edgeMap = new Map<string, {
       count: number;
       isExternal: boolean;
+      /** Either end is a DaemonSet / host-network peer — drawn in the DaemonSets hue. */
+      isDaemonSet: boolean;
       ports: Map<string, number>;
       protocols: Set<string>;
       dropCount: number;
@@ -323,10 +325,12 @@ const NetworkGraphInner: React.FC<NetworkGraphProps> = ({
         if (sourcePod && destPod && sourcePod.id !== destPod.id) {
           const edgeKey = `${sourcePod.id}::${destPod.id}`;
           const isExternalEdge = !!(sourcePod.isExternal || destPod.isExternal);
+          const isDaemonSetEdge = isDaemonSetPeer(sourcePod) || isDaemonSetPeer(destPod);
           if (!edgeMap.has(edgeKey)) {
             edgeMap.set(edgeKey, {
               count: 0,
               isExternal: isExternalEdge,
+              isDaemonSet: isDaemonSetEdge,
               ports: new Map(),
               protocols: new Set(),
               dropCount: 0,
@@ -353,14 +357,16 @@ const NetworkGraphInner: React.FC<NetworkGraphProps> = ({
 
     edgeMap.forEach((edgeData, key) => {
       const [source, target] = key.split('::');
-      const { count, isExternal, ports, protocols, dropCount } = edgeData;
+      const { count, isExternal, isDaemonSet, ports, protocols, dropCount } = edgeData;
 
       // Trust-state edge coloring (kguardian brand): denied flows are the single
       // most important signal for a runtime-security operator, so they get the
       // error red + a bolder stroke; egress-to-external is warm amber (dashed);
       // trusted in-cluster traffic is the brand indigo (was an off-brand #3B82F6).
+      // DaemonSet / host-network peers take the DaemonSets toggle's teal so the
+      // toggle, the node and its traffic read as one association.
       const isDrop = dropCount > 0;
-      const strokeColor = isDrop ? '#EF4444' : isExternal ? '#F59E0B' : '#4E3AD9';
+      const strokeColor = edgeStrokeColor({ isDrop, isDaemonSet, isExternal });
 
       // Build semantic label from port/protocol data
       let label: string;
@@ -693,6 +699,9 @@ const NetworkGraphInner: React.FC<NetworkGraphProps> = ({
             <div className="flex items-center gap-3 px-3 py-1.5 rounded-surface bg-hubble-card/90 border border-hubble-border backdrop-blur-sm text-[11px] text-secondary">
               <span className="flex items-center gap-1.5"><span className="w-3.5 h-0.5 rounded-full" style={{ background: '#4E3AD9' }} />Trusted</span>
               <span className="flex items-center gap-1.5"><span className="w-3.5 h-0 border-t-2 border-dashed" style={{ borderColor: '#F59E0B' }} />Egress</span>
+              {showDaemonSetNodes && daemonSetCount > 0 && (
+                <span className="flex items-center gap-1.5"><span className="w-3.5 h-0 border-t-2 border-dashed" style={{ borderColor: EDGE_COLOR_DAEMONSET }} />DaemonSet</span>
+              )}
               <span className="flex items-center gap-1.5"><span className="w-3.5 h-[3px] rounded-full" style={{ background: '#EF4444' }} />Denied</span>
             </div>
           </Panel>

--- a/frontend/src/components/NetworkGraph.tsx
+++ b/frontend/src/components/NetworkGraph.tsx
@@ -11,9 +11,11 @@ import ReactFlow, {
 import type { Node, Edge } from 'reactflow';
 import 'reactflow/dist/style.css';
 import ELK from 'elkjs/lib/elk.bundled.js';
-import { Eye, EyeOff, Activity, ShieldAlert, Server, Crosshair, X, ArrowRight, ArrowDown } from 'lucide-react';
+import { Activity, ShieldAlert, Server, Crosshair, X } from 'lucide-react';
 import PodNode from './PodNode';
 import { shouldExitFocus } from '../utils/graphFocus';
+import { partitionDaemonSetPeers, shouldAutoShowDaemonSets } from '../utils/daemonSetPeers';
+import { GraphControls } from './GraphControls';
 import { buildPeerIndex, resolvePeer, type PeerResolution } from '../utils/peerResolution';
 import { buildExternalNodes, remoteNodeForRow } from '../utils/externalPeers';
 import type { PodNodeData, PodInfo, ServiceInfo, NetworkTraffic } from '../types';
@@ -31,6 +33,9 @@ interface NetworkGraphProps {
   services: ServiceInfo[];
   showExternalNodes: boolean;
   onToggleExternalNodes: () => void;
+  /** Show DaemonSet / host-network peers (utils/daemonSetPeers). Off by default. */
+  showDaemonSetNodes: boolean;
+  onToggleDaemonSetNodes: () => void;
   showTraffic: boolean;
   onToggleTraffic: () => void;
   layoutDirection: 'LR' | 'TB';
@@ -59,6 +64,8 @@ const NetworkGraphInner: React.FC<NetworkGraphProps> = ({
   services,
   showExternalNodes,
   onToggleExternalNodes,
+  showDaemonSetNodes,
+  onToggleDaemonSetNodes,
   showTraffic,
   onToggleTraffic,
   layoutDirection,
@@ -188,12 +195,41 @@ const NetworkGraphInner: React.FC<NetworkGraphProps> = ({
 
   // Combine in-namespace and external pods for rendering
   // When traffic is enabled, hide local pods that have no traffic
+  // DaemonSet / host-network peers are computed like any other external node
+  // (so counts and policy inputs see them) but rendered only when the toggle
+  // is on. The focused or selected node is never hidden; the Unattributed and
+  // Internet aggregates never qualify (see isDaemonSetPeer).
+  const daemonSetPartition = useMemo(
+    () => partitionDaemonSetPeers(externalNodes, { show: showDaemonSetNodes, focusedId: focusedNodeId, selectedId: selectedPodId }),
+    [externalNodes, showDaemonSetNodes, focusedNodeId, selectedPodId],
+  );
+  const daemonSetCount = useMemo(
+    () => partitionDaemonSetPeers(externalNodes, { show: false, focusedId: null, selectedId: null }).hidden.length,
+    [externalNodes],
+  );
+
+  // A `?focus=` link to a DaemonSet peer reveals the whole class, not just
+  // the pinned node — flip the toggle on (it persists like the other toggles).
+  // Once per focused id: the user may still turn the toggle off afterwards
+  // (the focused node itself stays pinned), and StrictMode's double effect
+  // run must not flip it twice.
+  const autoShownFocusRef = React.useRef<string | null>(null);
+  useEffect(() => {
+    if (autoShownFocusRef.current === focusedNodeId) return;
+    if (shouldAutoShowDaemonSets(focusedNodeId, externalNodes, showDaemonSetNodes)) {
+      autoShownFocusRef.current = focusedNodeId;
+      onToggleDaemonSetNodes();
+    } else if (!focusedNodeId) {
+      autoShownFocusRef.current = null;
+    }
+  }, [focusedNodeId, externalNodes, showDaemonSetNodes, onToggleDaemonSetNodes]);
+
   const allDisplayPods = useMemo(() => {
     const visiblePods = showTraffic
       ? pods.filter((pod) => pod.traffic && pod.traffic.length > 0)
       : pods;
-    return [...visiblePods, ...externalNodes];
-  }, [pods, externalNodes, showTraffic]);
+    return [...visiblePods, ...daemonSetPartition.visible];
+  }, [pods, daemonSetPartition, showTraffic]);
 
   // Focus is only meaningful while the focused node exists in the current
   // node set. Switching namespace (or the pod being deleted) used to leave
@@ -575,7 +611,7 @@ const NetworkGraphInner: React.FC<NetworkGraphProps> = ({
     onPodSelect(null);
   }, [onPodSelect]);
 
-  const externalCount = externalNodes.length;
+  const externalCount = daemonSetPartition.visible.length;
 
   // Compute namespace-level summary stats for the Security Summary Panel
   const summaryStats = useMemo(() => {
@@ -664,45 +700,18 @@ const NetworkGraphInner: React.FC<NetworkGraphProps> = ({
 
         {/* Graph controls */}
         <Panel position="top-right">
-          <div className="flex gap-2">
-            <button
-              onClick={onToggleTraffic}
-              className={`flex items-center gap-2 h-8 px-3 rounded-control border text-xs font-medium transition-colors ${
-                showTraffic
-                  ? 'bg-hubble-accent/15 border-hubble-accent/50 text-hubble-accent hover:bg-hubble-accent/25'
-                  : 'bg-hubble-card border-hubble-border text-tertiary hover:border-hubble-border-strong hover:text-secondary'
-              }`}
-              title={showTraffic ? 'Hide traffic edges' : 'Show traffic edges'}
-            >
-              {showTraffic ? <Eye className="w-3.5 h-3.5" /> : <EyeOff className="w-3.5 h-3.5" />}
-              Traffic
-            </button>
-            {showTraffic && (
-              <button
-                onClick={onToggleExternalNodes}
-                className={`flex items-center gap-2 h-8 px-3 rounded-control border text-xs font-medium transition-colors ${
-                  showExternalNodes
-                    ? 'bg-hubble-warning/15 border-hubble-warning/50 text-hubble-warning hover:bg-hubble-warning/25'
-                    : 'bg-hubble-card border-hubble-border text-tertiary hover:border-hubble-border-strong hover:text-secondary'
-                }`}
-                title={showExternalNodes ? 'Hide external namespace nodes' : 'Show external namespace nodes'}
-              >
-                {showExternalNodes ? <Eye className="w-3.5 h-3.5" /> : <EyeOff className="w-3.5 h-3.5" />}
-                External{externalCount > 0 ? ` (${externalCount})` : ''}
-              </button>
-            )}
-            {showTraffic && (
-              <button
-                onClick={onToggleLayoutDirection}
-                className="flex items-center gap-2 h-8 px-3 rounded-control border text-xs font-medium transition-colors
-                           bg-hubble-card border-hubble-border text-secondary hover:border-hubble-border-strong hover:text-primary"
-                title={`Switch to ${layoutDirection === 'LR' ? 'vertical' : 'horizontal'} layout`}
-              >
-                {layoutDirection === 'LR' ? <ArrowRight className="w-3.5 h-3.5" /> : <ArrowDown className="w-3.5 h-3.5" />}
-                Layout
-              </button>
-            )}
-          </div>
+          <GraphControls
+            showTraffic={showTraffic}
+            onToggleTraffic={onToggleTraffic}
+            showExternalNodes={showExternalNodes}
+            onToggleExternalNodes={onToggleExternalNodes}
+            externalCount={externalCount}
+            showDaemonSetNodes={showDaemonSetNodes}
+            onToggleDaemonSetNodes={onToggleDaemonSetNodes}
+            daemonSetCount={daemonSetCount}
+            layoutDirection={layoutDirection}
+            onToggleLayoutDirection={onToggleLayoutDirection}
+          />
         </Panel>
       </ReactFlow>
     </div>

--- a/frontend/src/components/PodNode.daemonSet.test.tsx
+++ b/frontend/src/components/PodNode.daemonSet.test.tsx
@@ -1,0 +1,37 @@
+// @vitest-environment jsdom
+import { afterEach, expect, test } from 'vitest';
+import { cleanup, render } from '@testing-library/react';
+import { ReactFlowProvider } from 'reactflow';
+import PodNode from './PodNode';
+import type { PodInfo } from '../types';
+
+// DaemonSet / host-network peer cards carry the DaemonSets hue on their spine
+// and icon — and nothing else: the operator asked for no tag text on the node,
+// the colour alone ties the toggle, the node and its edges together.
+
+afterEach(cleanup);
+
+const pod = (name: string, extra: Partial<PodInfo> = {}): PodInfo => ({
+  pod_name: name, pod_ip: '192.168.50.101', pod_namespace: 'observability', time_stamp: 't', node_name: 'worker-1', is_dead: false, ...extra,
+});
+const renderNode = (pods: PodInfo[], isExternal = true) => {
+  const data = { id: 'n', label: 'node-exporter', pod: pods[0], pods, traffic: [], isExpanded: false, isExternal, externalNamespace: 'observability', onToggle: () => {}, onFocus: () => {} };
+  return render(
+    <ReactFlowProvider>
+      <PodNode id="n" data={data as never} selected={false} type="podNode" xPos={0} yPos={0} zIndex={0} isConnectable={false} dragging={false} />
+    </ReactFlowProvider>,
+  );
+};
+
+test('DaemonSet peer: teal spine, no badge text', () => {
+  const { container } = renderNode([pod('node-exporter-abc', { workload_kind: 'DaemonSet', host_network: true })]);
+  expect(container.querySelector('.border-l-hubble-info')).not.toBeNull();
+  expect(container.querySelector('.border-l-hubble-warning')).toBeNull();
+  expect(container.textContent).not.toMatch(/DaemonSet|host-network/);
+});
+
+test('ordinary external peer keeps the amber spine', () => {
+  const { container } = renderNode([pod('grafana-0', { workload_kind: 'Deployment', host_network: false })]);
+  expect(container.querySelector('.border-l-hubble-warning')).not.toBeNull();
+  expect(container.querySelector('.border-l-hubble-info')).toBeNull();
+});

--- a/frontend/src/components/PodNode.tsx
+++ b/frontend/src/components/PodNode.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Handle, Position } from 'reactflow';
 import { ChevronDown, ChevronRight, Network, Server, Globe, FileCode, Crosshair } from 'lucide-react';
+import { isDaemonSetOrHostNetworkPod } from '../utils/daemonSetPeers';
 import type { PodNodeData } from '../types';
 import { Button } from './ui/Button';
 
@@ -34,11 +35,19 @@ const PodNode: React.FC<PodNodeProps> = React.memo(({ data, selected }) => {
   }, 0) || 0;
 
   const IconComponent = isExternal ? Globe : Server;
+  // DaemonSet / host-network peers (see utils/daemonSetPeers) get the same
+  // teal as their toolbar toggle so the badge, the spine and the toggle that
+  // hides them all read as one thing.
+  const daemonSetPeer = isExternal && (data.pods && data.pods.length > 0 ? data.pods : [data.pod]).some(isDaemonSetOrHostNetworkPod);
+  const daemonSetBadge = daemonSetPeer
+    ? ((data.pods ?? []).some((p) => p.workload_kind === 'DaemonSet') ? 'DaemonSet' : 'host-network')
+    : null;
   // Trust state → accent: external endpoints = warning amber, in-cluster
-  // workloads = brand indigo. Encoded as a left spine rather than a full tinted
-  // border (elevation + a spine reads authored; a rounded tint box reads generic).
-  const accentColor = isExternal ? 'text-hubble-warning' : 'text-hubble-accent';
-  const spineColor = isExternal ? 'border-l-hubble-warning' : 'border-l-hubble-accent';
+  // workloads = brand indigo, DaemonSet/host-network peers = teal. Encoded as
+  // a left spine rather than a full tinted border (elevation + a spine reads
+  // authored; a rounded tint box reads generic).
+  const accentColor = daemonSetPeer ? 'text-hubble-info' : isExternal ? 'text-hubble-warning' : 'text-hubble-accent';
+  const spineColor = daemonSetPeer ? 'border-l-hubble-info' : isExternal ? 'border-l-hubble-warning' : 'border-l-hubble-accent';
 
   const borderClasses = selected
     ? `border-hubble-border-strong ring-1 ring-hubble-accent/60 shadow-lg`
@@ -87,6 +96,14 @@ const PodNode: React.FC<PodNodeProps> = React.memo(({ data, selected }) => {
               <div className="text-xs text-tertiary truncate" title={data.externalNamespace}>
                 ns: {data.externalNamespace}
               </div>
+            )}
+            {daemonSetBadge && (
+              <span
+                className="inline-block mt-0.5 px-1.5 py-px rounded-control border border-hubble-info/40 bg-hubble-info/10 text-[10px] font-medium text-hubble-info"
+                title="Hidden by the DaemonSets toggle when it is off"
+              >
+                {daemonSetBadge}
+              </span>
             )}
             {podCount > 1 && (
               <div className="text-xs text-tertiary">

--- a/frontend/src/components/PodNode.tsx
+++ b/frontend/src/components/PodNode.tsx
@@ -35,13 +35,10 @@ const PodNode: React.FC<PodNodeProps> = React.memo(({ data, selected }) => {
   }, 0) || 0;
 
   const IconComponent = isExternal ? Globe : Server;
-  // DaemonSet / host-network peers (see utils/daemonSetPeers) get the same
-  // teal as their toolbar toggle so the badge, the spine and the toggle that
-  // hides them all read as one thing.
+  // DaemonSet / host-network peers (see utils/daemonSetPeers) take the same
+  // teal as their toolbar toggle and their edges — colour alone carries the
+  // association, no tag text on the card.
   const daemonSetPeer = isExternal && (data.pods && data.pods.length > 0 ? data.pods : [data.pod]).some(isDaemonSetOrHostNetworkPod);
-  const daemonSetBadge = daemonSetPeer
-    ? ((data.pods ?? []).some((p) => p.workload_kind === 'DaemonSet') ? 'DaemonSet' : 'host-network')
-    : null;
   // Trust state → accent: external endpoints = warning amber, in-cluster
   // workloads = brand indigo, DaemonSet/host-network peers = teal. Encoded as
   // a left spine rather than a full tinted border (elevation + a spine reads
@@ -97,14 +94,7 @@ const PodNode: React.FC<PodNodeProps> = React.memo(({ data, selected }) => {
                 ns: {data.externalNamespace}
               </div>
             )}
-            {daemonSetBadge && (
-              <span
-                className="inline-block mt-0.5 px-1.5 py-px rounded-control border border-hubble-info/40 bg-hubble-info/10 text-[10px] font-medium text-hubble-info"
-                title="Hidden by the DaemonSets toggle when it is off"
-              >
-                {daemonSetBadge}
-              </span>
-            )}
+
             {podCount > 1 && (
               <div className="text-xs text-tertiary">
                 {podCount} {isExternal ? (AGGREGATE_NAMESPACES.has(data.externalNamespace ?? '') ? 'IPs' : 'pods') : 'replicas'}

--- a/frontend/src/components/SettingsPanel.tsx
+++ b/frontend/src/components/SettingsPanel.tsx
@@ -80,6 +80,9 @@ export function SettingsPanel({ isOpen, onClose, namespaces }: SettingsPanelProp
           <Row label="Show external endpoints" hint="Internet / cross-cluster traffic nodes">
             <Toggle checked={settings.showExternalNodes} onChange={(v) => updateSettings({ showExternalNodes: v })} />
           </Row>
+          <Row label="Show DaemonSet peers" hint="node-exporter, CNI and CSI agents — hidden by default to declutter the map">
+            <Toggle checked={settings.showDaemonSetNodes} onChange={(v) => updateSettings({ showDaemonSetNodes: v })} />
+          </Row>
           <Row label="Show traffic edges">
             <Toggle checked={settings.showTraffic} onChange={(v) => updateSettings({ showTraffic: v })} />
           </Row>

--- a/frontend/src/contexts/SettingsContext.tsx
+++ b/frontend/src/contexts/SettingsContext.tsx
@@ -9,6 +9,11 @@ export interface AppSettings {
   defaultNamespace: string | null;
   /** Graph defaults — persisted so the view survives reloads. */
   showExternalNodes: boolean;
+  /** Show DaemonSet / host-network peers (node-exporter, CNI, CSI agents) on
+   *  the map. Off by default: since node-IP traffic is recorded they appear
+   *  as peers of nearly every pod and drown the workload picture. Policy
+   *  generation ignores this — those peers stay in the generated rules. */
+  showDaemonSetNodes: boolean;
   showTraffic: boolean;
   layoutDirection: 'LR' | 'TB';
 }
@@ -16,6 +21,7 @@ export interface AppSettings {
 const DEFAULT_SETTINGS: AppSettings = {
   defaultNamespace: null,
   showExternalNodes: true,
+  showDaemonSetNodes: false,
   showTraffic: true,
   layoutDirection: 'LR',
 };
@@ -33,9 +39,14 @@ function loadSettings(): AppSettings {
   }
 }
 
+type BooleanSettingKey = { [K in keyof AppSettings]: AppSettings[K] extends boolean ? K : never }[keyof AppSettings];
+
 interface SettingsContextValue {
   settings: AppSettings;
   updateSettings: (patch: Partial<AppSettings>) => void;
+  /** Flip a boolean setting from its CURRENT value (functional update), so a
+   *  toggle fired from an effect or a stale closure cannot double-flip. */
+  toggleSetting: (key: BooleanSettingKey) => void;
   resetSettings: () => void;
 }
 
@@ -62,10 +73,19 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     [],
   );
 
+  const toggleSetting = useCallback(
+    (key: BooleanSettingKey) => setSettings((prev) => {
+      const next = { ...prev, [key]: !prev[key] };
+      try { localStorage.setItem(STORAGE_KEY, JSON.stringify(next)); } catch { /* ignore */ }
+      return next;
+    }),
+    [],
+  );
+
   const resetSettings = useCallback(() => persist(DEFAULT_SETTINGS), [persist]);
 
   return (
-    <SettingsContext.Provider value={{ settings, updateSettings, resetSettings }}>
+    <SettingsContext.Provider value={{ settings, updateSettings, toggleSetting, resetSettings }}>
       {children}
     </SettingsContext.Provider>
   );

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -54,6 +54,12 @@
   --color-hubble-warning-hover: #D98908;
   --color-hubble-error: #EF4444;
   --color-hubble-error-hover: #DC2626;
+  /* Third categorical hue (teal) for things that are neither the brand
+     accent nor a trust state: the map's DaemonSet / host-network peers,
+     whose toggle must read differently from Traffic (indigo) and External
+     (amber) at a glance. teal-600 keeps ≥4.5:1 on the dark ground. */
+  --color-hubble-info: #0D9488;
+  --color-hubble-info-hover: #0F766E;
 
   /* One radius step for interactive controls (buttons, inputs, tabs) so the
      app stops mixing rounded / rounded-lg / rounded-full at random. */

--- a/frontend/src/utils/daemonSetPeers.test.ts
+++ b/frontend/src/utils/daemonSetPeers.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test } from 'vitest';
+import type { PodInfo, PodNodeData } from '../types';
+import {
+  isDaemonSetOrHostNetworkPod,
+  isDaemonSetPeer,
+  partitionDaemonSetPeers,
+  shouldAutoShowDaemonSets,
+} from './daemonSetPeers';
+
+const pod = (name: string, extra: Partial<PodInfo> = {}): PodInfo => ({
+  pod_name: name, pod_ip: '10.0.0.1', pod_namespace: 'monitoring', time_stamp: 't', node_name: 'n', is_dead: false, ...extra,
+});
+const node = (id: string, pods: PodInfo[], isExternal = true): PodNodeData =>
+  ({ id, label: id, pod: pods[0], pods, traffic: [], isExpanded: false, isExternal }) as PodNodeData;
+
+const nodeExporter = pod('node-exporter-abc', { workload_kind: 'DaemonSet', host_network: true });
+const ciliumAgent = pod('cilium-x', { workload_kind: 'DaemonSet', host_network: false });
+const kubeletLike = pod('kube-proxy-y', { host_network: true }); // no workload_kind from an older row
+const grafana = pod('grafana-0', { workload_kind: 'Deployment', host_network: false });
+const legacy = pod('legacy-0'); // neither field (old broker)
+
+describe('isDaemonSetOrHostNetworkPod', () => {
+  test('DaemonSet-owned OR host-network qualifies; null/absent does not', () => {
+    expect(isDaemonSetOrHostNetworkPod(nodeExporter)).toBe(true);
+    expect(isDaemonSetOrHostNetworkPod(ciliumAgent)).toBe(true);
+    expect(isDaemonSetOrHostNetworkPod(kubeletLike)).toBe(true);
+    expect(isDaemonSetOrHostNetworkPod(grafana)).toBe(false);
+    expect(isDaemonSetOrHostNetworkPod(legacy)).toBe(false);
+    expect(isDaemonSetOrHostNetworkPod(pod('n', { host_network: null }))).toBe(false);
+    expect(isDaemonSetOrHostNetworkPod(null)).toBe(false);
+  });
+});
+
+describe('isDaemonSetPeer', () => {
+  test('only EXTERNAL nodes are candidates — the namespace\'s own DaemonSets always render', () => {
+    expect(isDaemonSetPeer(node('external-monitoring-node-exporter-out', [nodeExporter]))).toBe(true);
+    expect(isDaemonSetPeer(node('monitoring-node-exporter', [nodeExporter], false))).toBe(false);
+  });
+  test('any member of the identity group qualifies the node', () => {
+    expect(isDaemonSetPeer(node('x-in', [grafana, ciliumAgent]))).toBe(true);
+    expect(isDaemonSetPeer(node('x-in', [grafana, legacy]))).toBe(false);
+  });
+  test('Internet / Service placeholder members (no workload facts) are never hidden', () => {
+    expect(isDaemonSetPeer(node('external-internet-in', [pod('1.2.3.4', { pod_namespace: 'internet' })]))).toBe(false);
+  });
+});
+
+describe('partitionDaemonSetPeers', () => {
+  const ds = node('external-monitoring-node-exporter-out', [nodeExporter]);
+  const cni = node('external-kube-system-cilium-in', [ciliumAgent]);
+  const app = node('external-media-grafana-out', [grafana]);
+  const all = [ds, cni, app];
+
+  test('toggle on ⇒ nothing hidden, order preserved', () => {
+    expect(partitionDaemonSetPeers(all, { show: true, focusedId: null, selectedId: null })).toEqual({ visible: all, hidden: [] });
+  });
+  test('toggle off ⇒ DaemonSet/host-network peers hidden, others kept', () => {
+    const { visible, hidden } = partitionDaemonSetPeers(all, { show: false, focusedId: null, selectedId: null });
+    expect(visible).toEqual([app]);
+    expect(hidden).toEqual([ds, cni]);
+  });
+  test('focused peer is never hidden', () => {
+    const { visible, hidden } = partitionDaemonSetPeers(all, { show: false, focusedId: ds.id, selectedId: null });
+    expect(visible).toEqual([ds, app]);
+    expect(hidden).toEqual([cni]);
+  });
+  test('selected peer is never hidden', () => {
+    const { visible } = partitionDaemonSetPeers(all, { show: false, focusedId: null, selectedId: cni.id });
+    expect(visible).toEqual([cni, app]);
+  });
+});
+
+describe('shouldAutoShowDaemonSets', () => {
+  const ds = node('external-monitoring-node-exporter-out', [nodeExporter]);
+  const app = node('external-media-grafana-out', [grafana]);
+  test('focus on a hidden-class peer while the toggle is off ⇒ turn it on', () => {
+    expect(shouldAutoShowDaemonSets(ds.id, [ds, app], false)).toBe(true);
+  });
+  test('already on, no focus, or focus on a normal peer ⇒ leave it', () => {
+    expect(shouldAutoShowDaemonSets(ds.id, [ds, app], true)).toBe(false);
+    expect(shouldAutoShowDaemonSets(null, [ds, app], false)).toBe(false);
+    expect(shouldAutoShowDaemonSets(app.id, [ds, app], false)).toBe(false);
+    expect(shouldAutoShowDaemonSets('missing', [ds, app], false)).toBe(false);
+  });
+});

--- a/frontend/src/utils/daemonSetPeers.test.ts
+++ b/frontend/src/utils/daemonSetPeers.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, test } from 'vitest';
 import type { PodInfo, PodNodeData } from '../types';
 import {
+  EDGE_COLOR_DAEMONSET,
+  EDGE_COLOR_DENIED,
+  EDGE_COLOR_EXTERNAL,
+  EDGE_COLOR_TRUSTED,
+  edgeStrokeColor,
   isDaemonSetOrHostNetworkPod,
   isDaemonSetPeer,
   partitionDaemonSetPeers,
@@ -67,6 +72,19 @@ describe('partitionDaemonSetPeers', () => {
   test('selected peer is never hidden', () => {
     const { visible } = partitionDaemonSetPeers(all, { show: false, focusedId: null, selectedId: cni.id });
     expect(visible).toEqual([cni, app]);
+  });
+});
+
+describe('edgeStrokeColor', () => {
+  test('edges to/from a DaemonSet peer take the DaemonSets hue, distinct from External', () => {
+    expect(edgeStrokeColor({ isDrop: false, isDaemonSet: true, isExternal: true })).toBe(EDGE_COLOR_DAEMONSET);
+    expect(EDGE_COLOR_DAEMONSET).not.toBe(EDGE_COLOR_EXTERNAL);
+    expect(EDGE_COLOR_DAEMONSET).not.toBe(EDGE_COLOR_TRUSTED);
+  });
+  test('denied always wins; otherwise external amber, in-cluster indigo', () => {
+    expect(edgeStrokeColor({ isDrop: true, isDaemonSet: true, isExternal: true })).toBe(EDGE_COLOR_DENIED);
+    expect(edgeStrokeColor({ isDrop: false, isDaemonSet: false, isExternal: true })).toBe(EDGE_COLOR_EXTERNAL);
+    expect(edgeStrokeColor({ isDrop: false, isDaemonSet: false, isExternal: false })).toBe(EDGE_COLOR_TRUSTED);
   });
 });
 

--- a/frontend/src/utils/daemonSetPeers.test.ts
+++ b/frontend/src/utils/daemonSetPeers.test.ts
@@ -48,6 +48,14 @@ describe('isDaemonSetPeer', () => {
   test('Internet / Service placeholder members (no workload facts) are never hidden', () => {
     expect(isDaemonSetPeer(node('external-internet-in', [pod('1.2.3.4', { pod_namespace: 'internet' })]))).toBe(false);
   });
+  test('the Unattributed aggregate is never hidden, even if a member carries DaemonSet facts', () => {
+    const unattributed = {
+      ...node('external-unattributed-in', [pod('192.168.50.101', { pod_namespace: 'unattributed', workload_kind: 'DaemonSet', host_network: true })]),
+      externalNamespace: 'unattributed',
+    } as PodNodeData;
+    expect(isDaemonSetPeer(unattributed)).toBe(false);
+    expect(partitionDaemonSetPeers([unattributed], { show: false, focusedId: null, selectedId: null }).hidden).toEqual([]);
+  });
 });
 
 describe('partitionDaemonSetPeers', () => {

--- a/frontend/src/utils/daemonSetPeers.ts
+++ b/frontend/src/utils/daemonSetPeers.ts
@@ -1,4 +1,5 @@
 import type { PodInfo, PodNodeData } from '../types';
+import { UNATTRIBUTED_NAMESPACE } from './peerResolution';
 
 // "DaemonSets" map toggle.
 //
@@ -23,6 +24,9 @@ export function isDaemonSetOrHostNetworkPod(p: PodInfo | undefined | null): bool
  */
 export function isDaemonSetPeer(node: PodNodeData): boolean {
   if (!node.isExternal) return false;
+  // The Unattributed / Internet aggregates stand for bare IPs, not pods; a
+  // guarded-out former IP holder must stay visible whatever it once was.
+  if (node.externalNamespace === UNATTRIBUTED_NAMESPACE || node.externalNamespace === 'internet') return false;
   const members = node.pods && node.pods.length > 0 ? node.pods : [node.pod];
   return members.some(isDaemonSetOrHostNetworkPod);
 }

--- a/frontend/src/utils/daemonSetPeers.ts
+++ b/frontend/src/utils/daemonSetPeers.ts
@@ -27,6 +27,21 @@ export function isDaemonSetPeer(node: PodNodeData): boolean {
   return members.some(isDaemonSetOrHostNetworkPod);
 }
 
+// Map colours for the association: the toggle, the peer node's spine and
+// every edge to/from such a peer share the DaemonSets hue (hubble-info) the
+// way External shares amber with its nodes and edges. Denied stays red.
+export const EDGE_COLOR_DENIED = '#EF4444';
+export const EDGE_COLOR_EXTERNAL = '#F59E0B';
+export const EDGE_COLOR_TRUSTED = '#4E3AD9';
+export const EDGE_COLOR_DAEMONSET = '#0D9488'; // --color-hubble-info
+
+export function edgeStrokeColor(edge: { isDrop: boolean; isDaemonSet: boolean; isExternal: boolean }): string {
+  if (edge.isDrop) return EDGE_COLOR_DENIED;
+  if (edge.isDaemonSet) return EDGE_COLOR_DAEMONSET;
+  if (edge.isExternal) return EDGE_COLOR_EXTERNAL;
+  return EDGE_COLOR_TRUSTED;
+}
+
 export interface DaemonSetPartition {
   visible: PodNodeData[];
   hidden: PodNodeData[];

--- a/frontend/src/utils/daemonSetPeers.ts
+++ b/frontend/src/utils/daemonSetPeers.ts
@@ -1,0 +1,67 @@
+import type { PodInfo, PodNodeData } from '../types';
+
+// "DaemonSets" map toggle.
+//
+// Since the controller began recording pod→node-IP traffic (#1431), almost
+// every pod in every namespace has node-exporter, the CNI agent, CSI node
+// plugins and friends as peers. They are real traffic — the policy
+// generators MUST keep them — but on the map they are noise that hides the
+// workload-to-workload picture, so they are hidden by default. Only external
+// (cross-namespace) peers are ever hidden: the selected namespace's own
+// workloads always render, as does the focused or selected node.
+
+/** A pod that belongs to a DaemonSet or shares the node's network. */
+export function isDaemonSetOrHostNetworkPod(p: PodInfo | undefined | null): boolean {
+  if (!p) return false;
+  return p.workload_kind === 'DaemonSet' || p.host_network === true;
+}
+
+/**
+ * Whether a graph node is a DaemonSet / host-network PEER. In-namespace
+ * workloads (`isExternal` false), the Internet node and Service nodes with
+ * synthetic member pods never qualify.
+ */
+export function isDaemonSetPeer(node: PodNodeData): boolean {
+  if (!node.isExternal) return false;
+  const members = node.pods && node.pods.length > 0 ? node.pods : [node.pod];
+  return members.some(isDaemonSetOrHostNetworkPod);
+}
+
+export interface DaemonSetPartition {
+  visible: PodNodeData[];
+  hidden: PodNodeData[];
+}
+
+/**
+ * Split external peers into the ones to render and the ones the toggle
+ * hides. `focusedId` / `selectedId` are never hidden: hiding the node the
+ * user just focused or clicked would make the map contradict the URL.
+ */
+export function partitionDaemonSetPeers(
+  externalNodes: readonly PodNodeData[],
+  opts: { show: boolean; focusedId: string | null; selectedId: string | null },
+): DaemonSetPartition {
+  if (opts.show) return { visible: [...externalNodes], hidden: [] };
+  const visible: PodNodeData[] = [];
+  const hidden: PodNodeData[] = [];
+  for (const node of externalNodes) {
+    const pinned = node.id === opts.focusedId || node.id === opts.selectedId;
+    if (!pinned && isDaemonSetPeer(node)) hidden.push(node);
+    else visible.push(node);
+  }
+  return { visible, hidden };
+}
+
+/**
+ * A shared `?focus=` link pointing at a DaemonSet peer should reveal that
+ * peer's whole class, not just the one node the pin exception keeps: flip the
+ * toggle on. Returns true exactly when the caller should turn it on.
+ */
+export function shouldAutoShowDaemonSets(
+  focusedId: string | null,
+  externalNodes: readonly PodNodeData[],
+  show: boolean,
+): boolean {
+  if (show || !focusedId) return false;
+  return externalNodes.some((n) => n.id === focusedId && isDaemonSetPeer(n));
+}

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -15,6 +15,7 @@ export default {
         'hubble-success': '#10B981',
         'hubble-warning': '#F59E0B',
         'hubble-error': '#EF4444',
+        'hubble-info': '#0D9488',
       },
     },
   },


### PR DESCRIPTION
## Summary

Operator request: *"With the UI changes to show daemonsets it's extremely busy on the UI, we might need a toggle to hide those by default."*

Since the controller records pod→node-IP traffic (#1431), node-exporter, the CNI agent, CSI node plugins and similar DaemonSets appear as peers of almost every pod and drown the workload-to-workload picture on the Network Map.

- New **DaemonSets** toggle next to **External** in the map toolbar — tooltip *"Show DaemonSet and host-network peers such as node-exporter, CNI and CSI agents"* — **off by default**, persisted with the other graph settings (`kg-settings`), also exposed in Settings → Graph defaults.
- When off, external peers whose resolved pod is DaemonSet-owned (`workload_kind === "DaemonSet"`) **or** host-network (`host_network === true`) are hidden with their edges; the button reads `DaemonSets (N hidden)`. Peers stay in the underlying data.
- The selected namespace's own workloads, the focused node and the selected node are never hidden. A `?focus=` link to a hidden peer turns the toggle on automatically (once per focused id, so it can still be switched off afterwards).
- Service nodes now carry their backing pods' workload facts, so a Service fronting a DaemonSet (the node-exporter ClusterIP) is recognised.
- **Policy generation is unaffected** — the peers remain in generated NetworkPolicy / CiliumNetworkPolicy rules.
- Toolbar extracted into `GraphControls` so it can be rendered in jsdom.

## Verification

- `npm run lint` (0 errors; 1 pre-existing warning), `npm test` 24 files / 161 tests, `npm run build` — all green.
- Unit tests: filter predicate, partition (focused/selected pin), focus override; jsdom test of the toolbar toggle.
- Live against the cluster-00 broker (`kubectl port-forward svc/kguardian-broker`, read-only): `home-system` map goes 26 nodes / 66 edges → 25 / 54 with the toggle off (`DaemonSets (1 hidden)`, node-exporter gone); cold load of a focus link to the node-exporter peer auto-enables and persists the toggle; toggling it off while focused sticks and keeps the focused node pinned.

## Not in scope

Node IPs are shared by every host-network pod on a node and the IP→pod lookup keeps the last (possibly dead) row, so some node-IP peers resolve to a dead pod and are dropped from the map, or to the namespace's own host-network pod. Pre-existing attribution behaviour; noted for a follow-up.

https://claude.ai/code/session_01Bhiv9RNPRaFPzkFPDUYjDW
