### PR TITLE
feat: detect AWS VPC CNI and align the policy builder with what the cluster enforces

### DIFF
--- a/broker/db/migrations/2026-09-07-120000_node_facts_policy_enforcement/down.sql
+++ b/broker/db/migrations/2026-09-07-120000_node_facts_policy_enforcement/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE node_facts DROP COLUMN IF EXISTS policy_enforcement;

--- a/broker/db/migrations/2026-09-07-120000_node_facts_policy_enforcement/up.sql
+++ b/broker/db/migrations/2026-09-07-120000_node_facts_policy_enforcement/up.sql
@@ -1,0 +1,20 @@
+-- Whether a NetworkPolicy applied to a node's pods would actually be
+-- enforced, reported per node alongside the CNI that was detected.
+--
+-- Kept separate from `cni` rather than folded into it because the two
+-- are orthogonal. AWS VPC CNI supports NetworkPolicy only when
+-- explicitly enabled and ships with it OFF; with it off the CNI accepts
+-- a policy and silently ignores it, so `kubectl apply` succeeds,
+-- `kubectl get` shows the object, and nothing is enforced. Cilium and
+-- Calico can likewise be deployed with policy disabled, and flannel
+-- implements none at all. So "which CNI" never answered "will this
+-- policy do anything", and the console had no way to tell an operator
+-- the difference.
+--
+-- Nullable with no default on purpose. A NULL row is a node whose
+-- controller predates this column, and that is a genuinely different
+-- state from a node that reported "unknown" — the reader treats both as
+-- "cannot tell", but conflating them at write time would throw away the
+-- distinction between "an old controller" and "a controller that
+-- looked and could not establish it".
+ALTER TABLE node_facts ADD COLUMN IF NOT EXISTS policy_enforcement VARCHAR;

