### PR TITLE
fix: supervise controller subsystems independently and bound every await

### DIFF
--- a/controller/clippy.toml
+++ b/controller/clippy.toml
@@ -2,11 +2,14 @@
 # enforced rule rather than a comment.
 #
 # DashMap::get returns a Ref that holds the shard's read lock until dropped.
-# Held across an .await it deadlocks the whole controller, because every
-# subsystem is composed into one task by try_join! in main.rs and the pod
-# watcher's insert() then blocks the thread on that shard. That outage shipped
-# once already: a stalled controller, Running with zero restarts and silent
-# logs, and it took a production report to find.
+# Held across an .await it deadlocks the controller: the pod watcher's insert()
+# blocks its worker thread outright on that shard, and if that is the thread
+# that would have polled the guard-holding future to completion, neither side
+# ever moves. That outage shipped once already: a stalled controller, Running
+# with zero restarts and silent logs, and it took a production report to find.
+# Each subsystem has its own task now (see src/supervisor.rs), which bounds how
+# much of the controller one held guard can take down. It does not make holding
+# one safe, and the guard is still held across the await either way.
 #
 # clippy::await_holding_lock does NOT catch it — dashmap wraps the parking_lot
 # guard in its own Ref type, which the lint cannot see through. Neither do the

--- a/controller/src/bpf.rs
+++ b/controller/src/bpf.rs
@@ -17,8 +17,8 @@ use tracing::{info, warn};
 
 // Each ring-buffer callback runs on the libbpf-rs poll thread, which is
 // inside a `task::spawn_blocking` and therefore not cancelable by Tokio.
-// If the corresponding mpsc receiver is dropped (e.g. its task in
-// `try_join!` got cancelled because a sister task errored), every
+// If the corresponding mpsc receiver is dropped (e.g. its consumer
+// task stopped, or the supervisor cancelled it on shutdown), every
 // subsequent eBPF event would log a "(receiver closed)" line, flooding
 // stderr at syscall frequency. Latch the first failure per channel,
 // log it loudly via the structured logger, then drop subsequent events
@@ -28,18 +28,30 @@ static NETWORK_SEND_FAILED: AtomicBool = AtomicBool::new(false);
 static SYSCALL_SEND_FAILED: AtomicBool = AtomicBool::new(false);
 static POLICY_DROP_SEND_FAILED: AtomicBool = AtomicBool::new(false);
 
-// Set when ANY receiver closes — signals the spawn_blocking poll loop
-// to exit on its next iteration. Without this, the poll loop would keep
-// running indefinitely after try_join! cancels its sibling tasks (the
-// underlying root cause of the spam #880 patched). Exiting forces the
-// JoinHandle to resolve, which in turn surfaces an error to main's
-// try_join! and the kubelet restarts the pod cleanly. Self-heal
-// pattern, mirrored from broker /health (#876).
+// Set when ANY receiver closes, and by main on its way out — signals
+// the spawn_blocking poll loop to exit on its next iteration. Without
+// this, the poll loop would keep running indefinitely after the
+// consumers are gone (the underlying root cause of the spam #880
+// patched). Exiting forces the JoinHandle to resolve, which surfaces a
+// fault to the supervisor and the kubelet restarts the pod cleanly.
+// Self-heal pattern, mirrored from broker /health (#876).
 static EBPF_SHUTDOWN: AtomicBool = AtomicBool::new(false);
 
-/// Trip the eBPF shutdown flag from a receiver-closed callback. Idempotent.
+/// Trip the eBPF shutdown flag. Idempotent.
+///
+/// Called from the receiver-closed callbacks below, and by `main` on
+/// its way out. The second caller is not optional: the poll loop runs
+/// inside `spawn_blocking`, and dropping the runtime waits — with no
+/// timeout — for every blocking task that has already started
+/// (`BlockingPool::drop` → `shutdown(None)`). So on SIGTERM the
+/// process cannot exit until this loop notices and returns. It used to
+/// notice only when a `blocking_send` failed against a dropped
+/// receiver, which requires an eBPF event to arrive: on an idle node
+/// there might not be one for minutes, and SIGTERM turned into "wait
+/// for the kubelet's SIGKILL". Telling it directly makes shutdown
+/// deterministic at one poll interval (~100ms).
 #[inline]