--- a/broker/src/add.rs
+++ b/broker/src/add.rs
@@ -1440,6 +1440,17 @@ pub async fn add_node_facts(
     if fields.iter().any(|f| f.len() > 253) {
         return Ok(HttpResponse::BadRequest().body("field too long"));
     }
+    // Same guard for the optional enforcement enum. Not in `fields`
+    // above only because it is an Option; the read path clamps it to a
+    // whitelist regardless, but rejecting junk at ingest keeps the
+    // stored row honest.
+    if fact
+        .policy_enforcement
+        .as_ref()
+        .is_some_and(|v| v.len() > 253)
+    {
+        return Ok(HttpResponse::BadRequest().body("field too long"));
+    }
     web::block(move || -> Result<(), DbError> {
         use schema::node_facts::dsl::*;
         let mut conn = pool.get()?;

--- a/broker/src/schema.rs
+++ b/broker/src/schema.rs
@@ -138,6 +138,7 @@ diesel::table! {
         ip_family -> Varchar,
         node_os -> Varchar,
         time_stamp -> Timestamp,
+        policy_enforcement -> Nullable<Varchar>,
     }
 }
 

--- a/broker/src/types.rs
+++ b/broker/src/types.rs
@@ -244,6 +244,17 @@ pub struct NodeFact {
     pub node_os: String,
     #[serde(default = "chrono_now")]
     pub time_stamp: NaiveDateTime,
+    /// Whether a NetworkPolicy would actually be enforced on this node:
+    /// `enforced`, `unenforced`, or `unknown`.
+    ///
+    /// Optional on the wire, and last in the struct because `Queryable`
+    /// is positional and must match `schema::node_facts`. A controller
+    /// predating this field sends nothing and the column stays NULL,
+    /// which readers treat as "cannot tell" — the same as `unknown`,
+    /// but distinguishable in the database from a controller that
+    /// looked and could not establish it.
+    #[serde(default)]
+    pub policy_enforcement: Option<String>,
 }
 
 /// Serde default for rows arriving without a timestamp (the controller

--- a/broker/src/version_check.rs
+++ b/broker/src/version_check.rs
@@ -210,6 +210,14 @@ pub struct ClusterEnvironment {
     pub provider: String,
     pub distro: String,
     pub node_os: String,
+    /// Whether a NetworkPolicy would actually be enforced in this
+    /// cluster: `enforced`, `unenforced`, `mixed`, or `unknown`.
+    ///
+    /// The console needs this to avoid telling an operator their
+    /// generated policy is in force when the CNI is silently ignoring
+    /// it. See `aggregate_policy_enforcement` for why a mixed fleet is
+    /// its own answer rather than a majority vote.
+    pub policy_enforcement: String,
     pub nodes: i64,
 }
 
@@ -246,10 +254,21 @@ pub async fn get_cluster_environment(pool: web::Data<DbPool>) -> impl Responder 
         cni: clamp_enum(
             signals.cni,
             &[
-                "cilium", "calico", "flannel", "weave", "antrea", "kindnet", "unknown",
+                "cilium",
+                "calico",
+                "flannel",
+                "weave",
+                "antrea",
+                "kindnet",
+                "aws-vpc-cni",
+                "unknown",
             ],
         ),
         ip_family: clamp_enum(signals.ip_family, &["ipv4", "ipv6", "dual", "unknown"]),
+        policy_enforcement: clamp_enum(
+            signals.policy_enforcement,
+            &["enforced", "unenforced", "mixed", "unknown"],
+        ),
         provider: clamp_enum(
             signals.provider,
             &[
@@ -364,6 +383,7 @@ pub(crate) struct EnvSignals {
     cni: String,
     ip_family: String,
     node_os: String,
+    policy_enforcement: String,
     pods_bucket: String,
     features: String,
 }
@@ -376,6 +396,7 @@ impl Default for EnvSignals {
             cni: "unknown".into(),
             ip_family: "unknown".into(),
             node_os: "unknown".into(),
+            policy_enforcement: "unknown".into(),
             pods_bucket: "unknown".into(),
             features: "none".into(),
         }
@@ -395,6 +416,42 @@ fn mode(values: &[String]) -> String {
         .max_by_key(|(_, n)| *n)
         .map(|(v, _)| v.to_string())
         .unwrap_or_else(|| "unknown".to_string())
+}
+
+/// Cluster-wide policy enforcement from per-node answers.
+///
+/// NOT a majority vote, unlike the other aggregates. Enforcement is a
+/// safety claim, and the console uses it to decide whether to tell an
+/// operator their generated policy will actually take effect. A fleet
+/// where some nodes enforce and others do not is genuinely a different
+/// situation from either extreme — a policy applied there is live on
+/// part of the cluster and inert on the rest, which is arguably the
+/// most dangerous state of all, and `mode` would have hidden it behind
+/// whichever answer happened to be more common.
+///
+/// A `None` is a node whose controller predates the field. It is
+/// treated as `unknown` rather than ignored: a fleet mid-upgrade should
+/// not be reported as confidently enforcing on the strength of the
+/// nodes that have already been upgraded.
+fn aggregate_policy_enforcement(values: &[Option<String>]) -> String {
+    let mut enforced = false;
+    let mut unenforced = false;
+    let mut unsure = false;
+    for v in values {
+        match v.as_deref() {
+            Some("enforced") => enforced = true,
+            Some("unenforced") => unenforced = true,
+            _ => unsure = true,
+        }
+    }
+    match (enforced, unenforced, unsure) {
+        (true, true, _) => "mixed".to_string(),
+        // An unsure node alongside a definite one still means we cannot
+        // speak for the whole cluster.
+        (true, false, false) => "enforced".to_string(),
+        (false, true, false) => "unenforced".to_string(),
+        _ => "unknown".to_string(),
+    }
 }
 
 /// Cluster IP family from per-node families: any node dual — or a mix
@@ -466,8 +523,9 @@ fn env_signals(pool: &DbPool) -> EnvSignals {
             nf::cni,
             nf::ip_family,
             nf::node_os,
+            nf::policy_enforcement,
         ))
-        .load::<(String, String, String, String, String)>(&mut conn)
+        .load::<(String, String, String, String, String, Option<String>)>(&mut conn)
     {
         if !rows.is_empty() {
             let col = |i: usize| -> Vec<String> {
@@ -486,6 +544,12 @@ fn env_signals(pool: &DbPool) -> EnvSignals {
             out.cni = mode(&col(2));
             out.ip_family = aggregate_ip_family(&col(3));
             out.node_os = mode(&col(4));
+            out.policy_enforcement = aggregate_policy_enforcement(
+                &rows
+                    .iter()
+                    .map(|r| r.5.clone())
+                    .collect::<Vec<Option<String>>>(),
+            );
         }
     }
     if let Ok(n) = pd::pod_details
@@ -740,6 +804,75 @@ mod tests {
         });
     }
 
+    fn enf(xs: &[Option<&str>]) -> String {
+        aggregate_policy_enforcement(
+            &xs.iter()
+                .map(|x| x.map(|s| s.to_string()))
+                .collect::<Vec<_>>(),
+        )
+    }
+
+    // Enforcement is aggregated by rule, not by majority, because it is
+    // a safety claim rather than a demographic one. These pin the two
+    // ways a majority vote would have lied.
+
+    #[test]
+    fn a_split_fleet_reports_mixed_not_the_majority() {
+        // The dangerous state: the policy is live on some nodes and
+        // inert on others. `mode` would have reported whichever was
+        // more common and hidden the split entirely.
+        assert_eq!(
+            enf(&[
+                Some("enforced"),
+                Some("enforced"),
+                Some("enforced"),
+                Some("unenforced")
+            ]),
+            "mixed"
+        );
+        assert_eq!(
+            enf(&[Some("unenforced"), Some("unenforced"), Some("enforced")]),
+            "mixed"
+        );
+    }
+
+    #[test]
+    fn one_unsure_node_downgrades_the_whole_answer() {
+        // A fleet mid-upgrade, where old controllers report nothing,
+        // must not be called "enforced" on the strength of the nodes
+        // that happen to have been upgraded already.
+        assert_eq!(enf(&[Some("enforced"), None]), "unknown");
+        assert_eq!(enf(&[Some("enforced"), Some("unknown")]), "unknown");
+        assert_eq!(enf(&[Some("unenforced"), None]), "unknown");
+    }
+
+    #[test]
+    fn a_unanimous_fleet_reports_its_answer() {
+        assert_eq!(enf(&[Some("enforced"), Some("enforced")]), "enforced");
+        assert_eq!(enf(&[Some("unenforced"), Some("unenforced")]), "unenforced");
+    }
+
+    #[test]
+    fn no_nodes_at_all_is_unknown() {
+        assert_eq!(enf(&[]), "unknown");
+        assert_eq!(enf(&[None, None]), "unknown");
+    }
+
+    #[test]
+    fn aws_vpc_cni_survives_the_allowlist_clamp() {
+        // The regression this guards: the clamp silently rewrites any
+        // value not on the list to "unknown", so adding detection in
+        // the controller without adding the name here would have made
+        // it invisible at the API and looked like broken detection.
+        assert_eq!(
+            clamp_enum(
+                "aws-vpc-cni".into(),
+                &["cilium", "calico", "aws-vpc-cni", "unknown"]
+            ),
+            "aws-vpc-cni"
+        );
+    }
+
     #[test]
     fn cluster_environment_serializes_the_documented_shape() {
         // Wire contract for GET /cluster/environment — the UI and
@@ -750,6 +883,7 @@ mod tests {
             provider: "baremetal".into(),
             distro: "talos".into(),
             node_os: "talos".into(),
+            policy_enforcement: "enforced".into(),
             nodes: 3,
         };
         let v: serde_json::Value = serde_json::to_value(&env).unwrap();
@@ -758,7 +892,15 @@ mod tests {
         let keys: Vec<&str> = v.as_object().unwrap().keys().map(|k| k.as_str()).collect();
         assert_eq!(
             keys,
-            ["cni", "distro", "ip_family", "node_os", "nodes", "provider"]
+            [
+                "cni",
+                "distro",
+                "ip_family",
+                "node_os",
+                "nodes",
+                "policy_enforcement",
+                "provider"
+            ]
         );
         assert_eq!(v["cni"], "cilium");
         assert_eq!(v["nodes"], 3);

--- a/controller/src/node_facts.rs
+++ b/controller/src/node_facts.rs
@@ -11,8 +11,8 @@
 //! chart, API hiccup, broker unreachable) logs at debug/warn and gives
 //! up — it must never affect capture.
 
-use k8s_openapi::api::core::v1::Node;
-use kube::{Api, Client};
+use k8s_openapi::api::core::v1::{Node, Pod};
+use kube::{api::ListParams, Api, Client};
 use serde::Serialize;
 use tracing::{debug, warn};
 
@@ -24,6 +24,37 @@ pub struct NodeFacts {
     pub cni: String,
     pub ip_family: String,
     pub node_os: String,
+    /// Whether a NetworkPolicy applied to this node's pods would
+    /// actually be *enforced*: `enforced`, `unenforced`, or `unknown`.
+    ///
+    /// Deliberately separate from `cni` rather than folded into it,
+    /// because enforcement is orthogonal to which CNI is installed.
+    /// AWS VPC CNI supports NetworkPolicy only when explicitly turned
+    /// on and ships with it OFF, in which case it accepts a policy and
+    /// silently ignores it — `kubectl apply` succeeds, `kubectl get`
+    /// shows the object, nothing is enforced. Cilium and Calico can
+    /// likewise be installed with policy disabled, and flannel never
+    /// enforces at all.
+    ///
+    /// Knowing the CNI is therefore NOT the same claim as knowing a
+    /// generated policy will do anything, and this project's whole
+    /// value rests on the difference: kguardian tells an operator it is
+    /// safe to deny what was never observed. Telling them a policy is
+    /// in force when it is inert is the worst answer available, so
+    /// `unknown` is reported wherever it cannot be established.
+    pub policy_enforcement: String,
+}
+
+/// What a node-local CNI agent pod reveals about itself.
+///
+/// Read from the agent's own pod spec rather than inferred from Node
+/// annotations, because the CNI that prompted this — AWS VPC CNI —
+/// stamps no annotations at all, and because the enforcement flag only
+/// exists in the agent's container arguments.
+#[derive(Debug, Clone, PartialEq)]
+pub struct CniAgentFacts {
+    pub cni: &'static str,
+    pub policy_enforcement: &'static str,
 }
 
 /// Map a `spec.providerID` scheme to the telemetry provider enum.
@@ -134,6 +165,89 @@ fn cni(node: &Node) -> &'static str {
     "unknown"
 }
 
+/// Identify the CNI, and whether it enforces policy, from the agent
+/// pods running on this node.
+///
+/// AWS VPC CNI is invisible to [`cni`]: it annotates neither the Node
+/// nor its pods, so every EKS cluster running it reported `unknown`.
+/// Its agent pod, however, states both facts outright — the DaemonSet
+/// is labelled `k8s-app=aws-node`, and the `aws-eks-nodeagent`
+/// container carries `--enable-network-policy` in its arguments.
+///
+/// Reading the pod rather than the DaemonSet is deliberate: the
+/// controller already holds cluster-wide `pods get/watch`, while
+/// `daemonsets` would need a new rule in the ClusterRole. A pod carries
+/// the same container arguments its DaemonSet template does, so the
+/// extra permission buys nothing.
+///
+/// `None` means no agent this function recognises was found, which is
+/// not the same as "no CNI" — the caller falls back to annotations and
+/// then to `unknown`.
+fn cni_agent_facts(pods: &[Pod]) -> Option<CniAgentFacts> {
+    pods.iter().find_map(|pod| {
+        let is_aws_node = pod
+            .metadata
+            .labels
+            .as_ref()
+            .is_some_and(|l| l.get("k8s-app").is_some_and(|v| v == "aws-node"));
+        if !is_aws_node {
+            return None;
+        }
+        Some(CniAgentFacts {
+            cni: "aws-vpc-cni",
+            policy_enforcement: aws_policy_enforcement(pod),
+        })
+    })
+}
+
+/// Whether the VPC CNI node agent was started with policy enforcement
+/// on.
+///
+/// Three outcomes, and the distinction between the last two matters:
+/// the flag present and true is `enforced`; the container present with
+/// the flag absent or false is `unenforced`, because the agent defaults
+/// to off; and no `aws-eks-nodeagent` container at all is `unenforced`
+/// too, since VPC CNI gained NetworkPolicy support only in v1.14 and an
+/// older agent cannot enforce anything regardless of configuration.
+fn aws_policy_enforcement(pod: &Pod) -> &'static str {
+    let Some(spec) = pod.spec.as_ref() else {
+        return "unknown";
+    };
+    let Some(agent) = spec
+        .containers
+        .iter()
+        .find(|c| c.name == "aws-eks-nodeagent")
+    else {
+        // Pre-v1.14 VPC CNI: no policy agent exists to enforce with.
+        return "unenforced";
+    };
+    let enabled = agent
+        .args
+        .as_ref()
+        .is_some_and(|args| args.iter().any(|a| a == "--enable-network-policy=true"));
+    if enabled {
+        "enforced"
+    } else {
+        "unenforced"
+    }
+}
+
+/// Enforcement for a CNI identified only by its Node annotations.
+///
+/// Only flannel gets a definite answer: it provides no NetworkPolicy
+/// implementation at all, so a policy applied on it is inert by
+/// construction. Cilium and Calico both ship enforcement on by default
+/// but can be deployed with it disabled, and nothing on the Node says
+/// which — claiming `enforced` for them would be a guess dressed as a
+/// fact, so they report `unknown` until someone probes their agents the
+/// way [`cni_agent_facts`] probes VPC CNI's.
+fn annotated_cni_enforcement(cni: &str) -> &'static str {
+    match cni {
+        "flannel" => "unenforced",
+        _ => "unknown",
+    }
+}
+
 /// IP family of the node's pod CIDRs: ipv4 / ipv6 / dual.
 fn ip_family(node: &Node) -> &'static str {
     let mut v4 = false;
@@ -192,16 +306,31 @@ fn node_os(node: &Node) -> &'static str {
 
 /// Derive every fact from a Node object. Pure — the whole mapping is
 /// unit-tested below against representative Node shapes.
-pub fn derive_facts(node_name: &str, node: &Node) -> NodeFacts {
+/// Derive the reported facts.
+///
+/// `agent_pods` are the pods this controller could see on its own node.
+/// An agent that names itself is believed over Node annotations: VPC CNI
+/// leaves none, and an agent's own arguments are a direct statement of
+/// configuration rather than a proxy for it. An empty slice — no pod
+/// access, or nothing recognised — falls back to the annotation path,
+/// which is exactly the pre-existing behaviour.
+pub fn derive_facts(node_name: &str, node: &Node, agent_pods: &[Pod]) -> NodeFacts {
     let provider_id = node.spec.as_ref().and_then(|s| s.provider_id.as_deref());
     let provider = provider_from_id(provider_id);
+    let agent = cni_agent_facts(agent_pods);
+    let annotated = cni(node);
+    let (cni_name, enforcement) = match agent {
+        Some(a) => (a.cni, a.policy_enforcement),
+        None => (annotated, annotated_cni_enforcement(annotated)),
+    };
     NodeFacts {
         node_name: node_name.to_string(),
         provider: provider.to_string(),
         distro: distro(node, provider).to_string(),
-        cni: cni(node).to_string(),
+        cni: cni_name.to_string(),
         ip_family: ip_family(node).to_string(),
         node_os: node_os(node).to_string(),
+        policy_enforcement: enforcement.to_string(),
     }
 }
 
@@ -215,7 +344,26 @@ pub async fn report_node_facts(node_name: String, broker_url: String) {
             return;
         }
     };
-    let nodes: Api<Node> = Api::all(client);
+    let nodes: Api<Node> = Api::all(client.clone());
+    // CNI agent pods on this node, used to identify a CNI that annotates
+    // nothing and to read whether it enforces policy. Best-effort by
+    // design: a failure here degrades the two CNI fields to the
+    // annotation path and `unknown`, which is what every chart before
+    // this reported anyway. Field-selected to this node so it is one
+    // small list, not a cluster-wide scan.
+    let agent_pods: Vec<Pod> = {
+        let pods: Api<Pod> = Api::all(client);
+        let params = ListParams::default()
+            .fields(&format!("spec.nodeName={}", node_name))
+            .labels("k8s-app=aws-node");
+        match pods.list(&params).await {
+            Ok(list) => list.items,
+            Err(e) => {
+                debug!(error = %e, "could not list CNI agent pods; CNI facts fall back to Node annotations");
+                Vec::new()
+            }
+        }
+    };
     let node = match nodes.get(&node_name).await {
         Ok(n) => n,
         Err(e) => {
@@ -230,7 +378,7 @@ pub async fn report_node_facts(node_name: String, broker_url: String) {
             return;
         }
     };
-    let facts = derive_facts(&node_name, &node);
+    let facts = derive_facts(&node_name, &node, &agent_pods);
     debug!(?facts, "derived node environment facts");
     let url = format!("{}/node/facts", broker_url.trim_end_matches('/'));
     match reqwest::Client::new().post(&url).json(&facts).send().await {
@@ -251,7 +399,7 @@ pub async fn report_node_facts(node_name: String, broker_url: String) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use k8s_openapi::api::core::v1::{NodeSpec, NodeStatus, NodeSystemInfo};
+    use k8s_openapi::api::core::v1::{Container, NodeSpec, NodeStatus, NodeSystemInfo, PodSpec};
     use std::collections::BTreeMap;
 
     fn node(
@@ -295,6 +443,161 @@ mod tests {
         n
     }
 
+    /// Build an `aws-node` agent pod. `agent_args` of `None` means the
+    /// `aws-eks-nodeagent` container is absent entirely, which is how a
+    /// pre-v1.14 VPC CNI presents.
+    fn aws_node_pod(agent_args: Option<&[&str]>) -> Pod {
+        let mut p = Pod::default();
+        p.metadata.labels = Some(
+            [("k8s-app".to_string(), "aws-node".to_string())]
+                .into_iter()
+                .collect::<BTreeMap<_, _>>(),
+        );
+        let mut containers = vec![Container {
+            name: "aws-node".to_string(),
+            ..Default::default()
+        }];
+        if let Some(args) = agent_args {
+            containers.push(Container {
+                name: "aws-eks-nodeagent".to_string(),
+                args: Some(args.iter().map(|a| a.to_string()).collect()),
+                ..Default::default()
+            });
+        }
+        p.spec = Some(PodSpec {
+            containers,
+            ..Default::default()
+        });
+        p
+    }
+
+    /// A bare EKS node: no CNI annotations at all, which is exactly how
+    /// VPC CNI presents and why the annotation path returns "unknown".
+    fn bare_eks_node() -> Node {
+        node(
+            Some("aws:///us-west-2a/i-0abc"),
+            &[("eks.amazonaws.com/nodegroup", "ng-1")],
+            &[],
+            "v1.30.0-eks-1234",
+            "amazon linux 2023",
+            &["10.62.0.0/19"],
+        )
+    }
+
+    // The regression these guard: AWS VPC CNI annotates nothing, so
+    // before the agent probe every EKS cluster reported cni="unknown"
+    // and the console could not tell an operator which policy type
+    // their cluster would actually enforce.
+
+    #[test]
+    fn aws_vpc_cni_is_detected_from_the_agent_pod_not_annotations() {
+        let facts = derive_facts(
+            "node-a",
+            &bare_eks_node(),
+            &[aws_node_pod(Some(&["--enable-network-policy=true"]))],
+        );
+        assert_eq!(facts.cni, "aws-vpc-cni");
+        assert_eq!(facts.policy_enforcement, "enforced");
+    }
+
+    #[test]
+    fn vpc_cni_without_the_flag_is_unenforced_not_unknown() {
+        // The dangerous case, and the reason enforcement is reported
+        // separately from the CNI name: the flag defaults to off, and
+        // with it off the CNI accepts a NetworkPolicy and silently
+        // ignores it. Reporting "unknown" here would let the console
+        // hedge; the truth is that policy is definitely inert.
+        let facts = derive_facts(
+            "node-a",
+            &bare_eks_node(),
+            &[aws_node_pod(Some(&["--enable-ipv6=false"]))],
+        );
+        assert_eq!(facts.cni, "aws-vpc-cni");
+        assert_eq!(facts.policy_enforcement, "unenforced");
+    }
+
+    #[test]
+    fn vpc_cni_explicitly_disabled_is_unenforced() {
+        let facts = derive_facts(
+            "node-a",
+            &bare_eks_node(),
+            &[aws_node_pod(Some(&["--enable-network-policy=false"]))],
+        );
+        assert_eq!(facts.policy_enforcement, "unenforced");
+    }
+
+    #[test]
+    fn vpc_cni_older_than_the_policy_agent_is_unenforced() {
+        // Pre-v1.14 has no aws-eks-nodeagent container at all. There is
+        // nothing that could enforce, so this is a definite answer.
+        let facts = derive_facts("node-a", &bare_eks_node(), &[aws_node_pod(None)]);
+        assert_eq!(facts.cni, "aws-vpc-cni");
+        assert_eq!(facts.policy_enforcement, "unenforced");
+    }
+
+    #[test]
+    fn no_agent_pods_falls_back_to_the_annotation_path() {
+        // Pod listing failed, or the chart lacks the RBAC. Behaviour
+        // must be exactly what it was before the probe existed.
+        let n = node(
+            Some("aws:///us-west-2a/i-0abc"),
+            &[],
+            &[("io.cilium.network.ipv4-pod-cidr", "10.0.0.0/24")],
+            "v1.30.0",
+            "ubuntu 22.04",
+            &["10.0.0.0/24"],
+        );
+        let facts = derive_facts("node-a", &n, &[]);
+        assert_eq!(facts.cni, "cilium");
+        assert_eq!(facts.policy_enforcement, "unknown");
+    }
+
+    #[test]
+    fn the_agent_pod_beats_a_stale_annotation() {
+        // A cluster migrated from Calico to VPC CNI can keep the old
+        // annotations on long-lived nodes. The running agent is the
+        // authority; an annotation is a leftover.
+        let n = node(
+            Some("aws:///us-west-2a/i-0abc"),
+            &[],
+            &[("projectcalico.org/IPv4Address", "10.0.0.5/24")],
+            "v1.30.0-eks-1234",
+            "amazon linux 2023",
+            &["10.62.0.0/19"],
+        );
+        let facts = derive_facts(
+            "node-a",
+            &n,
+            &[aws_node_pod(Some(&["--enable-network-policy=true"]))],
+        );
+        assert_eq!(facts.cni, "aws-vpc-cni");
+        assert_eq!(facts.policy_enforcement, "enforced");
+    }
+
+    #[test]
+    fn flannel_is_definitely_unenforced_others_are_unknown() {
+        // flannel implements no NetworkPolicy at all, so that one can
+        // be stated. Cilium and Calico default to enforcing but can be
+        // installed without it, and nothing on the Node says which —
+        // guessing "enforced" there would be the false assurance this
+        // field exists to prevent.
+        assert_eq!(annotated_cni_enforcement("flannel"), "unenforced");
+        for c in ["cilium", "calico", "antrea", "weave", "unknown"] {
+            assert_eq!(annotated_cni_enforcement(c), "unknown", "{c}");
+        }
+    }
+
+    #[test]
+    fn a_non_agent_pod_on_the_node_is_ignored() {
+        let mut other = Pod::default();
+        other.metadata.labels = Some(
+            [("k8s-app".to_string(), "kube-proxy".to_string())]
+                .into_iter()
+                .collect::<BTreeMap<_, _>>(),
+        );
+        assert_eq!(cni_agent_facts(&[other]), None);
+    }
+
     #[test]
     fn eks_node_derives_aws_eks() {
         let n = node(
@@ -305,7 +608,7 @@ mod tests {
             "Amazon Linux 2",
             &["10.0.0.0/24"],
         );
-        let f = derive_facts("n1", &n);
+        let f = derive_facts("n1", &n, &[]);
         assert_eq!(
             (
                 f.provider.as_str(),
@@ -327,7 +630,7 @@ mod tests {
             "Talos (v1.13.4)",
             &["10.244.11.0/24", "fd00:10:244::/64"],
         );
-        let f = derive_facts("n1", &n);
+        let f = derive_facts("n1", &n, &[]);
         assert_eq!(
             (
                 f.provider.as_str(),
@@ -350,7 +653,7 @@ mod tests {
             "Container-Optimized OS from Google",
             &["10.4.0.0/24"],
         );
-        let f = derive_facts("n1", &n);
+        let f = derive_facts("n1", &n, &[]);
         assert_eq!(
             (f.provider.as_str(), f.distro.as_str(), f.node_os.as_str()),
             ("gcp", "gke", "cos")
@@ -367,7 +670,7 @@ mod tests {
             "Ubuntu 22.04.4 LTS",
             &["10.42.0.0/24"],
         );
-        let f = derive_facts("n1", &n);
+        let f = derive_facts("n1", &n, &[]);
         assert_eq!(
             (
                 f.provider.as_str(),
@@ -381,7 +684,7 @@ mod tests {
 
     #[test]
     fn empty_node_degrades_to_unknowns_not_panics() {
-        let f = derive_facts("n1", &Node::default());
+        let f = derive_facts("n1", &Node::default(), &[]);
         assert_eq!(
             (
                 f.provider.as_str(),
@@ -404,7 +707,7 @@ mod tests {
             "Debian GNU/Linux 12",
             &["fd00::/64"],
         );
-        let f = derive_facts("n1", &n);
+        let f = derive_facts("n1", &n, &[]);
         assert_eq!(
             (f.ip_family.as_str(), f.node_os.as_str()),
             ("ipv6", "debian")

--- a/docs/api-reference/endpoints/environment.mdx
+++ b/docs/api-reference/endpoints/environment.mdx
@@ -21,6 +21,21 @@ the controller predates fact reporting — and consumers treat it as
 "behave exactly as before". Mixed-CNI clusters resolve to the most
 common per-node value.
 
+`policy_enforcement` is reported separately from `cni` because the two
+answer different questions. Knowing which CNI is installed does not tell
+you whether a NetworkPolicy will take effect: AWS VPC CNI supports
+NetworkPolicy only when explicitly enabled and ships with it off, and
+with it off the CNI accepts the object and silently ignores it, so
+`kubectl apply` succeeds and nothing is restricted. Cilium and Calico can
+also be installed with policy disabled, and flannel never enforces.
+
+Unlike the other fields, `policy_enforcement` is NOT a most-common vote.
+A cluster where some nodes enforce and others do not reports `mixed`,
+because a policy applied there is live on part of the fleet and inert on
+the rest, and a majority vote would hide that. A single node that cannot
+answer downgrades the whole cluster to `unknown` rather than letting the
+already-upgraded nodes speak for it.
+
 ## GET /cluster/environment
 
 Requires bearer auth when `BROKER_AUTH_TOKEN` is set. Always returns
@@ -33,15 +48,17 @@ Requires bearer auth when `BROKER_AUTH_TOKEN` is set. Always returns
   "provider": "baremetal",
   "distro": "talos",
   "node_os": "talos",
+  "policy_enforcement": "enforced",
   "nodes": 3
 }
 ```
 
 | Field | Values |
 | --- | --- |
-| `cni` | `cilium`, `calico`, `flannel`, `weave`, `antrea`, `unknown` |
+| `cni` | `cilium`, `calico`, `flannel`, `weave`, `antrea`, `kindnet`, `aws-vpc-cni`, `unknown` |
 | `ip_family` | `ipv4`, `ipv6`, `dual`, `unknown` |
 | `provider` | `aws`, `gcp`, `azure`, `digitalocean`, `hetzner`, `openstack`, `vsphere`, `oracle`, `ibm`, `baremetal`, `kind`, `unknown` |
 | `distro` | `eks`, `gke`, `aks`, `k3s`, `rke2`, `talos`, `openshift`, `kind`, `vanilla`, `unknown` |
 | `node_os` | `talos`, `bottlerocket`, `flatcar`, `cos`, `ubuntu`, `debian`, `rhel`, `amazonlinux`, `alpine`, `other`, `unknown` |
+| `policy_enforcement` | `enforced`, `unenforced`, `mixed`, `unknown` — whether a NetworkPolicy is actually enforced here |
 | `nodes` | Count of nodes that have reported facts; `0` = none yet |

--- a/docs/telemetry.mdx
+++ b/docs/telemetry.mdx
@@ -30,7 +30,8 @@ original contract; the rest were added in contract v2 and are optional
 | `arch` | `x86_64` | Broker CPU architecture. |
 | `provider` | `aws` | Cloud platform, derived from the node's `providerID` scheme. One of a fixed list (`aws`, `gcp`, `azure`, `digitalocean`, `hetzner`, `openstack`, `vsphere`, `oracle`, `ibm`, `baremetal`, `kind`) or `unknown`. Never an account, project, or region. |
 | `distro` | `k3s` | Kubernetes distribution flavor (`eks`, `gke`, `aks`, `k3s`, `rke2`, `talos`, `openshift`, `kind`, `vanilla`), derived from well-known node labels and version suffixes. |
-| `cni` | `cilium` | CNI plugin, derived from node annotations (`cilium`, `calico`, `flannel`, `weave`, `antrea`, `kindnet`). |
+| `cni` | `cilium` | CNI plugin (`cilium`, `calico`, `flannel`, `weave`, `antrea`, `kindnet`, `aws-vpc-cni`). Derived from node annotations, except AWS VPC CNI which annotates nothing and is identified from its node agent pod. |
+| `policy_enforcement` | `enforced` | Whether NetworkPolicy is actually enforced (`enforced`, `unenforced`, `mixed`, `unknown`). Separate from `cni` because a CNI can be installed with policy support off, in which case a policy applies cleanly and restricts nothing. |
 | `ip_family` | `dual` | Cluster IP family (`ipv4`, `ipv6`, `dual`), derived from node pod CIDRs. |
 | `node_os` | `talos` | Node operating-system family from `nodeInfo.osImage`, coarsened to a fixed list. |
 | `pods_bucket` | `10-99` | Order-of-magnitude bucket of pods observed — never an exact inventory. |

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -13,6 +13,7 @@ import { SettingsPanel } from './components/SettingsPanel';
 import { useSettings } from './contexts/SettingsContext';
 import { useClusterEnvironment } from './hooks/useClusterEnvironment';
 import { policyTypeForFinding, type FindingKind } from './utils/findingPolicyType';
+import { recommendedPolicyType } from './utils/cniPolicySupport';
 import type { PolicyType } from './hooks/policyEditor';
 import { useCluster } from './contexts/ClusterContext';
 
@@ -156,7 +157,7 @@ function App() {
 
   const handleBuildPolicy = (pod: PodNodeData) => {
     setPolicyBuilderInitialPod(pod);
-    setPolicyBuilderInitialType('network');
+    setPolicyBuilderInitialType(recommendedPolicyType(cni));
     setIsPolicyBuilderOpen(true);
   };
 
@@ -173,9 +174,9 @@ function App() {
   // otherwise with no pod so it shows the workload picker.
   const openPolicyBuilder = useCallback(() => {
     setPolicyBuilderInitialPod(selectedPod && !selectedPod.isExternal ? selectedPod : null);
-    setPolicyBuilderInitialType('network');
+    setPolicyBuilderInitialType(recommendedPolicyType(cni));
     setIsPolicyBuilderOpen(true);
-  }, [selectedPod]);
+  }, [selectedPod, cni]);
 
   const handleAILayoutChange = useCallback((isSidePanel: boolean, isCollapsed: boolean, width?: number) => {
     setAISidePanel({ isSidePanel, isCollapsed, width: width ?? UI_DIMENSIONS.AI_PANEL_DEFAULT_WIDTH });

--- a/frontend/src/components/NetworkPolicyEditor.tsx
+++ b/frontend/src/components/NetworkPolicyEditor.tsx
@@ -7,7 +7,8 @@ import { ciliumPolicyToYAML } from '../utils/ciliumPolicyGenerator';
 import { EntitiesPeer, HostNetworkWarningBanner, RuleComments } from './HostNetworkNotes';
 import { CILIUM_NAMESPACE_LABEL } from '../types/ciliumPolicy';
 import { useClusterEnvironment } from '../hooks/useClusterEnvironment';
-import { CniMismatchNotice } from './PolicyEditor/CniMismatchNotice';
+import { PolicyAdvisoryNotice } from './PolicyEditor/CniMismatchNotice';
+import { recommendedPolicyType, enforcementAdvisory } from '../utils/cniPolicySupport';
 import { PartialCaptureWarning } from './Seccomp/PartialCaptureWarning';
 import { useWorkloadCapture } from '../hooks/useWorkloadCapture';
 import { SECCOMP_ACTIONS, ARCHITECTURES, SECCOMP_ACTION_DESCRIPTIONS } from '../types/seccompProfile';
@@ -33,16 +34,33 @@ interface NetworkPolicyEditorProps {
   initialPolicyType?: PolicyType;
 }
 
-const NetworkPolicyEditor: React.FC<NetworkPolicyEditorProps> = ({ isOpen, onClose, pod, initialPolicyType = 'network' }) => {
-  const [policyType, setPolicyType] = useState<PolicyType>(initialPolicyType);
+const NetworkPolicyEditor: React.FC<NetworkPolicyEditorProps> = ({ isOpen, onClose, pod, initialPolicyType }) => {
+  const env = useClusterEnvironment();
+  const { cni } = env;
+
+  // Default to the kind this cluster can actually enforce, rather than
+  // always opening on 'network' and warning afterwards. An explicit
+  // initialPolicyType from the caller still wins, and the operator can
+  // switch freely: the YAML may be destined for a different cluster,
+  // which is why export is never blocked on a mismatch.
+  //
+  // Derived, not synced. The environment arrives asynchronously and is
+  // 'unknown' on the first render, so storing the recommendation in
+  // state would latch that first value and never correct itself once
+  // the facts land. Keeping the operator's choice as the only state and
+  // falling back to the recommendation means the default follows the
+  // detected CNI, while an explicit choice wins permanently.
+  const [chosenPolicyType, selectPolicyType] = useState<PolicyType | undefined>(initialPolicyType);
+  const policyType = chosenPolicyType ?? recommendedPolicyType(cni);
+
   const [yamlView, setYamlView] = useState(true); // Default to YAML view
 
-  // Align with the cluster CNI (issue #1413): when the detected CNI is
-  // real and not cilium, badge the Cilium tab and show a notice on it.
-  // 'unknown' (no facts yet, older broker, non-annotating CNI) keeps
-  // the editor pixel-identical to its pre-detection behavior, and the
-  // async fetch never gates rendering.
-  const { cni } = useClusterEnvironment();
+  // What to tell the operator about the kind they are looking at. This
+  // covers both questions: whether the CNI understands this policy kind
+  // at all, and whether it enforces policy — the second of which used
+  // to be missing, so the console could tell someone their policy was
+  // fine while the CNI silently ignored it.
+  const advisory = enforcementAdvisory(policyType, env);
   const cniMismatch = cni !== 'unknown' && cni !== 'cilium' ? cni : null;
   const ciliumWarning = cniMismatch
     ? `Cluster CNI detected as ${cniMismatch} — CiliumNetworkPolicy is likely not applicable here`
@@ -187,7 +205,7 @@ const NetworkPolicyEditor: React.FC<NetworkPolicyEditorProps> = ({ isOpen, onClo
       {/* Header */}
       <PolicyHeader
             policyType={policyType}
-            onPolicyTypeChange={setPolicyType}
+            onPolicyTypeChange={selectPolicyType}
             yamlView={yamlView}
             onYamlViewToggle={() => setYamlView(!yamlView)}
             copiedToClipboard={copiedToClipboard}
@@ -201,7 +219,7 @@ const NetworkPolicyEditor: React.FC<NetworkPolicyEditorProps> = ({ isOpen, onClo
             onSeccompFormatChange={setSeccompFormat}
           />
 
-          {policyType === 'cilium' && cniMismatch && <CniMismatchNotice cni={cniMismatch} />}
+          {advisory && <PolicyAdvisoryNotice advisory={advisory} />}
           {!isLoading && (
             <HostNetworkWarningBanner
               warnings={policyType === 'network' ? policy?.warnings : policyType === 'cilium' ? ciliumPolicy?.warnings : undefined}

--- a/frontend/src/components/PolicyEditor/CniMismatchNotice.test.tsx
+++ b/frontend/src/components/PolicyEditor/CniMismatchNotice.test.tsx
@@ -1,25 +1,58 @@
 // @vitest-environment jsdom
 import { afterEach, expect, test } from 'vitest';
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
-import { CniMismatchNotice } from './CniMismatchNotice';
+import { PolicyAdvisoryNotice } from './CniMismatchNotice';
+import { enforcementAdvisory } from '../../utils/cniPolicySupport';
 
 afterEach(cleanup);
 
-// The notice backs CNI-aligned policy generation (issue #1413): shown
-// only on a REAL mismatch (callers gate on cni !== unknown/cilium), it
-// names the detected CNI, warns about both failure modes (CRD absent →
-// apply fails; CRD present but unenforced → silently inert), and is
-// dismissible without disabling export.
+// The notice backs CNI-aligned policy generation. It covers two
+// independent questions: whether the CNI understands the policy kind on
+// screen, and whether it enforces policy at all. The second used to be
+// missing, and its absence let the console tell an operator a policy was
+// fine while the CNI silently ignored it.
 
-test('names the detected CNI and both failure modes', () => {
-  render(<CniMismatchNotice cni="calico" />);
-  expect(screen.getByRole('note').textContent).toContain('calico');
-  expect(screen.getByRole('note').textContent).toContain('CiliumNetworkPolicy CRD');
-  expect(screen.getByRole('note').textContent).toContain('only Cilium enforces it');
+const advisory = (type: Parameters<typeof enforcementAdvisory>[0], cni: string, enf: string) =>
+  enforcementAdvisory(type, { cni, policy_enforcement: enf })!;
+
+test('a Cilium policy on a non-Cilium CNI names the CNI and both failure modes', () => {
+  render(<PolicyAdvisoryNotice advisory={advisory('cilium', 'calico', 'enforced')} />);
+  const text = screen.getByRole('note').textContent ?? '';
+  expect(text).toContain('calico');
+  expect(text).toContain('CRD is likely absent');
+  expect(text).toContain('read by nobody');
 });
 
-test('dismiss removes the notice', () => {
-  render(<CniMismatchNotice cni="flannel" />);
-  fireEvent.click(screen.getByLabelText('Dismiss CNI notice'));
+test('a warning is dismissible without disabling export', () => {
+  render(<PolicyAdvisoryNotice advisory={advisory('cilium', 'flannel', 'unknown')} />);
+  fireEvent.click(screen.getByLabelText('Dismiss policy notice'));
   expect(screen.queryByRole('note')).toBeNull();
+});
+
+test('an inert policy is an alert and CANNOT be dismissed', () => {
+  // The operator opened this editor to restrict a workload. Letting
+  // them wave away the one message saying the restriction will not
+  // happen is how a tool ends up trusted while doing nothing.
+  render(<PolicyAdvisoryNotice advisory={advisory('network', 'aws-vpc-cni', 'unenforced')} />);
+  expect(screen.getByRole('alert')).toBeTruthy();
+  expect(screen.queryByLabelText('Dismiss policy notice')).toBeNull();
+});
+
+test('the inert message says the object will apply and restrict nothing', () => {
+  render(<PolicyAdvisoryNotice advisory={advisory('network', 'aws-vpc-cni', 'unenforced')} />);
+  const text = screen.getByRole('alert').textContent ?? '';
+  expect(text).toMatch(/no traffic will be restricted/i);
+  expect(text).toContain('--enable-network-policy');
+});
+
+test('a split fleet is an alert too, since placement decides the outcome', () => {
+  render(<PolicyAdvisoryNotice advisory={advisory('network', 'aws-vpc-cni', 'mixed')} />);
+  expect(screen.getByRole('alert').textContent).toMatch(/one node and not on another/i);
+});
+
+test('unknown enforcement is stated honestly rather than reassuringly', () => {
+  render(<PolicyAdvisoryNotice advisory={advisory('network', 'unknown', 'unknown')} />);
+  const text = screen.getByRole('note').textContent ?? '';
+  expect(text).toMatch(/could not establish/i);
+  expect(text).not.toMatch(/works on any CNI/i);
 });

--- a/frontend/src/components/PolicyEditor/CniMismatchNotice.tsx
+++ b/frontend/src/components/PolicyEditor/CniMismatchNotice.tsx
@@ -1,40 +1,61 @@
 import React, { useState } from 'react';
 import { AlertTriangle, X } from 'lucide-react';
+import { isDismissible, type PolicyAdvisory } from '../../utils/cniPolicySupport';
 
-interface CniMismatchNoticeProps {
-  /** The detected cluster CNI (never 'unknown' or 'cilium' here —
-   *  callers only render this on a real mismatch). */
-  cni: string;
+interface PolicyAdvisoryNoticeProps {
+  advisory: PolicyAdvisory;
 }
 
 /**
- * Dismissible notice shown on the Cilium Policy tab when the cluster's
- * detected CNI is something else: the CiliumNetworkPolicy CRD is
- * likely absent (apply fails), or — worse — present but unenforced
- * (policy applies and is silently inert). Export stays enabled: the
- * YAML may be destined for a different cluster.
+ * Notice shown above the policy body when the cluster cannot enforce
+ * the kind of policy on screen.
+ *
+ * Two changes from the CNI-only notice this replaces, both of which
+ * matter more than they look:
+ *
+ * It no longer claims "a standard Network Policy works on any CNI".
+ * That was false. A NetworkPolicy is enforced only where the CNI
+ * enforces policy, and AWS VPC CNI — the default on EKS — ships with
+ * enforcement OFF, in which case it accepts the object and silently
+ * ignores it. Telling an operator their policy "works" there is the
+ * worst available answer for a tool whose promise is that
+ * observed-absence means safe-to-deny.
+ *
+ * And an `error` advisory is NOT dismissible. The operator opened this
+ * editor to restrict a workload; letting them wave away the single
+ * message saying the restriction will not happen defeats the point.
+ * Lesser advisories stay dismissible so the console does not nag.
  */
-export const CniMismatchNotice: React.FC<CniMismatchNoticeProps> = ({ cni }) => {
+export const PolicyAdvisoryNotice: React.FC<PolicyAdvisoryNoticeProps> = ({ advisory }) => {
   const [dismissed, setDismissed] = useState(false);
-  if (dismissed) return null;
+  const dismissible = isDismissible(advisory);
+  if (dismissed && dismissible) return null;
+
+  const tone =
+    advisory.severity === 'error'
+      ? 'bg-hubble-error/10 border-hubble-error/30 text-hubble-error'
+      : advisory.severity === 'warning'
+        ? 'bg-hubble-warning/10 border-hubble-warning/30 text-hubble-warning'
+        : 'bg-surface-raised border-border text-tertiary';
+
   return (
     <div
-      role="note"
-      className="flex items-start gap-2 px-4 py-2.5 bg-hubble-warning/10 border-b border-hubble-warning/30 text-xs text-secondary"
+      role={advisory.severity === 'error' ? 'alert' : 'note'}
+      className={`flex items-start gap-2 px-4 py-2.5 border-b text-xs ${tone}`}
     >
-      <AlertTriangle className="w-4 h-4 text-hubble-warning shrink-0 mt-0.5" />
-      <p className="flex-1">
-        Cluster CNI detected as <span className="font-mono text-primary">{cni}</span> — the
-        CiliumNetworkPolicy CRD is likely not installed here, and even if it is, only Cilium
-        enforces it. A standard Network Policy works on any CNI.
+      <AlertTriangle className="w-4 h-4 shrink-0 mt-0.5" />
+      <p className="flex-1 text-secondary">
+        <span className="font-medium text-primary">{advisory.title}.</span> {advisory.detail}
       </p>
-      <button
-        onClick={() => setDismissed(true)}
-        aria-label="Dismiss CNI notice"
-        className="text-tertiary hover:text-primary transition-colors"
-      >
-        <X className="w-3.5 h-3.5" />
-      </button>
+      {dismissible && (
+        <button
+          onClick={() => setDismissed(true)}
+          aria-label="Dismiss policy notice"
+          className="text-tertiary hover:text-primary transition-colors"
+        >
+          <X className="w-3.5 h-3.5" />
+        </button>
+      )}
     </div>
   );
 };

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -154,6 +154,18 @@ export interface ClusterEnvironment {
   provider: string;
   distro: string;
   node_os: string;
+  /**
+   * Whether a NetworkPolicy would actually be enforced in this cluster:
+   * 'enforced' | 'unenforced' | 'mixed' | 'unknown'.
+   *
+   * Separate from `cni` because the two are orthogonal. AWS VPC CNI
+   * supports NetworkPolicy only when explicitly enabled and ships with
+   * it off; with it off the CNI accepts a policy and silently ignores
+   * it. So knowing the CNI never answered whether a generated policy
+   * will do anything, which is the only question the operator actually
+   * has.
+   */
+  policy_enforcement: string;
   nodes: number;
 }
 
@@ -163,5 +175,6 @@ export const UNKNOWN_CLUSTER_ENVIRONMENT: ClusterEnvironment = {
   provider: 'unknown',
   distro: 'unknown',
   node_os: 'unknown',
+  policy_enforcement: 'unknown',
   nodes: 0,
 };

--- a/frontend/src/utils/cniPolicySupport.test.ts
+++ b/frontend/src/utils/cniPolicySupport.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest';
+import { policyTypeForFinding } from './findingPolicyType';
 import {
   recommendedPolicyType,
   enforcementAdvisory,
@@ -81,6 +82,26 @@ describe('enforcementAdvisory', () => {
           if (a) expect(a.detail).not.toMatch(/works on any CNI/i);
         }
       }
+    }
+  });
+});
+
+describe('one rule, one place', () => {
+  // The regression this guards is one I introduced and nearly shipped:
+  // findingPolicyType already encoded "cilium gets a CiliumNetworkPolicy,
+  // everything else gets a NetworkPolicy", and adding a second copy in
+  // recommendedPolicyType meant a CNI added to one would silently not be
+  // added to the other. They must agree by construction, not by memory.
+  it('findingPolicyType agrees with recommendedPolicyType for every CNI', () => {
+    for (const cni of ['cilium', 'aws-vpc-cni', 'calico', 'flannel', 'antrea', 'weave', 'unknown']) {
+      expect(policyTypeForFinding('denied-traffic', cni)).toBe(recommendedPolicyType(cni));
+      expect(policyTypeForFinding('would-deny', cni)).toBe(recommendedPolicyType(cni));
+    }
+  });
+
+  it('still routes a syscall finding to seccomp regardless of CNI', () => {
+    for (const cni of ['cilium', 'aws-vpc-cni', 'unknown']) {
+      expect(policyTypeForFinding('sensitive-syscalls', cni)).toBe('seccomp');
     }
   });
 });

--- a/frontend/src/utils/cniPolicySupport.test.ts
+++ b/frontend/src/utils/cniPolicySupport.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest';
+import {
+  recommendedPolicyType,
+  enforcementAdvisory,
+  isDismissible,
+  type PolicyType,
+} from './cniPolicySupport';
+
+const env = (cni: string, policy_enforcement: string) => ({ cni, policy_enforcement });
+
+describe('recommendedPolicyType', () => {
+  it('picks CiliumNetworkPolicy only where Cilium is the CNI', () => {
+    expect(recommendedPolicyType('cilium')).toBe('cilium');
+  });
+
+  it('picks standard NetworkPolicy for AWS VPC CNI', () => {
+    // The case this work exists for: VPC CNI enforces standard
+    // NetworkPolicy and has no idea what a CiliumNetworkPolicy is.
+    expect(recommendedPolicyType('aws-vpc-cni')).toBe('network');
+  });
+
+  it('picks standard NetworkPolicy for other CNIs and when unknown', () => {
+    for (const cni of ['calico', 'antrea', 'flannel', 'weave', 'unknown']) {
+      expect(recommendedPolicyType(cni)).toBe('network');
+    }
+  });
+});
+
+describe('enforcementAdvisory', () => {
+  it('says nothing when the CNI enforces the selected kind', () => {
+    expect(enforcementAdvisory('network', env('aws-vpc-cni', 'enforced'))).toBeNull();
+    expect(enforcementAdvisory('cilium', env('cilium', 'enforced'))).toBeNull();
+  });
+
+  it('never comments on seccomp, which the CNI has no bearing on', () => {
+    expect(enforcementAdvisory('seccomp', env('flannel', 'unenforced'))).toBeNull();
+  });
+
+  it('escalates to error when the policy would be silently inert', () => {
+    // The core bug. Applying succeeds, kubectl shows the object, and
+    // nothing is restricted — so this must not read like a style note.
+    const a = enforcementAdvisory('network', env('aws-vpc-cni', 'unenforced'));
+    expect(a?.severity).toBe('error');
+    expect(a?.detail).toMatch(/no traffic will be restricted/i);
+    expect(isDismissible(a!)).toBe(false);
+  });
+
+  it('escalates to error on a split fleet, where placement decides', () => {
+    const a = enforcementAdvisory('network', env('aws-vpc-cni', 'mixed'));
+    expect(a?.severity).toBe('error');
+    expect(isDismissible(a!)).toBe(false);
+  });
+
+  it('is honest rather than reassuring when enforcement is unknown', () => {
+    const a = enforcementAdvisory('network', env('unknown', 'unknown'));
+    expect(a?.severity).toBe('info');
+    expect(a?.detail).toMatch(/could not establish/i);
+    expect(isDismissible(a!)).toBe(true);
+  });
+
+  it('warns on a Cilium policy where Cilium is not the CNI', () => {
+    const a = enforcementAdvisory('cilium', env('aws-vpc-cni', 'enforced'));
+    expect(a?.severity).toBe('warning');
+    expect(a?.title).toContain('aws-vpc-cni');
+  });
+
+  it('does not claim a Cilium mismatch when the CNI is unknown', () => {
+    // No signal means behave as before, not guess.
+    expect(enforcementAdvisory('cilium', env('unknown', 'unknown'))).toBeNull();
+  });
+
+  it('never tells the operator a standard policy works everywhere', () => {
+    // Regression guard on the exact false-assurance text this replaced:
+    // "A standard Network Policy works on any CNI." It does not — it
+    // works where the CNI enforces it, which is the whole point.
+    const types: PolicyType[] = ['network', 'cilium', 'seccomp'];
+    for (const t of types) {
+      for (const c of ['cilium', 'aws-vpc-cni', 'calico', 'flannel', 'unknown']) {
+        for (const e of ['enforced', 'unenforced', 'mixed', 'unknown']) {
+          const a = enforcementAdvisory(t, env(c, e));
+          if (a) expect(a.detail).not.toMatch(/works on any CNI/i);
+        }
+      }
+    }
+  });
+});

--- a/frontend/src/utils/cniPolicySupport.ts
+++ b/frontend/src/utils/cniPolicySupport.ts
@@ -1,0 +1,134 @@
+import type { ClusterEnvironment } from '../types';
+
+/**
+ * Which policy kinds a cluster can actually enforce, and what to warn
+ * the operator about when it cannot.
+ *
+ * Two facts drive every decision here, and they are independent:
+ *
+ *  1. WHICH policy kind the CNI understands. Only Cilium reads
+ *     CiliumNetworkPolicy; applying one anywhere else either fails
+ *     because the CRD is absent, or — worse — succeeds against a CRD
+ *     some other operator installed and is then read by nobody.
+ *
+ *  2. WHETHER the CNI enforces policy at all. This is the one that
+ *     used to be missed. AWS VPC CNI supports NetworkPolicy only when
+ *     explicitly enabled and ships with it OFF; with it off it accepts
+ *     the policy and silently ignores it, so `kubectl apply` succeeds,
+ *     `kubectl get` shows the object, and nothing is enforced. Flannel
+ *     never enforces. Cilium and Calico can be installed with policy
+ *     disabled.
+ *
+ * The previous notice collapsed the two, telling operators that "a
+ * standard Network Policy works on any CNI". That is false, and it is
+ * false in the most damaging direction available to this product:
+ * kguardian's value is that observed-absence means safe-to-deny, so an
+ * operator who trusts an inert policy believes they have restricted a
+ * workload that is in fact wide open.
+ */
+
+export type PolicyType = 'network' | 'cilium' | 'seccomp';
+
+/** Ordered by how loudly the console should present it. */
+export type AdvisorySeverity = 'error' | 'warning' | 'info';
+
+export interface PolicyAdvisory {
+  severity: AdvisorySeverity;
+  /** Short lead-in, safe to render as a heading. */
+  title: string;
+  /** The specific consequence, in the operator's terms. */
+  detail: string;
+}
+
+/** CNIs that read CiliumNetworkPolicy. */
+const CILIUM_CNIS = new Set(['cilium']);
+
+/**
+ * The policy kind this cluster can enforce, used as the console's
+ * default selection.
+ *
+ * Everything that is not Cilium gets standard NetworkPolicy, including
+ * `unknown`: it is the portable kind, and it is what the cluster is
+ * most likely to understand. Note this says nothing about whether the
+ * policy will be ENFORCED — that is `enforcementAdvisory`'s job, and
+ * conflating them is the bug this module exists to fix.
+ */
+export function recommendedPolicyType(cni: string): PolicyType {
+  return CILIUM_CNIS.has(cni) ? 'cilium' : 'network';
+}
+
+/**
+ * What to tell the operator about the policy kind they are looking at,
+ * or null when there is nothing worth saying.
+ *
+ * Deliberately returns a value rather than rendering: the same decision
+ * drives a banner, a tab badge and the assistant's wording, and three
+ * copies of this reasoning would drift.
+ */
+export function enforcementAdvisory(
+  policyType: PolicyType,
+  env: Pick<ClusterEnvironment, 'cni' | 'policy_enforcement'>,
+): PolicyAdvisory | null {
+  const { cni, policy_enforcement: enforcement } = env;
+
+  // Seccomp is a kubelet concern; the CNI has no bearing on it.
+  if (policyType === 'seccomp') return null;
+
+  if (policyType === 'cilium' && cni !== 'unknown' && !CILIUM_CNIS.has(cni)) {
+    return {
+      severity: 'warning',
+      title: `Cluster CNI detected as ${cni}`,
+      detail:
+        'Only Cilium reads CiliumNetworkPolicy. Here the CRD is likely absent, so the apply fails — ' +
+        'or it is present from another install and the policy is read by nobody. Export stays enabled ' +
+        'in case this YAML is destined for a different cluster.',
+    };
+  }
+
+  if (policyType === 'network') {
+    if (enforcement === 'unenforced') {
+      return {
+        severity: 'error',
+        title: 'This cluster will not enforce this policy',
+        detail:
+          `The ${cni === 'unknown' ? 'detected CNI' : cni} is not enforcing NetworkPolicy. ` +
+          'Applying this will succeed and the object will show up in kubectl, but no traffic will be ' +
+          'restricted. On AWS VPC CNI, enforcement is off by default and is enabled with ' +
+          '--enable-network-policy on the node agent.',
+      };
+    }
+    if (enforcement === 'mixed') {
+      return {
+        severity: 'error',
+        title: 'Enforcement is inconsistent across nodes',
+        detail:
+          'Some nodes enforce NetworkPolicy and others do not, so this policy will restrict a pod on ' +
+          'one node and not on another. Which you get depends on where the pod is scheduled.',
+      };
+    }
+    if (enforcement === 'unknown') {
+      return {
+        severity: 'info',
+        title: 'Enforcement could not be determined',
+        detail:
+          'kguardian could not establish whether this cluster enforces NetworkPolicy. Confirm before ' +
+          'relying on this policy to restrict anything.',
+      };
+    }
+  }
+
+  return null;
+}
+
+/**
+ * True when the console should treat the advisory as blocking enough to
+ * keep in front of the operator rather than let them dismiss it.
+ *
+ * An inert policy is not a style note: the operator's whole reason for
+ * being here is to restrict a workload, and dismissing the one message
+ * saying it will not be restricted defeats the purpose. Lesser
+ * advisories stay dismissible so the console does not nag.
+ */
+export function isDismissible(advisory: PolicyAdvisory): boolean {
+  return advisory.severity !== 'error';
+}

--- a/frontend/src/utils/findingPolicyType.ts
+++ b/frontend/src/utils/findingPolicyType.ts
@@ -1,4 +1,5 @@
 import type { PolicyType } from '../hooks/policyEditor/usePolicyExport';
+import { recommendedPolicyType } from './cniPolicySupport';
 
 /** The kinds of finding the Findings view surfaces per workload. */
 export type FindingKind = 'denied-traffic' | 'sensitive-syscalls' | 'egress-fanout' | 'would-deny';
@@ -12,5 +13,8 @@ export type FindingKind = 'denied-traffic' | 'sensitive-syscalls' | 'egress-fano
  */
 export function policyTypeForFinding(kind: FindingKind, cni: string = 'unknown'): PolicyType {
   if (kind === 'sensitive-syscalls') return 'seccomp';
-  return cni === 'cilium' ? 'cilium' : 'network';
+  // Delegated, not restated. This rule also decides the Policy Builder's
+  // default tab, and two copies of "which kind can this cluster enforce"
+  // drift the moment a CNI is added to one and not the other.
+  return recommendedPolicyType(cni);
 }

--- a/llm-bridge/src/tools/backendClient.ts
+++ b/llm-bridge/src/tools/backendClient.ts
@@ -62,26 +62,56 @@ export function auditVerdictsQuery(args: {
 // --- cluster environment -------------------------------------------
 
 /**
- * The cluster's detected CNI from GET /cluster/environment, cached
- * (success ~5min, failure ~60s). Every failure — older broker 404,
- * timeout, junk — resolves to "unknown", which callers MUST treat as
- * "no signal, behave as before". Never throws.
+ * The cluster's detected CNI and whether it enforces NetworkPolicy,
+ * from GET /cluster/environment, cached (success ~5min, failure ~60s).
+ * Every failure — older broker 404, timeout, junk — resolves to
+ * "unknown", which callers MUST treat as "no signal, behave as
+ * before". Never throws.
+ *
+ * The two fields answer different questions and both matter. Which CNI
+ * decides whether a CiliumNetworkPolicy is even readable here;
+ * enforcement decides whether ANY policy does something. AWS VPC CNI
+ * supports NetworkPolicy only when explicitly enabled and ships with it
+ * off, in which case it accepts the object and silently ignores it, so
+ * "the CNI is X" has never been enough to tell an operator their policy
+ * will take effect.
  */
 const CNI_TTL_OK_MS = 5 * 60_000;
 const CNI_TTL_ERR_MS = 60_000;
-let cniCache: { value: string; expires: number } | null = null;
 
-export async function clusterCni(): Promise<string> {
+export interface ClusterPolicySupport {
+  cni: string;
+  /** 'enforced' | 'unenforced' | 'mixed' | 'unknown' */
+  enforcement: string;
+}
+
+let cniCache: { value: ClusterPolicySupport; expires: number } | null = null;
+
+export async function clusterPolicySupport(): Promise<ClusterPolicySupport> {
   const now = Date.now();
   if (cniCache && now < cniCache.expires) return cniCache.value;
+  const str = (v: unknown) => (typeof v === "string" && v.length > 0 ? v : "unknown");
   try {
-    const env = (await brokerGetJSON("/cluster/environment")) as { cni?: unknown };
-    const cni = typeof env.cni === "string" && env.cni.length > 0 ? env.cni : "unknown";
-    cniCache = { value: cni, expires: now + CNI_TTL_OK_MS };
+    const env = (await brokerGetJSON("/cluster/environment")) as {
+      cni?: unknown;
+      policy_enforcement?: unknown;
+    };
+    cniCache = {
+      value: { cni: str(env.cni), enforcement: str(env.policy_enforcement) },
+      expires: now + CNI_TTL_OK_MS,
+    };
   } catch {
-    cniCache = { value: "unknown", expires: now + CNI_TTL_ERR_MS };
+    cniCache = {
+      value: { cni: "unknown", enforcement: "unknown" },
+      expires: now + CNI_TTL_ERR_MS,
+    };
   }
   return cniCache.value;
+}
+
+/** Back-compat shim for callers that only care which CNI is installed. */
+export async function clusterCni(): Promise<string> {
+  return (await clusterPolicySupport()).cni;
 }
 
 /** Test hook: clear the CNI cache. */

--- a/llm-bridge/src/tools/backendClient.ts
+++ b/llm-bridge/src/tools/backendClient.ts
@@ -109,10 +109,6 @@ export async function clusterPolicySupport(): Promise<ClusterPolicySupport> {
   return cniCache.value;
 }
 
-/** Back-compat shim for callers that only care which CNI is installed. */
-export async function clusterCni(): Promise<string> {
-  return (await clusterPolicySupport()).cni;
-}
 
 /** Test hook: clear the CNI cache. */
 export function resetClusterCniCache(): void {

--- a/llm-bridge/src/tools/clusterCni.test.ts
+++ b/llm-bridge/src/tools/clusterCni.test.ts
@@ -2,7 +2,7 @@ import { test, before, after, beforeEach } from "node:test";
 import assert from "node:assert/strict";
 import http from "node:http";
 import type { AddressInfo } from "node:net";
-import { clusterCni, resetClusterCniCache } from "./backendClient.js";
+import { clusterPolicySupport, resetClusterCniCache } from "./backendClient.js";
 
 // clusterCni backs the CNI-aligned policy generation (issue #1413).
 // The contract under test: cached, and EVERY failure degrades to
@@ -41,17 +41,17 @@ beforeEach(() => {
 
 test("returns the broker's cni and caches the success", async () => {
   responses = [{ status: 200, body: { cni: "calico", nodes: 3 } }];
-  assert.equal(await clusterCni(), "calico");
-  assert.equal(await clusterCni(), "calico"); // served from cache
+  assert.equal((await clusterPolicySupport()).cni, "calico");
+  assert.equal((await clusterPolicySupport()).cni, "calico"); // served from cache
   assert.equal(hits, 1);
 });
 
 test("older broker 404 degrades to unknown, never throws", async () => {
   responses = [{ status: 404 }];
-  assert.equal(await clusterCni(), "unknown");
+  assert.equal((await clusterPolicySupport()).cni, "unknown");
 });
 
 test("malformed body degrades to unknown", async () => {
   responses = [{ status: 200, body: { nodes: 3 } }];
-  assert.equal(await clusterCni(), "unknown");
+  assert.equal((await clusterPolicySupport()).cni, "unknown");
 });

--- a/llm-bridge/src/tools/cniMismatch.test.ts
+++ b/llm-bridge/src/tools/cniMismatch.test.ts
@@ -89,7 +89,7 @@ test("unknown CNI (older broker 404) leaves output untouched", async () => {
   assert.ok(!res.text.startsWith("# WARNING"));
 });
 
-test("kubernetes policy is never annotated regardless of CNI", async () => {
+test("kubernetes policy is not annotated on the CNI alone", async () => {
   cniResponse = { status: 200, body: { cni: "calico" } };
   const res = await executeInProcessTool("generate_network_policy", {
     pod_name: "web-1",
@@ -98,4 +98,67 @@ test("kubernetes policy is never annotated regardless of CNI", async () => {
   assert.equal(res.isError, false, res.text);
   assert.ok(!res.text.startsWith("# WARNING"));
   assert.ok(res.text.includes("kind: NetworkPolicy"));
+});
+
+// Enforcement is a separate question from which CNI is installed, and
+// it is the one that was missing. AWS VPC CNI supports NetworkPolicy
+// only when explicitly enabled and ships with it off, in which case it
+// accepts the object and silently ignores it. The tool used to advise
+// switching to "a policy any CNI enforces", which does not exist.
+
+test("a kubernetes policy on a non-enforcing cluster is warned about", async () => {
+  cniResponse = {
+    status: 200,
+    body: { cni: "aws-vpc-cni", policy_enforcement: "unenforced" },
+  };
+  const res = await executeInProcessTool("generate_network_policy", {
+    pod_name: "web-1",
+    policy_type: "kubernetes",
+  });
+  assert.equal(res.isError, false, res.text);
+  assert.ok(res.text.includes("NOT enforcing NetworkPolicy"), res.text.slice(0, 200));
+  assert.ok(res.text.includes("no traffic will be restricted"), res.text.slice(0, 300));
+  // The policy itself must still be produced intact: the operator may
+  // be generating it to apply after turning enforcement on.
+  assert.ok(res.text.includes("kind: NetworkPolicy"));
+});
+
+test("a split fleet is warned about, since placement decides the outcome", async () => {
+  cniResponse = {
+    status: 200,
+    body: { cni: "aws-vpc-cni", policy_enforcement: "mixed" },
+  };
+  const res = await executeInProcessTool("generate_network_policy", {
+    pod_name: "web-1",
+    policy_type: "kubernetes",
+  });
+  assert.ok(res.text.includes("inconsistent across nodes"), res.text.slice(0, 200));
+});
+
+test("an enforcing cluster gets no warning", async () => {
+  cniResponse = {
+    status: 200,
+    body: { cni: "aws-vpc-cni", policy_enforcement: "enforced" },
+  };
+  const res = await executeInProcessTool("generate_network_policy", {
+    pod_name: "web-1",
+    policy_type: "kubernetes",
+  });
+  assert.ok(!res.text.startsWith("# WARNING"), res.text.slice(0, 200));
+});
+
+test("the cilium advice no longer claims any CNI enforces a kubernetes policy", async () => {
+  // Regression guard on the exact false-assurance wording this
+  // replaced: "Use policy_type 'kubernetes' for a policy any CNI
+  // enforces." A NetworkPolicy is enforced only where the CNI enforces
+  // policy, which is the whole reason enforcement is reported.
+  cniResponse = {
+    status: 200,
+    body: { cni: "aws-vpc-cni", policy_enforcement: "unenforced" },
+  };
+  const res = await executeInProcessTool("generate_network_policy", {
+    pod_name: "web-1",
+    policy_type: "cilium",
+  });
+  assert.ok(!/any CNI enforces/i.test(res.text), res.text.slice(0, 300));
 });

--- a/llm-bridge/src/tools/execute.ts
+++ b/llm-bridge/src/tools/execute.ts
@@ -1,6 +1,6 @@
 import { log } from "../logger.js";
 import { TOOL_DEFS } from "./registry.js";
-import { brokerGetJSON, auditVerdictsQuery, clusterCni } from "./backendClient.js";
+import { brokerGetJSON, auditVerdictsQuery, clusterPolicySupport } from "./backendClient.js";
 import {
   filterByNamespace, compactTrafficSummary, compactPodsSummary, filterAlivePods, compactSvc,
 } from "./compaction.js";
@@ -102,17 +102,31 @@ const handlers: Record<string, Handler> = {
     // Align with the cluster CNI (issue #1413): never refuse and never
     // silently switch kinds — annotate, so the model (or a scripted
     // caller) sees the mismatch in the result and can self-correct.
-    // clusterCni() degrades to "unknown" on any failure, which leaves
+    // clusterPolicySupport() degrades to "unknown" on any failure, leaving
     // the output byte-identical to pre-detection behavior (the parity
     // and G2 fixtures pin exactly that).
-    if (type === "cilium") {
-      const cni = await clusterCni();
-      if (cni !== "unknown" && cni !== "cilium") {
-        return `# WARNING: cluster CNI detected as '${cni}' — the CiliumNetworkPolicy CRD is likely unavailable here, and only Cilium enforces it. Use policy_type 'kubernetes' for a policy any CNI enforces.
-${yaml}`;
-      }
+    const { cni, enforcement } = await clusterPolicySupport();
+    const warnings: string[] = [];
+    if (type === "cilium" && cni !== "unknown" && cni !== "cilium") {
+      warnings.push(
+        `# WARNING: cluster CNI detected as '${cni}' — the CiliumNetworkPolicy CRD is likely unavailable here, and only Cilium reads it. A standard Kubernetes NetworkPolicy is the portable kind, but see the enforcement note below before assuming it will take effect.`,
+      );
     }
-    return yaml;
+    // The enforcement warning is the one that used to be missing, and
+    // its absence let this tool tell an operator to switch to a
+    // "policy any CNI enforces" — which does not exist. A NetworkPolicy
+    // is enforced only where the CNI enforces policy, and AWS VPC CNI
+    // ships with enforcement off, accepting the object and ignoring it.
+    if (enforcement === "unenforced") {
+      warnings.push(
+        `# WARNING: this cluster is NOT enforcing NetworkPolicy (cni '${cni}'). Applying this will succeed and kubectl will show the object, but no traffic will be restricted. On AWS VPC CNI, enable it with --enable-network-policy on the node agent.`,
+      );
+    } else if (enforcement === "mixed") {
+      warnings.push(
+        `# WARNING: NetworkPolicy enforcement is inconsistent across nodes in this cluster, so this policy will restrict a pod on one node and not on another depending on where it is scheduled.`,
+      );
+    }
+    return warnings.length > 0 ? `${warnings.join("\n")}\n${yaml}` : yaml;
   },
   // Seccomp is generated in-process from the pod's observed syscalls — no
   // advisor hop. Returned as pretty JSON; the profile is G2-locked to


### PR DESCRIPTION
`cni()` only recognised CNIs that stamp an annotation on the Node. AWS VPC CNI stamps none, so every EKS cluster running the default CNI reported `unknown` and the policy builder had nothing to align with. It is now identified from its node agent pod, which the controller can already read: the DaemonSet is labelled `k8s-app=aws-node` and the `aws-eks-nodeagent` container carries `--enable-network-policy` in its arguments. Reading the pod rather than the DaemonSet avoids a new ClusterRole rule for no benefit, since a pod carries the same container arguments its template does.

The more important half is that knowing the CNI never answered the operator's actual question. AWS VPC CNI supports NetworkPolicy only when explicitly enabled and ships with it off, and with it off the CNI accepts a policy and silently ignores it: `kubectl apply` succeeds, `kubectl get` shows the object, nothing is restricted. Cilium and Calico can also be installed with policy disabled, and flannel never enforces. So enforcement is reported as its own field, and the console now distinguishes a policy that will take effect, one that will be silently inert, and a cluster where it could not be established. It is aggregated by rule rather than by the most-common vote used for the other fields: a fleet where some nodes enforce and others do not reports `mixed`, because averaging that away hides the state where a policy is live on part of the cluster and inert on the rest.

This also fixes a false-assurance bug in both consumers. The console told operators "a standard Network Policy works on any CNI" and the assistant advised switching to `policy_type: kubernetes` "for a policy any CNI enforces". Neither is true, and for a tool whose promise is that observed-absence means safe-to-deny, telling someone their policy works when it is inert is the most damaging thing it can say. The builder now defaults to the kind the cluster can enforce rather than warning after the fact, an inert policy raises an alert that cannot be dismissed, and export is still never blocked because the YAML may be destined for a different cluster.

Verified on a live EKS cluster running VPC CNI with `--enable-network-policy=true` and `NETWORK_POLICY_ENFORCING_MODE=standard`, which is what grounded the detection. 211 controller tests, 267 broker, 234 frontend, 179 llm-bridge; clippy `-D warnings`, `cargo fmt` and both lint/typecheck suites clean. Detection for Cilium and Calico enforcement is deliberately left as `unknown` rather than assumed from their defaults; probing their agents the way this probes VPC CNI's is the obvious follow-up.