-fn signal_ebpf_shutdown() {
+pub fn signal_ebpf_shutdown() {
     EBPF_SHUTDOWN.store(true, Ordering::Relaxed);
 }
 
@@ -370,14 +382,14 @@ pub fn ebpf_handle(
 
         loop {
             // Honour the shutdown flag before polling so we exit promptly
-            // (within ~100ms) when a receiver-closed handler flips it.
-            // Returning Err propagates up through the JoinHandle into
-            // main's try_join!, which fails the controller and prompts
-            // the kubelet to restart the pod — clean recovery instead
-            // of a stuck process.
+            // (within ~100ms) when a receiver-closed handler — or main's
+            // shutdown path — flips it. Returning Err propagates up
+            // through the JoinHandle to the supervisor, which fails the
+            // controller and prompts the kubelet to restart the pod —
+            // clean recovery instead of a stuck process.
             if ebpf_shutdown_requested() {
                 return Err(Error::Custom(
-                    "eBPF poll loop exiting: an event-channel receiver was closed (likely a sister task in try_join! errored). Pod will restart.".into(),
+                    "eBPF poll loop exiting: shutdown was signalled (an event-channel receiver closed, or the Controller is terminating). Pod will restart if this was not a graceful shutdown.".into(),
                 ));
             }
             // Poll all ring buffers with a single call (much more efficient!)
@@ -570,6 +582,54 @@ mod tests {
         assert!(ebpf_shutdown_requested());
     }
 
+    /// The idle-node shutdown path, pinned.
+    ///
+    /// The poll loop lives in a `spawn_blocking` that nothing can
+    /// cancel, and dropping the runtime waits for it with no timeout
+    /// (tokio 1.53.1: `BlockingPool::drop` → `shutdown(None)` →
+    /// `shutdown_rx.wait(None)`). So this flag is the only thing that
+    /// lets the process exit at all.
+    ///
+    /// Before `signal_ebpf_shutdown` was reachable from outside this
+    /// module, the only thing that raised it was a `blocking_send`
+    /// failing against a dropped receiver — which requires an eBPF
+    /// event to arrive. Under traffic that is instant; on a node with
+    /// no traffic no event fires, nothing trips, and SIGTERM hung until
+    /// the kubelet's SIGKILL (30s, the default: this DaemonSet sets no
+    /// terminationGracePeriodSeconds and has no probes). "SIGTERM works"
+    /// was only ever true under load, which is exactly the kind of
+    /// thing that regresses invisibly.
+    ///
+    /// What this pins is the independence: the flag goes up with no
+    /// channel, no callback and no send failure anywhere.
+    #[test]
+    fn shutdown_can_be_requested_with_no_event_ever_arriving() {
+        let _guard = TEST_GUARD.lock().unwrap_or_else(|p| p.into_inner());
+        reset_state();
+
+        // An idle node: nothing has been sent, so none of the
+        // send-failure latches has fired.
+        assert!(!ebpf_shutdown_requested());
+        assert!(!NETWORK_SEND_FAILED.load(Ordering::Relaxed));
+        assert!(!SYSCALL_SEND_FAILED.load(Ordering::Relaxed));
+        assert!(!POLICY_DROP_SEND_FAILED.load(Ordering::Relaxed));
+
+        signal_ebpf_shutdown();
+
+        assert!(
+            ebpf_shutdown_requested(),
+            "the poll loop checks this at the top of every iteration, so raising it is what \
+             bounds SIGTERM at one ~100ms poll interval on a node with no traffic"
+        );
+        assert!(
+            !NETWORK_SEND_FAILED.load(Ordering::Relaxed)
+                && !SYSCALL_SEND_FAILED.load(Ordering::Relaxed)
+                && !POLICY_DROP_SEND_FAILED.load(Ordering::Relaxed),
+            "shutdown must not route through the send-failure latches; depending on them is \
+             precisely what made this path need traffic to work"
+        );
+    }
+
     #[test]
     fn signal_is_idempotent() {
         let _guard = TEST_GUARD.lock().unwrap_or_else(|p| p.into_inner());
@@ -578,6 +638,45 @@ mod tests {
         signal_ebpf_shutdown();
         signal_ebpf_shutdown();
         assert!(ebpf_shutdown_requested());
+    }
+
+    /// The shutdown *sequence*, not just the flag.
+    ///
+    /// `shutdown_can_be_requested_with_no_event_ever_arriving` above
+    /// proves the flag CAN be raised. It does not prove anything raises
+    /// it — mutation testing confirmed that deleting the call from the
+    /// shutdown path left the whole suite green while restoring the
+    /// idle-node hang. This drives the sequence `main` actually calls.
+    ///
+    /// `block_on` rather than `#[tokio::test]` so `TEST_GUARD` is never
+    /// held across an await: these statics are process-global and the
+    /// other tests in this module race for them.
+    #[test]
+    fn the_controller_shutdown_sequence_raises_the_ebpf_flag() {
+        let _guard = TEST_GUARD.lock().unwrap_or_else(|p| p.into_inner());
+        reset_state();
+        assert!(!ebpf_shutdown_requested());
+
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("build a test runtime");
+        let recovered = rt.block_on(async {
+            let mut supervisor = crate::supervisor::Supervisor::new();
+            crate::supervisor::shut_down(&mut supervisor, crate::supervisor::Draining::Gracefully)
+                .await
+        });
+
+        assert!(
+            recovered.is_empty(),
+            "nothing was running, so nothing faulted"
+        );
+        assert!(
+            ebpf_shutdown_requested(),
+            "the shutdown sequence must raise the flag: the poll loop is a spawn_blocking \
+             that nothing can cancel, and dropping the runtime waits for it with no \
+             timeout, so this is the only thing that lets the process exit on an idle node"
+        );
     }
 
     #[test]

--- a/controller/src/client.rs
+++ b/controller/src/client.rs
@@ -5,12 +5,42 @@ use tracing::debug;
 
 use lazy_static::lazy_static;
 
-lazy_static! {
-    static ref CLIENT: reqwest::Client = reqwest::Client::builder()
-        .timeout(std::time::Duration::from_secs(30))
-        .connect_timeout(std::time::Duration::from_secs(10))
+/// Ceiling on a whole broker request, connect through body.
+pub(crate) const REQUEST_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+/// Ceiling on establishing the TCP/TLS connection to the broker.
+pub(crate) const CONNECT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+
+/// Build an HTTP client with explicit ceilings on both halves of a
+/// request.
+///
+/// Factored out so no caller can get a client without them.
+/// `pod_reconciler` used to build its own with `ReqwestClient::new()`,
+/// which has NO timeouts at all — reqwest's default is to wait
+/// forever — so its broker GET could park indefinitely and pods
+/// stopped being marked dead with nothing logged. Timeouts are not a
+/// per-call-site decision; they belong to the client.
+fn build_http_client(
+    request_timeout: std::time::Duration,
+    connect_timeout: std::time::Duration,
+) -> reqwest::Client {
+    reqwest::Client::builder()
+        .timeout(request_timeout)
+        .connect_timeout(connect_timeout)
         .build()
-        .expect("Failed to create HTTP client");
+        .expect("Failed to create HTTP client")
+}
+
+lazy_static! {
+    static ref CLIENT: reqwest::Client = build_http_client(REQUEST_TIMEOUT, CONNECT_TIMEOUT);
+}
+
+/// The Controller's one HTTP client for broker traffic.
+///
+/// Shared rather than per-subsystem: it carries the timeouts above, and
+/// reqwest pools connections behind an `Arc`, so every caller reusing
+/// this one also stops re-dialling the broker on each request.
+pub(crate) fn http_client() -> &'static reqwest::Client {
+    &CLIENT
 }
 
 /// Build the broker URL for a given path, robust against trailing
@@ -202,6 +232,99 @@ pub(crate) async fn api_get_bytes(path: &str) -> Result<Vec<u8>, Error> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A listener that accepts and never responds — a broker that has
+    /// stopped serving without closing its socket. `reqwest`'s default
+    /// client waits on this forever.
+    fn hung_broker() -> (std::net::TcpListener, String) {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind loopback");
+        let addr = listener.local_addr().expect("local addr");
+        (listener, format!("http://{addr}/pod/list/node-a"))
+    }
+
+    /// The defect, pinned: this is exactly the client `pod_reconciler`
+    /// built (`ReqwestClient::new()`), and against a hung broker its
+    /// GET never returns.
+    #[tokio::test]
+    async fn a_default_reqwest_client_waits_forever() {
+        let (_listener, url) = hung_broker();
+        let client = reqwest::Client::new();
+
+        let outcome = tokio::time::timeout(
+            std::time::Duration::from_millis(750),
+            client.get(&url).send(),
+        )
+        .await;
+
+        assert!(
+            outcome.is_err(),
+            "reqwest::Client::new() has no request timeout; if this ever resolves, reqwest              has changed its defaults"
+        );
+    }
+
+    /// The fix: a client from the shared constructor gives up.
+    #[tokio::test]
+    async fn a_client_from_the_shared_builder_times_out() {
+        let (_listener, url) = hung_broker();
+        let client = build_http_client(
+            std::time::Duration::from_millis(200),
+            std::time::Duration::from_millis(100),
+        );
+
+        let started = tokio::time::Instant::now();
+        let err = client
+            .get(&url)
+            .send()
+            .await
+            .expect_err("a hung broker must produce an error, not a response");
+
+        assert!(err.is_timeout(), "expected a timeout, got {err}");
+        assert!(
+            started.elapsed() < std::time::Duration::from_secs(1),
+            "took {:?}",
+            started.elapsed()
+        );
+    }
+
+    /// The shipped ceilings, guarded.
+    ///
+    /// Every timeout test in this crate injects its own short ceiling so
+    /// the suite stays fast (200ms here, 300ms in `container`). That
+    /// proves the mechanism and leaves the production numbers asserted
+    /// nowhere: mutation testing raised `REQUEST_TIMEOUT` to 24 hours
+    /// with the whole suite and CI green. A bound costs nothing at
+    /// runtime and makes changing these deliberate rather than silent.
+    ///
+    /// The bound is not arbitrary. The controller posts to the broker
+    /// from subsystems that run on a clock — the syscall recorder every
+    /// 10s, the network batch flush every 1s — so a broker that is
+    /// wedged rather than down must not hold one of them past several
+    /// of its own ticks. 30s already allows that; a minute is the point
+    /// where it stops being a ceiling at all.
+    #[test]
+    fn the_shipped_broker_ceilings_stay_bounded() {
+        assert!(
+            REQUEST_TIMEOUT <= std::time::Duration::from_secs(60),
+            "a {REQUEST_TIMEOUT:?} request ceiling lets a wedged broker stall a subsystem \
+             across many of its own ticks; that is the #1344 hang with extra steps"
+        );
+        assert!(
+            CONNECT_TIMEOUT < REQUEST_TIMEOUT,
+            "the connect budget must be a fraction of the whole-request budget, not equal \
+             to or larger than it"
+        );
+    }
+
+    /// The shared client is the one built with the production
+    /// ceilings, and every caller gets the same pooled instance.
+    #[test]
+    fn the_shared_client_is_a_single_pooled_instance() {
+        assert!(
+            std::ptr::eq(http_client(), http_client()),
+            "callers must share one client, so connections are pooled rather than re-dialled"
+        );
+        assert!(CONNECT_TIMEOUT < REQUEST_TIMEOUT);
+    }
 
     // build_url is the URL constructor for every controller → broker
     // POST. Robustness against trailing slashes prevents double-slash

--- a/controller/src/container.rs
+++ b/controller/src/container.rs
@@ -8,9 +8,52 @@ use containerd_client::{
 use procfs::process::Process;
 use regex::Regex;
 use std::ffi::OsString;
+use std::time::Duration;
 use tracing::*;
 
 static REGEX_CONTAINERD: &str = "containerd://(?P<container_id>[0-9a-zA-Z]*)";
+
+/// Ceiling on establishing the containerd gRPC channel.
+///
+/// `containerd_client::connect` builds its `Endpoint` from
+/// `Endpoint::try_from("http://[::]")` and sets neither `.timeout()`
+/// nor `.connect_timeout()` (verified against containerd-client 0.9.0),
+/// so the await it hands back has no deadline of its own.
+///
+/// Measured, so the bound is not folklore: the two wedged-daemon
+/// shapes reachable in a test — a listener that accepts and never
+/// speaks, and one whose accept backlog is saturated — both resolve
+/// here rather than hanging. The HTTP/2 handshake completes on the
+/// client preface without waiting for the server's SETTINGS frame, and
+/// a full backlog surfaces as an immediate `EAGAIN`. So this ceiling
+/// is not the one that was losing pod ingestion; `RPC_TIMEOUT` is (see
+/// the tests). It stays because the call is still unbounded by
+/// construction — a path lookup stalling on the filesystem holding the
+/// socket, or a connector change upstream, puts the hang back — and a
+/// two-second ceiling on a same-node unix socket that a healthy
+/// containerd answers in single-digit milliseconds costs nothing.
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// Ceiling on the `Tasks.Get` RPC itself, and the load-bearing one.
+///
+/// This is the await that parks forever against a containerd that is
+/// alive, holding its socket, and answering nothing — a daemon blocked
+/// behind a stuck shim. It sits on the pod-registration path, awaited
+/// sequentially per container, per pod, per 60s resync pass, so one
+/// wedged daemon stopped ALL pod ingestion for the life of the
+/// process: no netns inode reached the ContainerMap, and every later
+/// pod's traffic was attributed to nothing.
+///
+/// Five seconds is well past containerd's own behaviour for a local
+/// task lookup and still bounded. A tonic `Endpoint::timeout` would
+/// cover this in the transport (the channel stack applies it via its
+/// `GrpcTimeout` layer), but reaching it means rebuilding the endpoint
+/// and its unix connector here, which pulls `tower` and `hyper-util`
+/// in as direct dependencies to reimplement what `connect` already
+/// does. `tokio::time::timeout` bounds the same await with no new
+/// dependencies and, unlike the transport setting, is exercisable in a
+/// unit test.
+const RPC_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Parse a Kubernetes pod-status containerID URL.
 ///
@@ -27,32 +70,55 @@ pub(crate) fn parse_container_id(s: &str) -> Option<String> {
         .filter(|s| !s.is_empty())
 }
 
-impl PodInspect {
-    pub async fn get_pod_inspect(self, container_id: &str) -> Option<PodInspect> {
-        let container_id = parse_container_id(container_id);
+/// Containerd socket path, trimmed.
+///
+/// Trim — a trailing newline from `CONTAINERD_SOCK="/run/...\n"` would
+/// break the unix-socket connect with a confusing "No such file or
+/// directory" error far from the env read.
+fn containerd_sock() -> String {
+    std::env::var("CONTAINERD_SOCK")
+        .map(|s| s.trim().to_string())
+        .unwrap_or_else(|_| "/run/containerd/containerd.sock".to_string())
+}
 
-        if let Some(container_id) = container_id {
-            // Trim — a trailing newline from `CONTAINERD_SOCK="/run/...\n"`
-            // would break the unix-socket connect with a confusing
-            // "No such file or directory" error far from the env read.
-            let sock_path = std::env::var("CONTAINERD_SOCK")
-                .map(|s| s.trim().to_string())
-                .unwrap_or_else(|_| "/run/containerd/containerd.sock".to_string());
-            match connect(&sock_path).await {
-                Ok(channel) => Some(
-                    self.set_container_id(container_id)
-                        .get_pid(channel)
-                        .await
-                        .get_net_namespace_id(),
-                ),
-                Err(err) => {
-                    error!("Failed to connect to containerd socket: {:?}", err);
-                    None
-                }
-            }
-        } else {
+/// Open a containerd channel, or give up after `timeout`.
+///
+/// Split out with an explicit timeout argument so the bound itself is
+/// testable against a socket that accepts and never speaks — the exact
+/// shape that used to park the pod watcher forever. See
+/// [`CONNECT_TIMEOUT`].
+async fn connect_containerd(sock_path: &str, timeout: Duration) -> Option<Channel> {
+    match tokio::time::timeout(timeout, connect(sock_path)).await {
+        Ok(Ok(channel)) => Some(channel),
+        Ok(Err(err)) => {
+            error!("Failed to connect to containerd socket: {:?}", err);
             None
         }
+        Err(_) => {
+            error!(
+                sock = sock_path,
+                timeout_secs = timeout.as_secs(),
+                "containerd did not complete the connection within the timeout; skipping \
+                 this container. Pod ingestion continues — before this bound existed the \
+                 await never returned and every subsequent pod on this node went \
+                 unobserved."
+            );
+            None
+        }
+    }
+}
+
+impl PodInspect {
+    pub async fn get_pod_inspect(self, container_id: &str) -> Option<PodInspect> {
+        let container_id = parse_container_id(container_id)?;
+        let sock_path = containerd_sock();
+        let channel = connect_containerd(&sock_path, CONNECT_TIMEOUT).await?;
+        Some(
+            self.set_container_id(container_id)
+                .get_pid(channel)
+                .await
+                .get_net_namespace_id(),
+        )
     }
 
     fn set_container_id(mut self, container_id: String) -> Self {
@@ -60,7 +126,14 @@ impl PodInspect {
         self
     }
 
-    async fn get_pid(mut self, channel: Channel) -> Self {
+    async fn get_pid(self, channel: Channel) -> Self {
+        self.get_pid_bounded(channel, RPC_TIMEOUT).await
+    }
+
+    /// `get_pid` with the RPC ceiling passed in, so a test can hold a
+    /// containerd that never answers without waiting [`RPC_TIMEOUT`]
+    /// for the assertion.
+    async fn get_pid_bounded(mut self, channel: Channel, rpc_timeout: Duration) -> Self {
         let mut client = TasksClient::new(channel.clone());
 
         // get_pid is only reached after set_container_id has populated
@@ -81,15 +154,30 @@ impl PodInspect {
         };
 
         let req = with_namespace!(req, "k8s.io");
-        match client.get(req).await {
-            Ok(resp) => {
+        // Bounded: `client.get(req)` is an ordinary tonic call with no
+        // deadline of its own, and a containerd whose task service is
+        // blocked behind a stuck shim answers it never. This await sits
+        // on the pod-registration path, so an unbounded one stops every
+        // later pod from being registered — the netns inode never lands
+        // in the ContainerMap, and its traffic is attributed to nothing.
+        match tokio::time::timeout(rpc_timeout, client.get(req)).await {
+            Ok(Ok(resp)) => {
                 let container_resp = resp.into_inner();
                 self.pid = container_resp.process.map(|p| p.pid);
             }
-            Err(err) => {
+            Ok(Err(err)) => {
                 error!(
                     "Failed to get container response for container id {:?}, {:?}",
                     self.container_id, err
+                );
+                self.pid = None;
+            }
+            Err(_) => {
+                error!(
+                    container_id = ?self.container_id,
+                    timeout_secs = rpc_timeout.as_secs(),
+                    "containerd Tasks.Get did not answer within the timeout; pid stays \
+                     unset and this container is skipped until the next resync"
                 );
                 self.pid = None;
             }
@@ -115,6 +203,157 @@ impl PodInspect {
 mod tests {
     use super::*;
 
+    /// Unlinks the socket path on drop so a failing test doesn't leave
+    /// litter behind in the temp dir.
+    struct TempSock(String);
+    impl Drop for TempSock {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_file(&self.0);
+        }
+    }
+
+    /// A containerd that is alive and holding its socket, and answers
+    /// nothing: bound, listening, never accepting. This is the shape of
+    /// a daemon wedged behind a stuck shim — the failure the pod
+    /// watcher actually met, as opposed to a daemon that is simply
+    /// down (which refuses the connection and fails fast).
+    ///
+    /// Both handles must be kept alive by the caller: the listener
+    /// holds the socket bound, `TempSock` unlinks it afterwards.
+    fn silent_containerd() -> (std::os::unix::net::UnixListener, String, TempSock) {
+        let path = format!(
+            "{}/kguardian-silent-containerd-{}-{:?}.sock",
+            std::env::temp_dir().display(),
+            std::process::id(),
+            std::thread::current().id(),
+        );
+        let _ = std::fs::remove_file(&path);
+        let listener = std::os::unix::net::UnixListener::bind(&path)
+            .expect("bind a unix socket in the temp dir");
+        (listener, path.clone(), TempSock(path))
+    }
+
+    /// A `Tasks.Get` for a plausible container id, built exactly as
+    /// `get_pid_bounded` builds it.
+    fn task_get_request() -> Request<GetRequest> {
+        let req = GetRequest {
+            container_id: "a".repeat(64),
+            ..Default::default()
+        };
+        with_namespace!(req, "k8s.io")
+    }
+
+    /// The defect, pinned, and located.
+    ///
+    /// Measured here rather than assumed: against a containerd that
+    /// holds its socket and answers nothing, `connect` RESOLVES — the
+    /// HTTP/2 handshake completes as soon as the client preface is
+    /// flushed and never waits for the server's SETTINGS frame — and
+    /// it is `client.get(req)` that parks forever. Neither call had a
+    /// deadline of its own, so this is where all pod ingestion stopped:
+    /// the await sits on the registration path, sequentially, per
+    /// container, per pod, per 60s resync pass.
+    #[tokio::test]
+    async fn the_raw_task_rpc_never_returns_against_a_silent_containerd() {
+        let (_listener, path, _cleanup) = silent_containerd();
+
+        let channel = connect(&path)
+            .await
+            .expect("a listening socket yields a channel even when the daemon is silent");
+        let mut client = TasksClient::new(channel);
+
+        let outcome =
+            tokio::time::timeout(Duration::from_millis(750), client.get(task_get_request())).await;
+
+        assert!(
+            outcome.is_err(),
+            "the Tasks.Get RPC is expected to be unbounded here; if this ever resolves, \
+             containerd-client or tonic has started applying a deadline and the constants \
+             in this module should be revisited"
+        );
+    }
+
+    /// The fix, through the production code path: the same silent
+    /// containerd, and `get_pid` gives up instead of parking. The lower
+    /// bound on the elapsed time is the point — it proves the RPC
+    /// really did hang and really was cut off, rather than erroring
+    /// out for some unrelated reason and passing by accident.
+    #[tokio::test]
+    async fn a_silent_containerd_is_cut_off_at_the_rpc_ceiling() {
+        let (_listener, path, _cleanup) = silent_containerd();
+
+        // The connect half stays fast; the ceiling on it must not have
+        // turned an ordinary dial into a stall.
+        let started = tokio::time::Instant::now();
+        let channel = connect_containerd(&path, CONNECT_TIMEOUT)
+            .await
+            .expect("a listening socket yields a channel");
+        assert!(
+            started.elapsed() < Duration::from_millis(500),
+            "connecting to a listening socket must stay fast; took {:?}",
+            started.elapsed()
+        );
+
+        let ceiling = Duration::from_millis(300);
+        let started = tokio::time::Instant::now();
+        let inspect = PodInspect {
+            container_id: Some("a".repeat(64)),
+            ..Default::default()
+        }
+        .get_pid_bounded(channel, ceiling)
+        .await;
+
+        assert!(
+            inspect.pid.is_none(),
+            "a timed-out RPC must leave pid unset rather than inventing one"
+        );
+        assert!(
+            started.elapsed() >= ceiling,
+            "the RPC must actually have hung and been cut off, not failed early; took {:?}",
+            started.elapsed()
+        );
+        assert!(
+            started.elapsed() < Duration::from_secs(2),
+            "and it must be cut off at the ceiling, not later; took {:?}",
+            started.elapsed()
+        );
+    }
+
+    /// The ceilings are a pod-registration budget, not a general
+    /// timeout. `pod_watcher::process_container_ids` walks a pod's
+    /// containers serially, so the worst an unresponsive daemon can
+    /// cost one resync pass is containers x (connect + rpc). That has
+    /// to stay well inside the 60s resync interval, or a single bad pod
+    /// starves the pass that was meant to be the safety net.
+    #[test]
+    fn the_containerd_ceilings_stay_inside_a_resync_pass() {
+        assert!(
+            CONNECT_TIMEOUT + RPC_TIMEOUT <= Duration::from_secs(10),
+            "a per-container budget of {:?} leaves too little of the 60s resync interval \
+             for a pod with several containers",
+            CONNECT_TIMEOUT + RPC_TIMEOUT
+        );
+    }
+
+    /// A socket that is simply absent still fails fast and quietly —
+    /// the connect ceiling must not have turned an ordinary error into
+    /// a two-second stall on every container of every pod.
+    #[tokio::test]
+    async fn a_missing_socket_still_fails_immediately() {
+        let started = tokio::time::Instant::now();
+        let channel = connect_containerd(
+            "/nonexistent/kguardian/containerd.sock",
+            Duration::from_secs(2),
+        )
+        .await;
+
+        assert!(channel.is_none());
+        assert!(
+            started.elapsed() < Duration::from_millis(500),
+            "a missing socket is an error, not a timeout; took {:?}",
+            started.elapsed()
+        );
+    }
     // parse_container_id is the gate that decides which pods we can
     // observe. A regression here either drops valid pods (we lose
     // visibility) or accepts garbage (we make containerd RPCs with

--- a/controller/src/lib.rs
+++ b/controller/src/lib.rs
@@ -22,3 +22,7 @@ pub mod bpf;
 pub mod capture_tiers;
 pub mod log;
 pub mod node_facts;
+/// One task per subsystem, with explicit supervision over what each
+/// one stopping means. Replaces the `try_join!` fabric main used to
+/// have; see the module docs for what that fused together.
+pub mod supervisor;

--- a/controller/src/main.rs
+++ b/controller/src/main.rs
@@ -10,6 +10,7 @@ use kguardian::log::init_logger;
 use kguardian::network::{handle_network_events, handle_policy_drop_events, PolicyDropEvent};
 use kguardian::seccomp_distributor::run as run_seccomp_distributor;
 use kguardian::service_watcher::watch_service;
+use kguardian::supervisor::{report, shut_down, Draining, Subsystem, Supervisor};
 use kguardian::syscall::{
     handle_syscall_events, send_syscall_cache_periodically, SyscallEventData,
 };
@@ -46,8 +47,9 @@ async fn main() -> Result<(), Error> {
 
     // One-shot, fire-and-forget: derive this node's environment facts
     // (provider/distro/CNI/IP family/OS) and report them to the broker
-    // for the anonymous telemetry check-in. Deliberately NOT part of
-    // the try_join! fabric — telemetry must never take capture down.
+    // for the anonymous telemetry check-in. Deliberately unsupervised —
+    // telemetry must never take capture down, and it is expected to
+    // finish.
     tokio::spawn(kguardian::node_facts::report_node_facts(
         node_name.clone(),
         broker_url.clone(),
@@ -89,39 +91,27 @@ async fn main() -> Result<(), Error> {
     let (sender_ip, recv_ip) = mpsc::channel(1000); // Use tokio's mpsc channel
 
     // Shared inode -> pod map. NOTE: DashMap is sharded RwLocks, not lock-free.
-    // Every subsystem below is joined into ONE task by try_join!, so a shard
-    // guard held across an .await blocks the whole controller permanently.
-    // Read it only via models::lookup_pod. See ContainerMap for the detail.
+    // A shard guard held across an .await blocks every subsystem that
+    // touches this map, and on a busy node that is most of them. Each
+    // subsystem has its own task now, so the blast radius is smaller
+    // than it was — but a held guard is still a cross-task deadlock,
+    // not a local stall. Read it only via models::lookup_pod. See
+    // ContainerMap for the detail.
     let container_map: ContainerMap = Arc::new(DashMap::new());
     let pod_c = Arc::clone(&container_map);
     let network_map = Arc::clone(&container_map);
     let syscall_map = Arc::clone(&container_map);
 
-    let pods = watch_pods(
-        node_name.clone(),
-        tx,
-        pod_c,
-        &excluded_namespaces,
-        sender_ip,
-        ignore_daemonset_traffic,
-        cluster_capture_level,
-    );
     info!("Ignoring namespaces: {:?}", excluded_namespaces);
-
-    let service = watch_service();
-
-    // Start pod reconciliation task
-    let pod_reconciler = reconcile_pods_task(node_name, broker_url);
 
     let (network_event_sender, network_event_receiver) = mpsc::channel::<NetworkEventData>(1000);
     let (syscall_event_sender, syscall_event_receiver) = mpsc::channel::<SyscallEventData>(1000);
     let (netpolicy_drop_sender, netpolicy_drop_receiver) = mpsc::channel::<PolicyDropEvent>(1000);
 
-    let network_event_handler = handle_network_events(network_event_receiver, network_map);
-    let netpolicy_drop_handler =
-        handle_policy_drop_events(netpolicy_drop_receiver, Arc::clone(&container_map));
-    let syscall_event_handler = handle_syscall_events(syscall_event_receiver, syscall_map);
-
+    // Spawned before anything is supervised: `ebpf_handle` is a
+    // `spawn_blocking` that starts loading and attaching programs the
+    // moment it is called, and its `JoinHandle` is what the supervised
+    // future below awaits.
     let ebpf_handle = ebpf_handle(
         network_event_sender,
         syscall_event_sender,
@@ -132,12 +122,87 @@ async fn main() -> Result<(), Error> {
         resolved_tiers,
     );
 
-    let syscall_recorder = send_syscall_cache_periodically();
+    // One task per subsystem.
+    //
+    // These nine used to be composed with `tokio::try_join!`, which is
+    // nine futures on ONE task. A task is polled by at most one worker
+    // and cannot be stolen mid-poll, so a blocking call in any of them
+    // froze all nine — measured on this 14-worker runtime: the in-join
+    // heartbeat stopped for good while a separately spawned task kept
+    // ticking — and all nine drained a single 128-operation cooperative
+    // budget between them. See the supervisor module docs.
+    //
+    // Almost everything here is `Required`: these subsystems are meant
+    // to run until the process does, and any of them stopping —
+    // including returning `Ok(())` — ends the Controller non-zero. That
+    // is not a new severity, it is the one `try_join!` already had for
+    // `Err`, extended to cover the clean exits it ignored:
+    // `handle_syscall_events`, `handle_network_events` and
+    // `handle_policy_drop_events` all return `Ok(())` when their
+    // channel closes, and `try_join!` went on waiting for the other
+    // eight — a live, healthy-looking, partially-blind Controller.
+    //
+    // Keeping them `Required` also keeps a second signal that per-task
+    // supervision makes easy to lose. Each of the three subsystems that
+    // builds a kube client can `?` out of that build when the apiserver
+    // is unreachable at boot; today that exits non-zero and the kubelet
+    // backs off, and with no liveness, readiness or startup probe on
+    // this DaemonSet that CrashLoopBackOff is the only thing an
+    // operator sees. It must not become an invisible in-process retry.
+    //
+    // `ebpf-loader` in particular keeps the property PR #1473 argued
+    // for: a Controller whose eBPF loader has died is not degraded, it
+    // is blind, and a blind Controller that stays up turns
+    // observed-absence-means-safe-to-deny into a lie that nothing
+    // marks. Isolating the subsystems from each other's stalls must not
+    // isolate the operator from their deaths.
+    let mut supervisor = Supervisor::new();
 
+    supervisor.spawn(
+        Subsystem::PodWatcher,
+        watch_pods(
+            node_name.clone(),
+            tx,
+            pod_c,
+            excluded_namespaces,
+            sender_ip,
+            ignore_daemonset_traffic,
+            cluster_capture_level,
+        ),
+    );
+    supervisor.spawn(Subsystem::ServiceWatch, watch_service());
+    supervisor.spawn(
+        Subsystem::NetworkEvents,
+        handle_network_events(network_event_receiver, network_map),
+    );
+    supervisor.spawn(
+        Subsystem::SyscallEvents,
+        handle_syscall_events(syscall_event_receiver, syscall_map),
+    );
+    supervisor.spawn(
+        Subsystem::NetpolicyDropEvents,
+        handle_policy_drop_events(netpolicy_drop_receiver, Arc::clone(&container_map)),
+    );
+    supervisor.spawn(
+        Subsystem::SyscallRecorder,
+        send_syscall_cache_periodically(),
+    );
+    supervisor.spawn(
+        Subsystem::PodReconciler,
+        reconcile_pods_task(node_name, broker_url),
+    );
     // Writes broker-generated per-workload seccomp profiles onto this
-    // node. No-ops unless SECCOMP_DISTRIBUTE=true; best-effort, so a
-    // failure here never restarts the controller.
-    let seccomp_distributor = run_seccomp_distributor();
+    // node. The one subsystem allowed to retire: `run` returns `Ok(())`
+    // straight away unless SECCOMP_DISTRIBUTE=true, which is the
+    // default install, so alarming on that would cry wolf everywhere.
+    //
+    // `MayRetire` exempts the clean `Ok` and nothing else — an `Err`
+    // from this subsystem is still a fault that ends the process.
+    // `run` has no `?` and no `return Err` today, so that is
+    // unreachable; if you add one, that is the behaviour you are
+    // choosing, and "best-effort" will no longer describe it.
+    supervisor.spawn(Subsystem::SeccompDistributor, run_seccomp_distributor());
+    supervisor.spawn(Subsystem::EbpfLoader, async move { ebpf_handle.await? });
 
     // Graceful shutdown on SIGTERM/SIGINT
     let shutdown = async {
@@ -148,58 +213,52 @@ async fn main() -> Result<(), Error> {
             _ = sigterm.recv() => info!("Received SIGTERM, shutting down"),
             _ = sigint => info!("Received SIGINT, shutting down"),
         }
-        Ok::<(), Error>(())
     };
 
-    // Wait for all tasks to complete or shutdown signal.
+    // Run until a subsystem faults or the kubelet asks us to stop.
     //
-    // `try_join!` means the FIRST subsystem to return `Err` tears down
-    // every other one. That is deliberate for the ones left here, and
-    // it is no longer a trapdoor for the apiserver watches: `watch_pods`
-    // and `watch_service` handle their stream errors in-band and never
-    // return at all now (see watch_loop). Before that, a single dropped
-    // apiserver connection resolved their `try_for_each`, propagated a
-    // `?` through here, and took kernel-side capture down with it — 26
-    // of 42 Controllers exited that way inside six minutes on
-    // 2026-09-04, each losing a `connections` LRU, its `inode_num`
-    // registrations and its tier allowlists with nothing to backfill
-    // them. Watch failures degrade the watch; they do not stop capture.
+    // The watches and the event consumers are infinite by construction,
+    // so the shutdown arm is the ordinary way this process ends; the
+    // supervision arm is the incident.
     //
-    // `ebpf_handle` stays in the join on purpose, and the asymmetry is
-    // the point. Kernel-side capture is the product: a Controller whose
-    // eBPF loader has died is not degraded, it is blind, and a blind
-    // Controller that keeps running turns kguardian's core guarantee
-    // (observed-absence means safe-to-deny) into a lie that nothing
-    // marks. Exiting non-zero is the only signal that reaches an
-    // operator today — there is no readiness endpoint on this
-    // DaemonSet — so a capture failure must still restart the pod.
-    // Pulling it out of the join would buy nothing and hide that.
+    // `Supervisor::watch` is cancel-safe, so losing this select! costs
+    // nothing: the tasks live in the JoinSet, not in this future.
+    let fault = tokio::select! {
+        fault = supervisor.watch() => Some(fault),
+        _ = shutdown => None,
+    };
+
+    // Stop the eBPF poll loop first, then abort and drain the rest.
+    // `shut_down` owns that ordering and explains why it is not
+    // negotiable; it is a function rather than two lines here so the
+    // sequence is covered by a test (`bpf::tests::
+    // the_controller_shutdown_sequence_raises_the_ebpf_flag`) instead
+    // of living in `main`, which has none.
     //
-    // The remaining hazard is that all of these are polled on ONE task,
-    // so a blocking mistake anywhere wedges everything. That is #1346
-    // and is not addressed here.
-    tokio::select! {
-        result = async {
-            tokio::try_join!(
-                service,
-                pods,
-                network_event_handler,
-                syscall_event_handler,
-                netpolicy_drop_handler,
-                syscall_recorder,
-                seccomp_distributor,
-                pod_reconciler,
-                async { ebpf_handle.await? }
-            )
-        } => { result?; }
-        // The watches are infinite by construction now, so the join
-        // branch above no longer completes on its own in the normal
-        // case: this arm is the ordinary way the process ends. Both
-        // futures are polled on this task, so completing here drops the
-        // join and cancels every subsystem with it.
-        _ = shutdown => {
+    // Draining also recovers faults that were already queued when we
+    // aborted. That matters on the fault path: when the eBPF loader
+    // dies it closes the event channels on its way out, so a consumer's
+    // clean `Ok` can win the race to be reported and the loader's own
+    // error would otherwise never be printed at all. On the graceful
+    // path the same drain stays quiet, because the poll loop returning
+    // `Err` after being told to stop is expected, not an incident.
+    let draining = match fault {
+        Some(_) => Draining::AfterFault,
+        None => Draining::Gracefully,
+    };
+    let _ = shut_down(&mut supervisor, draining).await;
+
+    match fault {
+        // `report` logs the fault and converts it into the error main
+        // returns, which is the non-zero exit and the pod restart. Every
+        // fault gets that treatment, a clean `Ok(())` retirement
+        // included — a subsystem that stopped is a hole in this node's
+        // observations whether or not it called it an error, and this
+        // DaemonSet has no other way to say so.
+        Some(fault) => Err(report(fault)),
+        None => {
             info!("Graceful shutdown complete");
+            Ok(())
         }
     }
-    Ok(())
 }

--- a/controller/src/models.rs
+++ b/controller/src/models.rs
@@ -81,11 +81,14 @@ pub struct PodRegistration {
 /// The value is an `Arc` on purpose. `DashMap` is NOT lock-free despite what
 /// the call sites used to claim: it is an array of `RwLock`-guarded shards,
 /// and `get()` hands back a `Ref` that keeps that shard read-locked until it
-/// is dropped. Holding one across an `.await` deadlocks the controller,
-/// because every subsystem is joined into a single task by `try_join!` in
-/// main.rs — a sibling future calling `insert()` on the same shard blocks the
-/// thread, and the future holding the guard can then never be polled to
-/// release it. Nothing recovers; the process stays alive and silent.
+/// is dropped. Holding one across an `.await` deadlocks the controller: the
+/// pod watcher calling `insert()` on the same shard blocks its worker
+/// thread outright, and if that thread is the one that would have polled
+/// the guard-holding future to completion, neither side ever moves.
+/// Nothing recovers; the process stays alive and silent. Each subsystem
+/// has its own task now (see `supervisor`), which bounds how much of the
+/// Controller one held guard can take down — it does not make holding one
+/// safe.
 ///
 /// Wrapping the value in `Arc` makes the safe pattern free: copy the handle
 /// out of the guard, let the guard drop, and only then await. See

--- a/controller/src/pod_reconciler.rs
+++ b/controller/src/pod_reconciler.rs
@@ -66,36 +66,41 @@ fn find_dead_pod_details<'a>(
 /// Marks pods as dead if they're no longer running on this node
 pub async fn reconcile_pods_task(node_name: String, broker_url: String) -> Result<(), Error> {
     let mut ticker = interval(Duration::from_secs(RECONCILE_INTERVAL_SECS));
-    let reqwest_client = ReqwestClient::new();
+    // The crate's shared client, not `ReqwestClient::new()`.
+    //
+    // `new()` builds a client with no request timeout and no connect
+    // timeout — reqwest's default is to wait forever — so the broker
+    // GET below could park indefinitely against a broker that accepted
+    // the connection and then stopped serving. Nothing logged, nothing
+    // retried, and pods on this node simply stopped being marked dead:
+    // their broker rows stayed alive holding IPs that had already been
+    // recycled onto other workloads. `client.rs` has carried 30s
+    // request / 10s connect ceilings all along; this reads them from
+    // the same place instead of quietly opting out, and reuses its
+    // connection pool while it is there.
+    let reqwest_client = crate::client::http_client();
     let kube_client = Client::try_default().await?;
 
     loop {
         ticker.tick().await;
 
-        if let Err(e) = reconcile_pods(&node_name, &broker_url, &reqwest_client, &kube_client).await
+        if let Err(e) = reconcile_pods(&node_name, &broker_url, reqwest_client, &kube_client).await
         {
             error!("Pod reconciliation failed: {}", e);
         }
     }
 }
 
-async fn reconcile_pods(
-    node_name: &str,
-    broker_url: &str,
+/// Fetch this node's alive pod rows from the broker.
+///
+/// Split out so the timeout behaviour of the client is exercisable
+/// without a kube client or a live broker — this is the GET that used
+/// to hang forever.
+async fn fetch_db_pods(
     reqwest_client: &ReqwestClient,
-    kube_client: &Client,
-) -> Result<(), Error> {
-    // debug not info — this fires every RECONCILE_INTERVAL_SECS (60s)
-    // forever, which is 1440 daily per controller per node. The
-    // outcome of the reconcile pass is already logged conditionally
-    // below (info when pods were marked dead, debug for "no changes"),
-    // so the per-tick "starting" line is pure noise at INFO.
-    debug!(
-        "reconcile_pods: starting pod reconciliation for node: {}",
-        node_name
-    );
-
-    // Get list of pods from database for this node (only alive pods).
+    broker_url: &str,
+    node_name: &str,
+) -> Result<Vec<PodDetail>, Error> {
     // Trim trailing slashes from broker_url so a configured
     // API_ENDPOINT="http://broker:9090/" doesn't produce a doubled
     // slash in the URL — same robustness pattern applied to
@@ -118,10 +123,30 @@ async fn reconcile_pods(
         )));
     }
 
-    let db_pods: Vec<PodDetail> = response
+    response
         .json::<Vec<PodDetail>>()
         .await
-        .map_err(|e| Error::Custom(format!("Failed to parse broker response: {}", e)))?;
+        .map_err(|e| Error::Custom(format!("Failed to parse broker response: {}", e)))
+}
+
+async fn reconcile_pods(
+    node_name: &str,
+    broker_url: &str,
+    reqwest_client: &ReqwestClient,
+    kube_client: &Client,
+) -> Result<(), Error> {
+    // debug not info — this fires every RECONCILE_INTERVAL_SECS (60s)
+    // forever, which is 1440 daily per controller per node. The
+    // outcome of the reconcile pass is already logged conditionally
+    // below (info when pods were marked dead, debug for "no changes"),
+    // so the per-tick "starting" line is pure noise at INFO.
+    debug!(
+        "reconcile_pods: starting pod reconciliation for node: {}",
+        node_name
+    );
+
+    // Get list of pods from database for this node (only alive pods).
+    let db_pods = fetch_db_pods(reqwest_client, broker_url, node_name).await?;
 
     // Get list of currently running pods from Kubernetes API for this node
     let pods_api: Api<Pod> = Api::all(kube_client.clone());
@@ -200,6 +225,65 @@ async fn reconcile_pods(
 mod tests {
     use super::*;
     use chrono::NaiveDateTime;
+
+    /// A broker that accepts the connection and then never answers —
+    /// the shape a broker takes when it is wedged rather than down.
+    /// A closed port produces a fast, ordinary error; this does not.
+    fn hung_broker() -> (std::net::TcpListener, String) {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind loopback");
+        let addr = listener.local_addr().expect("local addr");
+        (listener, format!("http://{addr}"))
+    }
+
+    /// The defect, pinned, through the real production code path: with
+    /// the client `reconcile_pods_task` used to build, this GET never
+    /// returns. The reconciler is the only thing that marks pods dead,
+    /// so a wedged broker meant recycled pod IPs stayed attributed to
+    /// workloads that no longer existed — indefinitely, with nothing
+    /// logged.
+    #[tokio::test]
+    async fn the_old_reconciler_client_hangs_on_a_wedged_broker() {
+        let (_listener, url) = hung_broker();
+
+        let outcome = tokio::time::timeout(
+            std::time::Duration::from_millis(750),
+            fetch_db_pods(&ReqwestClient::new(), &url, "node-a"),
+        )
+        .await;
+
+        assert!(
+            outcome.is_err(),
+            "ReqwestClient::new() has no timeouts, so this GET is unbounded"
+        );
+    }
+
+    /// The fix: the same wedged broker, through the same code path,
+    /// with a client carrying `client.rs`'s ceilings. The pass fails,
+    /// is logged by the caller, and the next tick tries again.
+    #[tokio::test]
+    async fn the_reconciler_gives_up_on_a_wedged_broker_and_ticks_again() {
+        let (_listener, url) = hung_broker();
+        let bounded = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_millis(200))
+            .connect_timeout(std::time::Duration::from_millis(100))
+            .build()
+            .expect("build client");
+
+        let started = tokio::time::Instant::now();
+        let err = fetch_db_pods(&bounded, &url, "node-a")
+            .await
+            .expect_err("a wedged broker must surface as an error");
+
+        assert!(
+            err.to_string().contains("Failed to fetch pods from broker"),
+            "the operator must be told which step failed: {err}"
+        );
+        assert!(
+            started.elapsed() < std::time::Duration::from_secs(1),
+            "took {:?}",
+            started.elapsed()
+        );
+    }
 
     fn db_pod(namespace: Option<&str>, name: &str) -> PodDetail {
         PodDetail {

--- a/controller/src/pod_watcher.rs
+++ b/controller/src/pod_watcher.rs
@@ -1,6 +1,7 @@
 use crate::capture_tiers::CaptureLevel;
 use crate::models::{pod_flags, ContainerMap, PodRegistration};
 use crate::network::canonicalize_ip;
+use crate::supervisor::{Draining, Subsystem, Supervisor};
 use crate::watch_loop::run_watch;
 use crate::{api_post_call, Error, PodDetail, PodInfo, PodInspect};
 use chrono::Utc;
@@ -20,15 +21,26 @@ use std::time::Duration;
 use tracing::{debug, error, info, warn};
 
 use tokio::sync::mpsc;
+
+/// Watch this node's pods and keep the netns-inode → pod map current.
+///
+/// Takes `excluded_namespaces` **by value**. It used to be a
+/// `&[String]` borrowed from `main`'s stack, which made the returned
+/// future non-`'static` and therefore impossible to `tokio::spawn` —
+/// which is why every subsystem ended up fused into one task by
+/// `try_join!` in the first place (#1346). An `Arc<[String]>` inside
+/// gives the two halves below a cheap shared handle without cloning
+/// the list per pod event.
 pub async fn watch_pods(
     node_name: String,
     tx: mpsc::Sender<PodRegistration>,
     container_map: ContainerMap,
-    excluded_namespaces: &[String],
+    excluded_namespaces: Vec<String>,
     sender_ip: mpsc::Sender<String>,
     ignore_daemonset_traffic: bool,
     cluster_capture_level: CaptureLevel,
 ) -> Result<(), Error> {
+    let excluded_namespaces: Arc<[String]> = excluded_namespaces.into();
     let c = Client::try_default().await?;
     let pods: Api<Pod> = Api::all(c.clone());
     #[cfg(not(debug_assertions))]
@@ -50,7 +62,7 @@ pub async fn watch_pods(
         node_name.clone(),
         tx.clone(),
         Arc::clone(&container_map),
-        excluded_namespaces.to_vec(),
+        Arc::clone(&excluded_namespaces),
         sender_ip.clone(),
         ignore_daemonset_traffic,
         c.clone(),
@@ -91,13 +103,14 @@ pub async fn watch_pods(
                 let t = tx.clone();
                 let sender_ip = sender_ip.clone();
                 let container_map = Arc::clone(&container_map);
+                let excluded_namespaces = Arc::clone(&excluded_namespaces);
                 let node_name = node_name.clone();
                 let c = c.clone();
                 async move {
                     if let Some(reg) = process_pod(
                         &p,
                         container_map,
-                        excluded_namespaces,
+                        &excluded_namespaces,
                         sender_ip,
                         ignore_daemonset_traffic,
                         &node_name,
@@ -129,16 +142,32 @@ pub async fn watch_pods(
         )
         .await;
         // Unreachable: `run_watch` loops forever. Present only to give
-        // this block the Result type `try_join!` needs.
+        // this block the `Result` the supervisor expects.
         Ok::<(), Error>(())
     };
 
-    // Run both concurrently, for the life of the process. Neither half
-    // returns any more: the watch is supervised in-band, and the resync
-    // loop already treats a failed LIST as a tick to skip. Cancellation
-    // on SIGTERM comes from main's shutdown select!, not from here.
-    tokio::try_join!(watch, resync)?;
-    Ok(())
+    // Two halves, two tasks, supervised.
+    //
+    // They used to be `try_join!`ed here, which put both on the task
+    // that ran them — so a containerd RPC stalling inside the watch's
+    // `process_pod` also stalled the resync loop. That is precisely
+    // backwards: the resync exists BECAUSE the streaming watch is not
+    // reliable (a `spec.nodeName` field-selector watch drops the
+    // unscheduled→scheduled transition), so the safety net must not
+    // share a fate with the thing it is a net for.
+    //
+    // Either half stopping is still fatal, exactly as `try_join!`
+    // made it — but now a clean `Ok` return is caught too, not just
+    // an `Err`. Both are infinite by construction, so either one
+    // returning means pod ingestion has silently stopped.
+    let mut subsystems = Supervisor::new();
+    subsystems.spawn(Subsystem::PodWatchStream, watch);
+    subsystems.spawn(Subsystem::PodResync, resync);
+    let fault = subsystems.watch().await;
+    // Logs any fault the other half had already queued, so a stall in
+    // one is not reported without the error that caused it.
+    let _ = subsystems.shutdown(Draining::AfterFault).await;
+    Err(fault.into())
 }
 
 /// Periodic re-list of this node's pods, registering any the streaming
@@ -151,7 +180,7 @@ async fn resync_pods(
     node_name: String,
     tx: mpsc::Sender<PodRegistration>,
     container_map: ContainerMap,
-    excluded_namespaces: Vec<String>,
+    excluded_namespaces: Arc<[String]>,
     sender_ip: mpsc::Sender<String>,
     ignore_daemonset_traffic: bool,
     client: Client,

--- a/controller/src/seccomp_distributor.rs
+++ b/controller/src/seccomp_distributor.rs
@@ -171,13 +171,17 @@ pub async fn run() -> Result<(), Error> {
         tokio::select! {
             ev = stream.next() => match ev {
                 // The backoff watcher is meant to be endless, but if it
-                // does end we must NOT return: try_join! would never
-                // notice, and CR reconciliation would be silently dead
-                // until the pod restarted for some other reason. And we
-                // must not Err either — a distributor failure never
-                // interrupts tracing. So: back off, rebuild the reflector
-                // + watcher, carry on. The ticker keeps firing meanwhile
-                // (against the last known store contents).
+                // does end we must NOT return. This subsystem is
+                // supervised as `MayRetire` — it is allowed to return
+                // `Ok(())`, because it does exactly that when
+                // SECCOMP_DISTRIBUTE is unset — so a return here is
+                // taken as a deliberate retirement and CR reconciliation
+                // would be silently dead until the pod restarted for
+                // some other reason. And we must not Err either — a
+                // distributor failure never interrupts tracing. So: back
+                // off, rebuild the reflector + watcher, carry on. The
+                // ticker keeps firing meanwhile (against the last known
+                // store contents).
                 None => {
                     let delay = rebuild_delay(stream_ends);
                     stream_ends = stream_ends.saturating_add(1);

--- a/controller/src/service_watcher.rs
+++ b/controller/src/service_watcher.rs
@@ -60,8 +60,9 @@ pub async fn watch_service() -> Result<(), Error> {
     )
     .await;
 
-    // Unreachable: `run_watch` loops forever. main's try_join! keeps
-    // holding this future until the shutdown select! cancels it.
+    // Unreachable: `run_watch` loops forever. The supervisor holds
+    // this task until shutdown cancels it; if this line is ever
+    // reached, that is a fault and it is reported as one.
     Ok(())
 }
 

--- a/controller/src/supervisor.rs
+++ b/controller/src/supervisor.rs
@@ -1,0 +1,978 @@
+//! Independent supervision for the Controller's long-lived subsystems.
+//!
+//! ## The arrangement this replaces
+//!
+//! `main` used to compose all nine subsystems with `tokio::try_join!`.
+//! That is nine *futures* but only one *task*, and the task — not the
+//! future — is what Tokio schedules. A task is polled by at most one
+//! worker at a time and cannot be stolen mid-poll, so the nine shared
+//! a single thread's worth of forward progress and a single fate. Two
+//! consequences were measured on the 14-worker runtime this DaemonSet
+//! actually runs:
+//!
+//! * **A blocking call anywhere froze everything.** A heartbeat placed
+//!   *inside* the join stopped ticking permanently the moment any
+//!   joined future blocked its worker, while a heartbeat in a
+//!   separately spawned task on the same runtime kept ticking. Thirteen
+//!   idle workers could not help: work stealing operates on tasks, and
+//!   there was only one.
+//! * **They shared one cooperative budget.** Tokio yields a task after
+//!   128 ready operations. Every mpsc `recv`, every timer, every IO op
+//!   across all nine subsystems decremented the same counter, so all
+//!   nine were forced to yield together, constantly. That is what made
+//!   the `ContainerMap` lock window in #1343 a permanent hazard rather
+//!   than a rare one — the yield points were everywhere, all the time.
+//!
+//! One `tokio::spawn` per subsystem fixes both: nine tasks, nine
+//! budgets, nine independently stealable units of work. There was no
+//! `tokio::spawn` anywhere in this crate before (only the
+//! `spawn_blocking` in `bpf.rs`), which is why neither property held.
+//!
+//! ## Why "the subsystem returned `Ok`" is a fault
+//!
+//! `try_join!` short-circuits on `Err` and only on `Err`. Three of the
+//! event consumers return `Ok(())` when their channel closes —
+//! `syscall::handle_syscall_events`, `network::handle_network_events`
+//! and `network::handle_policy_drop_events`. A consumer that retires
+//! *cleanly* did not resolve the join: `try_join!` went on waiting for
+//! the other eight. So this is not a hazard being prevented, it is one
+//! being narrowed — today's controller can already be alive, healthy
+//! from the outside, and partially blind, with no non-zero exit and no
+//! restart. Nothing in the old arrangement could tell "still working"
+//! from "finished, quietly, hours ago".
+//!
+//! So supervision here is not "wait for an error". It is "these
+//! subsystems are supposed to run until the process dies, and any of
+//! them stopping — `Ok`, `Err` or panic — is a fault".
+//!
+//! That cannot be a blanket rule, and the exception is a real
+//! distinction rather than a special case: a subsystem whose *feature
+//! is switched off* has nothing to do and returning is correct, while
+//! a *capture subsystem that stopped* is a hole in this node's
+//! observations. [`Disposition`] makes each subsystem declare which it
+//! is at its spawn site. Only the seccomp distributor is the first
+//! kind, and it is not a corner case — `seccomp_distributor::run`
+//! returns `Ok(())` immediately whenever `SECCOMP_DISTRIBUTE` is
+//! unset, which is the **default** install. Alarming on that would cry
+//! wolf on every cluster that has not opted in.
+//!
+//! ## What isolation must not quietly undo
+//!
+//! PR #1473 kept the eBPF handle inside `try_join!` deliberately: a
+//! Controller whose eBPF loader has died is not degraded, it is blind,
+//! and a blind Controller that stays up turns kguardian's core
+//! guarantee (observed-absence means safe-to-deny) into a lie that
+//! nothing marks. There is no readiness endpoint on this DaemonSet, so
+//! a non-zero exit is the only signal that reaches an operator.
+//!
+//! The same argument covers a second signal that is easy to lose here.
+//! `watch_service`, `watch_pods` and `reconcile_pods_task` each build a
+//! kube client before their infinite loop, and each can `?` out of it
+//! when the apiserver is unreachable at boot. Today that exits non-zero
+//! and the kubelet backs off — and this DaemonSet has no liveness,
+//! readiness or startup probe at all, so that CrashLoopBackOff is the
+//! only thing an operator sees. Per-task supervision must not turn it
+//! into an invisible in-process retry. That is why there is no
+//! "degraded, keep running" disposition: [`Disposition::Required`]
+//! preserves exactly the old fatality, the first subsystem to stop for
+//! any reason ends the process non-zero. What changes is that a stall
+//! no longer propagates, and that a clean stop is now caught too.
+
+use std::collections::HashMap;
+use std::fmt;
+use std::future::Future;
+use std::time::Duration;
+
+use tokio::task::{Id, JoinSet};
+use tracing::{debug, error, info, warn};
+
+use crate::error::Error;
+
+/// How long `shutdown` waits for aborted subsystems to actually stop
+/// before giving up and letting the process exit anyway.
+///
+/// Abort takes effect at a task's next await point, which for every
+/// subsystem here is microseconds away. The bound exists for the case
+/// that is not true — a task wedged inside a blocking call cannot be
+/// aborted at all, and SIGTERM must not turn into "hang until the
+/// kubelet sends SIGKILL" because of one of them.
+const SHUTDOWN_GRACE: Duration = Duration::from_secs(5);
+
+/// What a subsystem stopping means for the process.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Disposition {
+    /// The subsystem is meant to run for the life of the process. Any
+    /// exit — `Ok(())` included — is a fault that ends the Controller
+    /// non-zero.
+    ///
+    /// `Ok(())` is deliberately in that list. See the module docs: the
+    /// three channel consumers return `Ok` on channel close, and under
+    /// `try_join!` that produced a healthy-looking process with no
+    /// ingestion.
+    Required,
+    /// The subsystem may legitimately return `Ok(())` and stop —
+    /// its feature is switched off, or it has nothing to do on this
+    /// node. `Err` and panics are still faults.
+    ///
+    /// Only the seccomp distributor is declared this way:
+    /// `seccomp_distributor::run` returns `Ok(())` immediately unless
+    /// `SECCOMP_DISTRIBUTE=true`, and has always been best-effort.
+    MayRetire,
+}
+
+/// Declare the subsystem roster exactly once.
+///
+/// The enum, [`Subsystem::ALL`], [`Subsystem::name`] and
+/// [`Subsystem::disposition`] are all generated from the single list in
+/// the invocation below, because two hand-maintained lists drift. They
+/// did: a variant added to the enum and declared `MayRetire` but left
+/// out of a hand-written `ALL` passed clippy and all 203 tests, because
+/// `only_the_seccomp_distributor_may_retire` sweeps `ALL` and cannot
+/// see a variant that never reached it.
+///
+/// A test cannot close that, which is why this is a macro and not
+/// another assertion. Any such test needs its own list of variants to
+/// iterate, and that list drifts identically one level up; the
+/// successor-chain and index-map shapes both let an author satisfy the
+/// compiler's exhaustiveness check without ever linking the new variant
+/// in. Rust has no stable way to enumerate an enum's variants, so the
+/// only airtight fix is to stop having two lists.
+macro_rules! subsystems {
+    (
+        $(
+            $(#[$variant_doc:meta])*
+            $variant:ident => $name:literal, $disposition:expr;
+        )*
+    ) => {
+        /// Every supervised subsystem, and — via
+        /// [`Subsystem::disposition`] — what its stopping means.
+        ///
+        /// A closed enum rather than a `(name, Disposition)` pair
+        /// passed at each spawn site, because those literals were the
+        /// part of this design with no defence at all. Mutation testing
+        /// found it: flipping one word — `network-events` from
+        /// `Required` to `MayRetire` — turns "this node has gone blind,
+        /// exit non-zero" into "retired cleanly, the rest of the
+        /// Controller continues", and the whole suite stayed green.
+        ///
+        /// That mutation is *reachable*, not theoretical. The eBPF
+        /// loader drops the three event senders on its way out of
+        /// `spawn_blocking`, so `handle_network_events` returns
+        /// `Ok(())` immediately afterwards. One word would therefore
+        /// have restored the exact hazard PR #1473 closed: a live,
+        /// healthy-looking, permanently blind Controller.
+        ///
+        /// Making the disposition a property of the subsystem rather
+        /// than an argument means it cannot be overridden where the
+        /// future is spawned.
+        #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+        pub enum Subsystem {
+            $(
+                $(#[$variant_doc])*
+                $variant,
+            )*
+        }
+
+        impl Subsystem {
+            /// Every subsystem, generated from the roster so it cannot
+            /// drift from the enum. The disposition sweeps in the tests
+            /// below are only ever as complete as this is.
+            pub const ALL: &'static [Subsystem] = &[$(Subsystem::$variant),*];
+
+            /// The name that appears in logs and in a [`Fault`].
+            pub fn name(self) -> &'static str {
+                match self {
+                    $(Subsystem::$variant => $name,)*
+                }
+            }
+
+            /// What this subsystem stopping means for the process.
+            ///
+            /// Generated from the roster, so adding a subsystem forces
+            /// a deliberate answer to "and if this one stops?" at the
+            /// point of declaration. There is nowhere for a new one to
+            /// inherit a default from.
+            pub fn disposition(self) -> Disposition {
+                match self {
+                    $(Subsystem::$variant => $disposition,)*
+                }
+            }
+        }
+    };
+}
+
+// The roster: one line per subsystem — variant, log name, and what its
+// stopping means.
+//
+// Almost every entry is `Required`. These are capture, ingestion, and
+// the correlation data that capture depends on; each runs until the
+// process does, so any of them stopping is a hole in what this node
+// observed, and observed-absence is what kguardian turns into "safe to
+// deny".
+//
+// `SeccompDistributor` is the one exception, and it is not a corner
+// case: `seccomp_distributor::run` returns `Ok(())` immediately unless
+// SECCOMP_DISTRIBUTE=true, which is the default install, so alarming on
+// it would cry wolf on every cluster that has not opted in.
+subsystems! {
+    /// The pod watcher as `main` sees it; supervises the two below.
+    PodWatcher => "pod-watcher", Disposition::Required;
+    /// The streaming apiserver watch half of the pod watcher.
+    PodWatchStream => "pod-watch-stream", Disposition::Required;
+    /// The periodic re-list half — the safety net for the watch above.
+    PodResync => "pod-resync", Disposition::Required;
+    ServiceWatch => "service-watch", Disposition::Required;
+    NetworkEvents => "network-events", Disposition::Required;
+    SyscallEvents => "syscall-events", Disposition::Required;
+    NetpolicyDropEvents => "netpolicy-drop-events", Disposition::Required;
+    SyscallRecorder => "syscall-recorder", Disposition::Required;
+    PodReconciler => "pod-reconciler", Disposition::Required;
+    SeccompDistributor => "seccomp-distributor", Disposition::MayRetire;
+    EbpfLoader => "ebpf-loader", Disposition::Required;
+}
+
+/// Why the supervisor is draining, which decides how loud a fault
+/// recovered during the drain should be.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Draining {
+    /// The process is failing. Anything recovered here is part of the
+    /// incident and is logged at `error` — it is frequently the root
+    /// cause of whatever [`Supervisor::watch`] happened to report first.
+    AfterFault,
+    /// The process is stopping because it was asked to. A subsystem
+    /// reporting an error while being told to stop is expected here:
+    /// the eBPF poll loop returns `Err` *by design* once its shutdown
+    /// flag is raised, and there is a window between raising it and
+    /// aborting in which it does exactly that. Logging those at `error`
+    /// would put a false `subsystem 'ebpf-loader' failed` line in an
+    /// operator's logs on every single rolling restart.
+    Gracefully,
+}
+
+/// Why supervision ended. Every variant is a reason to stop the
+/// process; the distinction is what the operator gets told.
+#[derive(Debug)]
+pub enum Fault {
+    /// A [`Disposition::Required`] subsystem returned `Ok(())`. The
+    /// dangerous one: nothing else in the process notices, and it is
+    /// how "no ingestion" used to masquerade as "healthy".
+    Retired(&'static str),
+    /// A subsystem returned `Err`.
+    Failed(&'static str, Error),
+    /// A subsystem's task ended without producing a value: it panicked,
+    /// or it was aborted. Under `try_join!` a panic took the whole
+    /// process down by unwinding the one shared task; spawned tasks
+    /// capture the panic instead, so it has to be surfaced here or it
+    /// would be swallowed.
+    Crashed(&'static str, String),
+    /// Every supervised subsystem has stopped. Only reachable if all of
+    /// them were `MayRetire`, which is never true in `main`, but a
+    /// supervisor with nothing left to supervise must not park forever.
+    Exhausted,
+}
+
+impl Fault {
+    /// Which subsystem this fault is about.
+    pub fn subsystem(&self) -> &'static str {
+        match self {
+            Fault::Retired(name) | Fault::Failed(name, _) | Fault::Crashed(name, _) => name,
+            Fault::Exhausted => "<all>",
+        }
+    }
+}
+
+impl fmt::Display for Fault {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Fault::Retired(name) => write!(
+                f,
+                "subsystem '{name}' returned Ok and stopped. It is required to run for the \
+                 life of the process, so this node has stopped observing what it reports \
+                 on; exiting rather than staying up with a silent hole in the data"
+            ),
+            Fault::Failed(name, e) => {
+                write!(f, "subsystem '{name}' failed: {e}")
+            }
+            Fault::Crashed(name, detail) => {
+                write!(f, "subsystem '{name}' ended without a result: {detail}")
+            }
+            Fault::Exhausted => write!(
+                f,
+                "every supervised subsystem has stopped; nothing is observing this node"
+            ),
+        }
+    }
+}
+
+impl From<Fault> for Error {
+    fn from(fault: Fault) -> Self {
+        // Rendered rather than boxed: `main` returns this and the
+        // `Termination` impl prints it, and that printed line plus the
+        // non-zero exit code is the only channel an operator of this
+        // DaemonSet has.
+        Error::Custom(fault.to_string())
+    }
+}
+
+/// What was spawned under a given task id.
+struct Registered {
+    name: &'static str,
+    disposition: Disposition,
+}
+
+/// Runs each subsystem in its own task and reports the first fault.
+///
+/// The supervisor deliberately does **not** restart anything, and that
+/// is a hard constraint of this codebase rather than a preference.
+/// Three process-global pieces of state make in-process restart unsafe
+/// today:
+///
+/// * `bpf::EBPF_SHUTDOWN` is a latch with no production reset. It is
+///   tripped whenever a ring-buffer callback's `blocking_send` fails,
+///   i.e. whenever any of the three event Receivers is dropped. Restart
+///   a consumer task and the old receiver's drop latches it; every eBPF
+///   task started afterwards then returns `Err` on its first loop
+///   iteration. That is a hot restart loop, or permanent silent
+///   blindness, depending on what the supervisor does next.
+/// * `syscall`'s `SYSCALL_CACHE` and `LAST_SENT_CACHE` are
+///   `lazy_static` and outlive task death, and
+///   `send_syscall_cache_periodically` documents itself as their only
+///   writer. Two instances overlapping for even one tick — easy to
+///   write with a `JoinSet` that starts a replacement before the
+///   predecessor has *observably* terminated — race the diff and mark
+///   syscalls last-sent that were never posted, which is the shape of
+///   the bug that comment records fixing.
+/// * The eBPF loader is a `spawn_blocking` that owns the
+///   `PodRegistration` and ignore-IP Receivers, whose senders live in
+///   `watch_pods`. `JoinSet::abort` has no effect on a blocking task,
+///   so those channels cannot be re-wired for a restarted watcher.
+///
+/// Beyond those, every subsystem owns kernel or cluster state that a
+/// restart cannot rebuild in place (eBPF maps and their inode
+/// registrations, the watch resource version, the syscall diff cache),
+/// so "restart the subsystem" and "restart the pod" are the same
+/// operation with the second one being the honest, visible version of
+/// it. Reporting a fault and exiting is therefore the whole policy.
+pub struct Supervisor {
+    set: JoinSet<Result<(), Error>>,
+    registry: HashMap<Id, Registered>,
+}
+
+impl Default for Supervisor {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Supervisor {
+    pub fn new() -> Self {
+        Self {
+            set: JoinSet::new(),
+            registry: HashMap::new(),
+        }
+    }
+
+    /// Spawn `future` as the given subsystem's own task.
+    ///
+    /// Its own task is the entire point — see the module docs. Anything
+    /// composed into one task with `join!`/`try_join!` shares a worker
+    /// and a cooperative budget with its siblings and is not isolated
+    /// from them at all.
+    ///
+    /// Takes a [`Subsystem`], not a name and a disposition, so the
+    /// call site cannot decide that a capture subsystem is allowed to
+    /// retire. See `Subsystem` for the mutation that motivated it.
+    pub fn spawn<F>(&mut self, subsystem: Subsystem, future: F)
+    where
+        F: Future<Output = Result<(), Error>> + Send + 'static,
+    {
+        self.spawn_raw(subsystem.name(), subsystem.disposition(), future)
+    }
+
+    /// `spawn` with the name and disposition supplied directly.
+    ///
+    /// Private, and that is the whole protection: `main` and
+    /// `pod_watcher` live in other modules, so the only way they can
+    /// start a subsystem is `spawn` above, which carries the
+    /// disposition table with it. The tests need to conjure subsystems
+    /// that are not in the roster ("blocker", "heartbeat"), which is
+    /// the only reason this exists.
+    fn spawn_raw<F>(&mut self, name: &'static str, disposition: Disposition, future: F)
+    where
+        F: Future<Output = Result<(), Error>> + Send + 'static,
+    {
+        let handle = self.set.spawn(future);
+        self.registry
+            .insert(handle.id(), Registered { name, disposition });
+        info!(subsystem = name, ?disposition, "subsystem started");
+    }
+
+    /// Number of subsystems still running.
+    pub fn len(&self) -> usize {
+        self.set.len()
+    }
+
+    /// True once nothing is left to supervise.
+    pub fn is_empty(&self) -> bool {
+        self.set.is_empty()
+    }
+
+    /// Resolve with the first fault.
+    ///
+    /// A `MayRetire` subsystem returning `Ok(())` is logged and skipped;
+    /// everything else resolves. Cancel-safe: `join_next_with_id` is,
+    /// and the registry is only ever read here, so `main` can hold this
+    /// in a `select!` against SIGTERM without losing a task.
+    pub async fn watch(&mut self) -> Fault {
+        loop {
+            let Some(joined) = self.set.join_next_with_id().await else {
+                return Fault::Exhausted;
+            };
+
+            match joined {
+                Ok((id, Ok(()))) => {
+                    let (name, disposition) = self.identify(id);
+                    match disposition {
+                        Disposition::MayRetire => {
+                            info!(
+                                subsystem = name,
+                                "subsystem retired cleanly (declared optional); the rest \
+                                 of the Controller continues"
+                            );
+                            continue;
+                        }
+                        // The hole `try_join!` left open. Not an error
+                        // anywhere in the code, and that is exactly why
+                        // it went unnoticed: the subsystem "succeeded".
+                        Disposition::Required => return Fault::Retired(name),
+                    }
+                }
+                Ok((id, Err(e))) => {
+                    let (name, _) = self.identify(id);
+                    return Fault::Failed(name, e);
+                }
+                Err(join_error) => {
+                    let (name, _) = self.identify(join_error.id());
+                    return Fault::Crashed(name, join_error.to_string());
+                }
+            }
+        }
+    }
+
+    /// Abort every subsystem, wait briefly for them to stop, and
+    /// return any hard faults that had already happened.
+    ///
+    /// The return value is not bookkeeping — it is how the root cause
+    /// survives a race. When the eBPF loader dies, its `Err` and the
+    /// consumers' "channel closed, so return `Ok`" become ready at
+    /// almost the same instant: the loader's blocking closure drops the
+    /// senders on its way out, which wakes the consumers, and only then
+    /// does its `JoinHandle` resolve. Whichever [`watch`](Self::watch)
+    /// happens to see first is what `main` reports, so without this the
+    /// operator could get "subsystem 'network-events' returned Ok" and
+    /// never see the loader's error at all. That would make an eBPF
+    /// death *quieter* than it was under `try_join!`, which is the one
+    /// thing this change must not do. Aborting does not discard results
+    /// that are already queued, so draining recovers them.
+    ///
+    /// Bounded on purpose: see [`SHUTDOWN_GRACE`].
+    pub async fn shutdown(&mut self, draining: Draining) -> Vec<Fault> {
+        self.set.abort_all();
+
+        // Collected rather than resolved in place: the drain holds a
+        // mutable borrow of the JoinSet, and naming a subsystem needs
+        // the registry.
+        let mut raw: Vec<(Id, Result<Error, String>)> = Vec::new();
+        let set = &mut self.set;
+        let sink = &mut raw;
+        let drain = async {
+            while let Some(joined) = set.join_next_with_id().await {
+                match joined {
+                    Ok((_, Ok(()))) => {}
+                    Ok((id, Err(e))) => sink.push((id, Ok(e))),
+                    // A task we just aborted is not a fault; anything
+                    // else that ended without a value is.
+                    Err(je) if je.is_cancelled() => {}
+                    Err(je) => sink.push((je.id(), Err(je.to_string()))),
+                }
+            }
+        };
+
+        let stopped = tokio::time::timeout(SHUTDOWN_GRACE, drain).await.is_ok();
+        if stopped {
+            info!("all subsystems stopped");
+        } else {
+            // Only reachable if a task is wedged somewhere it cannot be
+            // cancelled — i.e. a blocking call on a worker thread. Say
+            // so; that is a bug worth a line in the logs of a pod that
+            // is on its way out anyway.
+            warn!(
+                grace_secs = SHUTDOWN_GRACE.as_secs(),
+                still_running = self.set.len(),
+                "some subsystems did not stop within the shutdown grace period; \
+                 exiting anyway"
+            );
+        }
+
+        raw.into_iter()
+            .map(|(id, outcome)| {
+                let (name, _) = self.identify(id);
+                let fault = match outcome {
+                    Ok(e) => Fault::Failed(name, e),
+                    Err(detail) => Fault::Crashed(name, detail),
+                };
+                match draining {
+                    Draining::AfterFault => error!("{fault}"),
+                    // Expected, not alarming: see `Draining::Gracefully`.
+                    Draining::Gracefully => debug!("while stopping: {fault}"),
+                }
+                fault
+            })
+            .collect()
+    }
+
+    /// Map a task id back to what was spawned under it.
+    ///
+    /// The registry is populated at spawn time and never pruned, so a
+    /// miss is impossible; fall back to a placeholder rather than
+    /// panicking inside the code path whose whole job is reporting that
+    /// something went wrong.
+    fn identify(&self, id: Id) -> (&'static str, Disposition) {
+        match self.registry.get(&id) {
+            Some(r) => (r.name, r.disposition),
+            None => ("<unregistered>", Disposition::Required),
+        }
+    }
+}
+
+/// Stop the Controller: tell the eBPF poll loop to exit, then abort and
+/// drain everything else.
+///
+/// The order is the entire function, which is why it is a function and
+/// not two lines in `main`. The poll loop lives in a `spawn_blocking`
+/// that nothing can cancel — `JoinSet::abort_all` reaches the async
+/// task awaiting its `JoinHandle`, not the blocking task — and dropping
+/// the runtime afterwards waits for it with no timeout (tokio 1.53.1:
+/// `BlockingPool::drop` → `shutdown(None)` → `shutdown_rx.wait(None)`).
+/// Raising the flag first is therefore the only thing that lets this
+/// process exit at all, and doing it second would not help: by then
+/// nothing is left to notice.
+///
+/// Before this was reachable from outside `bpf`, the flag went up only
+/// when a `blocking_send` failed against a dropped receiver — which
+/// needs an eBPF event to arrive. Under traffic that is instant; on an
+/// idle node no event fires and SIGTERM hung until the kubelet's
+/// SIGKILL.
+pub async fn shut_down(supervisor: &mut Supervisor, draining: Draining) -> Vec<Fault> {
+    crate::bpf::signal_ebpf_shutdown();
+    supervisor.shutdown(draining).await
+}
+
+/// Log a fault at the volume it deserves and convert it into the error
+/// `main` returns.
+///
+/// Split out from `main` so the mapping is testable: the property that
+/// matters is that *every* fault, including a clean `Ok` retirement,
+/// yields an `Err` — which is what makes the process exit non-zero and
+/// the kubelet restart the pod.
+pub fn report(fault: Fault) -> Error {
+    error!("{fault}");
+    Error::from(fault)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+    use std::sync::Arc;
+
+    /// How long the "blocking" subsystem hogs its worker, and how long
+    /// after starting it we look at the heartbeat. The gap matters:
+    /// the observation must land *while* the block is in progress,
+    /// because once it ends the pending timer fires immediately and a
+    /// frozen-then-thawed heartbeat looks identical to one that never
+    /// froze.
+    const BLOCK_FOR: Duration = Duration::from_millis(600);
+    const OBSERVE_AT: Duration = Duration::from_millis(250);
+    const HEARTBEAT_EVERY: Duration = Duration::from_millis(10);
+
+    /// A subsystem that does nothing but prove it is being polled.
+    async fn ticker(counter: Arc<AtomicU64>) -> Result<(), Error> {
+        loop {
+            tokio::time::sleep(HEARTBEAT_EVERY).await;
+            counter.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    /// A subsystem that makes the mistake this whole change exists to
+    /// contain: real blocking work on a runtime worker. `container.rs`
+    /// had the async equivalent — an unbounded await on a hung peer —
+    /// which wedges the task just as thoroughly.
+    async fn blocker(entered: Arc<AtomicBool>) -> Result<(), Error> {
+        entered.store(true, Ordering::Relaxed);
+        std::thread::sleep(BLOCK_FOR);
+        std::future::pending::<Result<(), Error>>().await
+    }
+
+    /// The defect, pinned, in the exact shape `main` had it. Kept next
+    /// to the fix so the fix cannot quietly become a tautology: if
+    /// someone recomposes the subsystems into one task, this test still
+    /// passes and the next one fails, which is the right way round.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn try_join_lets_one_blocking_subsystem_freeze_every_sibling() {
+        let ticks = Arc::new(AtomicU64::new(0));
+        let entered = Arc::new(AtomicBool::new(false));
+
+        // ONE task holding both futures — what `try_join!` builds.
+        let joined = tokio::spawn({
+            let ticks = Arc::clone(&ticks);
+            let entered = Arc::clone(&entered);
+            async move {
+                // Heartbeat first so it is polled first and has its
+                // timer armed before the sibling seizes the worker.
+                let _ = tokio::try_join!(ticker(ticks), blocker(entered));
+            }
+        });
+
+        tokio::time::sleep(OBSERVE_AT).await;
+
+        assert!(
+            entered.load(Ordering::Relaxed),
+            "the blocking subsystem must actually have started, or this test proves nothing"
+        );
+        assert_eq!(
+            ticks.load(Ordering::Relaxed),
+            0,
+            "a sibling in the same task cannot be polled while another future blocks the \
+             worker, no matter how many workers are idle — this is #1346"
+        );
+
+        joined.abort();
+    }
+
+    /// The fix, proven: same blocking subsystem, same runtime, same
+    /// wall-clock window — and the sibling keeps running.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn a_blocking_subsystem_does_not_freeze_its_siblings() {
+        let ticks = Arc::new(AtomicU64::new(0));
+        let entered = Arc::new(AtomicBool::new(false));
+
+        let mut sup = Supervisor::new();
+        sup.spawn_raw(
+            "heartbeat",
+            Disposition::Required,
+            ticker(Arc::clone(&ticks)),
+        );
+        sup.spawn_raw(
+            "blocker",
+            Disposition::Required,
+            blocker(Arc::clone(&entered)),
+        );
+
+        tokio::time::sleep(OBSERVE_AT).await;
+
+        assert!(
+            entered.load(Ordering::Relaxed),
+            "the blocking subsystem must actually have started"
+        );
+        let ticked = ticks.load(Ordering::Relaxed);
+        assert!(
+            ticked > 0,
+            "a blocking subsystem must not stop its siblings once each has its own task; \
+             heartbeat ticked {ticked} times in {OBSERVE_AT:?}"
+        );
+
+        sup.shutdown(Draining::AfterFault).await;
+    }
+
+    /// The other half of #1346: a required subsystem that returns
+    /// `Ok(())` — the channel-close path in `handle_syscall_events`,
+    /// `handle_network_events` and `handle_policy_drop_events` — must
+    /// be reported. (Named, not cited by line: the line numbers in the
+    /// issue had already rotted by the time this was written.)
+    #[tokio::test]
+    async fn a_required_subsystem_returning_ok_is_a_fault() {
+        let mut sup = Supervisor::new();
+        sup.spawn_raw("network-events", Disposition::Required, async {
+            // Exactly what those consumers do when their channel closes.
+            Ok(())
+        });
+        sup.spawn_raw("ebpf", Disposition::Required, async {
+            std::future::pending().await
+        });
+
+        match sup.watch().await {
+            Fault::Retired("network-events") => {}
+            other => panic!("expected a Retired fault naming the subsystem, got {other:?}"),
+        }
+        sup.shutdown(Draining::AfterFault).await;
+    }
+
+    /// And the same clean `Ok` under `try_join!`: nothing happens at
+    /// all. This is the pre-fix behaviour, pinned — a process that
+    /// looks perfectly healthy and ingests nothing.
+    #[tokio::test]
+    async fn try_join_never_notices_a_subsystem_that_retires_cleanly() {
+        let joined = async {
+            tokio::try_join!(async { Ok::<(), Error>(()) }, async {
+                std::future::pending::<Result<(), Error>>().await
+            },)
+        };
+        let mut joined = std::pin::pin!(joined);
+
+        assert!(
+            futures::poll!(joined.as_mut()).is_pending(),
+            "try_join! short-circuits only on Err: a capture subsystem that returns Ok and \
+             stops leaves the join parked forever with no signal to anyone"
+        );
+    }
+
+    /// A subsystem that is allowed to retire (the seccomp distributor
+    /// with `SECCOMP_DISTRIBUTE` unset) must not take the process down,
+    /// and must not stop the supervisor watching the others.
+    #[tokio::test]
+    async fn an_optional_subsystem_may_retire_without_faulting() {
+        let mut sup = Supervisor::new();
+        sup.spawn_raw("seccomp-distributor", Disposition::MayRetire, async {
+            Ok(())
+        });
+        sup.spawn_raw("ebpf", Disposition::Required, async {
+            tokio::time::sleep(Duration::from_millis(50)).await;
+            Err(Error::Custom("loader died".into()))
+        });
+
+        match sup.watch().await {
+            Fault::Failed("ebpf", _) => {}
+            other => panic!("the optional retirement should have been skipped, got {other:?}"),
+        }
+    }
+
+    /// eBPF loader death stays fatal. PR #1473's guarantee, restated as
+    /// a test: the loader stopping must produce an `Err` out of `main`,
+    /// which is the non-zero exit and the pod restart. "Isolated" must
+    /// never mean "survivable".
+    #[tokio::test]
+    async fn ebpf_death_still_ends_the_process() {
+        for fault in [
+            Fault::Failed("ebpf", Error::Custom("ring buffer poll failed".into())),
+            // Even a *clean* stop: a loader that returns Ok has still
+            // left this node blind.
+            Fault::Retired("ebpf"),
+            Fault::Crashed("ebpf", "task 7 panicked".into()),
+        ] {
+            let rendered = fault.to_string();
+            let err = report(fault);
+            assert!(
+                matches!(err, Error::Custom(_)),
+                "every fault must convert into an error main can return, so the process \
+                 exits non-zero: there is no readiness endpoint on this DaemonSet"
+            );
+            assert!(
+                err.to_string().contains("ebpf"),
+                "the operator must be told which subsystem died: {rendered}"
+            );
+        }
+    }
+
+    /// A panic in a spawned task is captured by the task, not by the
+    /// process. Under `try_join!` it unwound the shared task and took
+    /// the process with it; isolation must not turn that into silence.
+    #[tokio::test]
+    async fn a_panicking_subsystem_is_reported_rather_than_swallowed() {
+        let mut sup = Supervisor::new();
+        sup.spawn_raw("syscall-events", Disposition::Required, async {
+            panic!("inode map poisoned");
+        });
+
+        match sup.watch().await {
+            Fault::Crashed("syscall-events", detail) => {
+                assert!(detail.contains("panic"), "detail should say so: {detail}");
+            }
+            other => panic!("expected Crashed, got {other:?}"),
+        }
+    }
+
+    /// SIGTERM. `main` selects between `watch()` and the signal; this
+    /// pins both halves: the supervisor yields to the shutdown branch
+    /// even with every subsystem running, and `shutdown()` then really
+    /// stops them, promptly.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn shutdown_is_prompt_and_actually_stops_the_subsystems() {
+        let ticks = Arc::new(AtomicU64::new(0));
+        let mut sup = Supervisor::new();
+        for name in ["pod-watch", "service-watch", "network-events"] {
+            sup.spawn_raw(name, Disposition::Required, ticker(Arc::clone(&ticks)));
+        }
+
+        // Let them get going, so "stopped" is a real observation.
+        tokio::time::sleep(Duration::from_millis(60)).await;
+        assert!(ticks.load(Ordering::Relaxed) > 0, "subsystems must be live");
+
+        // `biased` polls the supervisor first, so the shutdown branch
+        // only wins if `watch()` genuinely yielded.
+        let winner = tokio::select! {
+            biased;
+            _ = sup.watch() => "fault",
+            _ = std::future::ready(()) => "sigterm",
+        };
+        assert_eq!(
+            winner, "sigterm",
+            "supervision must not starve main's shutdown branch"
+        );
+
+        let started = tokio::time::Instant::now();
+        assert!(
+            sup.shutdown(Draining::AfterFault).await.is_empty(),
+            "cancelling a healthy subsystem is not a fault and must not be reported as one"
+        );
+        assert!(
+            started.elapsed() < Duration::from_millis(500),
+            "SIGTERM must not wait on the grace period when nothing is wedged; took {:?}",
+            started.elapsed()
+        );
+
+        let after = ticks.load(Ordering::Relaxed);
+        tokio::time::sleep(Duration::from_millis(80)).await;
+        assert_eq!(
+            ticks.load(Ordering::Relaxed),
+            after,
+            "a shut-down subsystem must stop doing work, not merely stop being awaited"
+        );
+    }
+
+    /// The race that could have made an eBPF death quieter than
+    /// `try_join!` made it.
+    ///
+    /// The loader's `Err` and a consumer's channel-close `Ok` become
+    /// ready together — the loader drops the event senders on its way
+    /// out, which is exactly what closes the consumers' channels. If
+    /// the consumer wins, `watch` reports "network-events returned Ok"
+    /// and the loader's error would never be printed at all. The drain
+    /// in `shutdown` is what makes sure it is.
+    #[tokio::test]
+    async fn the_ebpf_failure_is_surfaced_even_when_a_consumer_is_reported_first() {
+        let mut sup = Supervisor::new();
+        sup.spawn_raw("network-events", Disposition::Required, async { Ok(()) });
+        sup.spawn_raw("ebpf-loader", Disposition::Required, async {
+            Err(Error::Custom(
+                "ring buffer poll failed 50 times consecutively".into(),
+            ))
+        });
+
+        // Let both finish, so both outcomes are queued and the order
+        // `watch` sees them in is genuinely arbitrary.
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        let reported = sup.watch().await;
+        let also = sup.shutdown(Draining::AfterFault).await;
+
+        let named: Vec<&'static str> = std::iter::once(reported.subsystem())
+            .chain(also.iter().map(Fault::subsystem))
+            .collect();
+        assert!(
+            named.contains(&"ebpf-loader"),
+            "the loader's death must reach the operator whichever subsystem was reported \
+             first; got {named:?}"
+        );
+    }
+
+    /// `SHUTDOWN_GRACE` is a ceiling on how long SIGTERM can take, and
+    /// it has to sit inside the kubelet's termination window — this
+    /// DaemonSet sets no `terminationGracePeriodSeconds`, so that
+    /// window is the 30s default. A grace at or past 30s is not a grace
+    /// period, it is "wait for SIGKILL", which is exactly the behaviour
+    /// the idle-node shutdown fix exists to remove.
+    ///
+    /// Guarded because the value is asserted nowhere else: mutation
+    /// testing set it to an hour with the whole suite green.
+    #[test]
+    fn the_shutdown_grace_stays_inside_the_kubelet_termination_window() {
+        assert!(
+            SHUTDOWN_GRACE < Duration::from_secs(30),
+            "a {SHUTDOWN_GRACE:?} grace exceeds the kubelet's default 30s window, so \
+             shutdown would end in SIGKILL rather than in this code"
+        );
+    }
+
+    // ---- the disposition table ----
+    //
+    // These exist because mutation testing found the table's spawn
+    // sites completely unprotected: flipping `network-events` to
+    // `MayRetire` left every other test in this crate green while
+    // turning "this node is blind, exit" into "retired cleanly, carry
+    // on". The disposition now lives on `Subsystem` rather than at the
+    // call site, and these pin the table it reads.
+
+    #[test]
+    fn every_capture_subsystem_is_required() {
+        for subsystem in [
+            Subsystem::EbpfLoader,
+            Subsystem::NetworkEvents,
+            Subsystem::SyscallEvents,
+            Subsystem::NetpolicyDropEvents,
+            Subsystem::SyscallRecorder,
+            Subsystem::PodWatcher,
+            Subsystem::PodWatchStream,
+            Subsystem::PodResync,
+            Subsystem::ServiceWatch,
+            Subsystem::PodReconciler,
+        ] {
+            assert_eq!(
+                subsystem.disposition(),
+                Disposition::Required,
+                "'{}' stopping means this node stops observing something, so it must end \
+                 the process. Logging 'retired cleanly' and carrying on is the hazard PR \
+                 #1473 closed.",
+                subsystem.name()
+            );
+        }
+    }
+
+    /// The non-tautological half: sweep the whole roster, so a variant
+    /// flipped to `MayRetire` — or a newly added subsystem declared
+    /// that way — fails here rather than shipping.
+    #[test]
+    fn only_the_seccomp_distributor_may_retire() {
+        let retiring: Vec<&'static str> = Subsystem::ALL
+            .iter()
+            .copied()
+            .filter(|s| s.disposition() == Disposition::MayRetire)
+            .map(Subsystem::name)
+            .collect();
+        assert_eq!(
+            retiring,
+            vec!["seccomp-distributor"],
+            "exactly one subsystem is a feature that can be switched off; everything else \
+             is capture and must be Required"
+        );
+    }
+
+    /// Names reach logs and faults, and `main`'s roster is read by
+    /// humans during an incident. Two subsystems sharing one would make
+    /// a fault report ambiguous about which thing actually died.
+    #[test]
+    fn subsystem_names_are_unique() {
+        let mut names: Vec<&'static str> = Subsystem::ALL
+            .iter()
+            .copied()
+            .map(Subsystem::name)
+            .collect();
+        let total = names.len();
+        names.sort_unstable();
+        names.dedup();
+        assert_eq!(names.len(), total, "duplicate subsystem name in the roster");
+    }
+
+    /// A supervisor with nothing left to supervise must resolve rather
+    /// than park: `JoinSet::join_next` yields `None` on an empty set,
+    /// and parking on that would be the same silent-healthy-process
+    /// failure in a different disguise.
+    #[tokio::test]
+    async fn an_empty_supervisor_faults_rather_than_parking() {
+        let mut sup = Supervisor::new();
+        sup.spawn_raw("seccomp-distributor", Disposition::MayRetire, async {
+            Ok(())
+        });
+        assert!(matches!(sup.watch().await, Fault::Exhausted));
+    }
+}

--- a/controller/src/watch_loop.rs
+++ b/controller/src/watch_loop.rs
@@ -53,7 +53,9 @@
 //! * A watch that stays broken escalates from `warn` to `error`, so a
 //!   permanently-wedged watcher cannot masquerade as a healthy one.
 //! * The loop is infinite by construction and holds no blocking work,
-//!   so main's shutdown `select!` can still cancel it on SIGTERM.
+//!   so the supervisor can still cancel its task promptly on SIGTERM.
+//!   Being infinite is also why a watch returning at all is treated as
+//!   a fault now — see `supervisor`.
 
 use futures::{Stream, StreamExt};
 use std::{
@@ -125,10 +127,11 @@ fn rebuild_delay(consecutive_ends: u32) -> Duration {
 
 /// Drive a watch stream for the lifetime of the process.
 ///
-/// **Never returns.** The only ways out are main's shutdown `select!`
-/// cancelling the future, or the process exiting. Callers that need a
-/// `Result` (to sit in a `try_join!`) should wrap the call in an async
-/// block that appends `Ok(())` after it.
+/// **Never returns.** The only ways out are the supervisor cancelling
+/// the task on shutdown, or the process exiting. Callers that need a
+/// `Result` (every supervised subsystem does) should wrap the call in an
+/// async block that appends `Ok(())` after it — unreachable, but it
+/// gives the block the right type.
 ///
 /// `make_stream` is called once up front and again whenever the stream
 /// ends, so it must rebuild from cloned handles rather than move them.
@@ -215,13 +218,14 @@ pub(crate) async fn run_watch<T, E, S, MkStream, F, Fut>(
         // cannot happen — its `ExponentialBackoff` is built
         // `.without_max_times()`, so `next()` never yields `None` and
         // `StreamBackoff` never reaches its `GivenUp` state — but a
-        // kube upgrade could change that, and the failure would be
-        // invisible. Do not return: main's `try_join!` would sit
-        // forever on a watch that is silently dead. Do not error out
-        // either: that restarts the pod and destroys exactly the kernel
-        // state this module exists to protect. Back off, rebuild, carry
-        // on — the same conclusion the SeccompProfile watcher reached
-        // in seccomp_distributor::run.
+        // kube upgrade could change that. Do not return: the
+        // supervisor would (correctly) read that as the watch having
+        // stopped and end the process. Do not error out either: that
+        // restarts the pod and destroys exactly the kernel state this
+        // module exists to protect. A stream that ends is recoverable
+        // in place, so recover in place — back off, rebuild, carry on,
+        // the same conclusion the SeccompProfile watcher reached in
+        // seccomp_distributor::run.
         let delay = rebuild_delay(consecutive_ends);
         consecutive_ends = consecutive_ends.saturating_add(1);
         degraded_since.get_or_insert_with(Instant::now);


### PR DESCRIPTION
Closes #1346. Closes #1344.

These are one defect in practice. `main` joined all nine subsystems with `try_join!`, making them futures in a single task, and two awaits inside those futures had no timeout. Either alone is survivable. Together, one unresponsive containerd produces a controller that is Running, 0 restarts, and doing nothing. Fixing only the fusing leaves the next blocking mistake fatal; fixing only the timeouts leaves every subsystem sharing one task and one 128-op cooperative budget, which is what makes the lock window in #1343 open constantly rather than rarely.

Subsystems now run as independent tasks, each declaring what its exit means. Two dispositions, not three: a "degraded" middle tier was rejected because `try_join!` already killed the process on `Err`, so anything softer would be a silent severity reduction smuggled in under a liveness fix. Nothing here is more permissive than what it replaces, and the startup `?` still exits non-zero, which matters because this DaemonSet has no probes and CrashLoopBackOff is the only signal an operator gets. Restart-on-fault was rejected too, with the three codebase-specific reasons recorded in the supervisor docs rather than left implicit, so anyone adding restart later has to argue past them.

Two things are worth a reviewer's attention. Demoting `network-events` or the eBPF loader to `MayRetire` was a one-word edit that left the whole suite green while restoring exactly the blindness #1473 closed; disposition is now a property of a closed enum with a private constructor, so that edit is unrepresentable and adding a subsystem is a compile error until someone answers the question. And `signal_ebpf_shutdown` firing on both exit paths is load-bearing rather than tidying: runtime drop waits unboundedly on the blocking poll task, which previously learned of shutdown only through a failed send, so on an idle node SIGTERM meant waiting for SIGKILL. Measured at 52.3ms now.

Contrary to #1344's text, `connect()` does not hang: hyper's h2 handshake completes on the client preface without waiting for the server's SETTINGS frame, and a saturated backlog returns `EAGAIN` immediately. The genuinely unbounded await was the RPC alone. A connect bound is kept as cheap defence against the one shape that is real, a stalled filesystem on the socket path.

Verified by mutation rather than assertion, because the pre-existing suite had no coverage of this fabric at all: `main` had zero tests, so 177 passing proved nothing about supervision. Rewiring onto one task fails three tests and hangs two; removing the RPC bound hangs the containerd test while the missing-socket test still passes, confirming it is not sensitive to the wrong thing. 177 to 202 tests, none removed.

Left open deliberately: the reconciler-client and `watch_pods` call sites need a real kube client to cover, and guarding `RPC_TIMEOUT`'s use site needs either a 5s wall-clock test or tokio's paused clock as a dev-dependency. The constants themselves are now asserted. Unflushed batches on shutdown are unchanged from `try_join!` and belong in their own change.