### PR TITLE
fix: say why a connection was blocked instead of assuming a policy did it

### DIFF
--- a/broker/db/migrations/2026-09-07-140000_pod_traffic_drop_cause/down.sql
+++ b/broker/db/migrations/2026-09-07-140000_pod_traffic_drop_cause/down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE pod_traffic DROP COLUMN IF EXISTS syn_retries;
+ALTER TABLE pod_traffic DROP COLUMN IF EXISTS drop_cause;

--- a/broker/db/migrations/2026-09-07-140000_pod_traffic_drop_cause/up.sql
+++ b/broker/db/migrations/2026-09-07-140000_pod_traffic_drop_cause/up.sql
@@ -1,0 +1,38 @@
+-- Why a flow was recorded as dropped, and the evidence behind it.
+--
+-- `decision = 'DROP'` came from netpolicy_drop.bpf.c, which reports a
+-- flow when a TCP handshake retransmits its SYN four times without
+-- reaching ESTABLISHED. That is an honest observation of silence, but
+-- the probe cannot see WHY the handshake failed, and every layer above
+-- it presented the result as a policy denial: the file name, this
+-- column, the "Network Policy Drop" log line, the `denied-traffic`
+-- finding in the UI.
+--
+-- Nothing in kguardian read a NetworkPolicy object, so it could not
+-- have known. In a cluster with no policies at all, every reported
+-- "policy drop" is definitionally something else — a port nothing
+-- listens on and blackholes, a security group, a route, an overloaded
+-- peer — and an operator sent to audit their policies is sent nowhere.
+--
+-- `drop_cause` carries the classification the evaluator derives from the
+-- policies actually installed:
+--   'no-policy'      no NetworkPolicy governs this pod in this
+--                    direction, so a policy cannot be the cause. The
+--                    useful answer, because it is conclusive.
+--   'policy-governs' a policy does select this pod, so a denial is
+--                    plausible. A lead, not a confirmation.
+--   'unknown'        coverage could not be established (evaluator not
+--                    deployed, RBAC missing, cache not synced). Must
+--                    never be presented as either of the above.
+-- NULL means the row predates this column, which reads the same as
+-- 'unknown' but stays distinguishable from a row that was classified.
+ALTER TABLE pod_traffic ADD COLUMN IF NOT EXISTS drop_cause VARCHAR;
+
+-- SYN retransmissions observed before the flow was reported. The probe
+-- has always captured this and the controller logged it, but it was
+-- never stored — so the one piece of evidence an operator could use to
+-- judge a drop was discarded at the boundary. Four retries is roughly
+-- seven seconds of trying, which also catches a peer that is alive but
+-- overloaded; seeing 4 versus 40 is the difference between "slow" and
+-- "blackholed".
+ALTER TABLE pod_traffic ADD COLUMN IF NOT EXISTS syn_retries INTEGER;

--- a/broker/src/audit.rs
+++ b/broker/src/audit.rs
@@ -29,6 +29,13 @@ enum AuditInsertError {
     Diesel(#[from] diesel::result::Error),
 }
 
+/// Wire format of the evaluator's `GET /policy-coverage` reply.
+#[derive(Debug, serde::Deserialize)]
+struct PolicyCoverage {
+    /// "no-policy", "policy-governs" or "unknown".
+    cause: String,
+}
+
 /// Wire format consumed by `POST /evaluate` — must match
 /// `evaluator/pkg/matcher.Flow` exactly.
 #[derive(Debug, Serialize)]
@@ -356,10 +363,95 @@ impl AuditClient {
     /// caller: the audit dispatcher holds an `in_flight` permit for the duration
     /// of this call, so a large ingest burst can't create unbounded concurrent
     /// /evaluate round-trips. Called only by the in-crate dispatcher.
+    /// Ask the evaluator which policies govern this pod, and record the
+    /// answer on the row.
+    ///
+    /// Best-effort throughout. Every failure path leaves `drop_cause`
+    /// NULL, which readers treat exactly as `unknown` — the honest
+    /// answer when the evaluator is not deployed, lacks RBAC for
+    /// networkpolicies, or has not synced. It must never be allowed to
+    /// fail the ingest that produced the row.
+    async fn classify_drop(&self, pool: &DbPool, traffic: &PodTraffic) {
+        let (Some(ns), Some(name)) = (
+            traffic.pod_namespace.as_deref(),
+            traffic.pod_name.as_deref(),
+        ) else {
+            return;
+        };
+        // The drop probe only observes outbound connects, so the pod
+        // that owns the row is always the originator.
+        let url = format!("{}/policy-coverage", self.base_url.trim_end_matches('/'));
+        let cause = match self
+            .http
+            .get(&url)
+            // Built as query parameters rather than interpolated so a
+            // pod or namespace name is escaped by the client rather
+            // than trusted into a URL.
+            .query(&[("namespace", ns), ("pod", name), ("direction", "Egress")])
+            .send()
+            .await
+        {
+            Ok(r) if r.status().is_success() => match r.json::<PolicyCoverage>().await {
+                Ok(c) => c.cause,
+                Err(e) => {
+                    debug!(error = %e, "policy-coverage body was not JSON; drop cause stays unknown");
+                    return;
+                }
+            },
+            Ok(r) => {
+                // A 404 is an evaluator older than this endpoint, which
+                // is expected during a rollout rather than an incident.
+                debug!(status = %r.status(), "policy-coverage unavailable; drop cause stays unknown");
+                return;
+            }
+            Err(e) => {
+                debug!(error = %e, "policy-coverage unreachable; drop cause stays unknown");
+                return;
+            }
+        };
+
+        let pool = pool.clone();
+        let uuid = traffic.uuid.clone();
+        let cause_for_db = cause.clone();
+        let wrote = actix_web::rt::task::spawn_blocking(
+            move || -> Result<usize, Box<dyn std::error::Error + Send + Sync>> {
+                use crate::schema::pod_traffic::dsl as pt;
+                let mut conn = pool.get()?;
+                Ok(diesel::update(pt::pod_traffic.filter(pt::uuid.eq(uuid)))
+                    .set(pt::drop_cause.eq(Some(cause_for_db)))
+                    .execute(&mut conn)?)
+            },
+        )
+        .await;
+        match wrote {
+            Ok(Ok(_)) => debug!(cause = %cause, "drop cause recorded"),
+            Ok(Err(e)) => debug!(error = %e, "recording drop cause failed"),
+            Err(e) => debug!(error = %e, "drop cause task panicked"),
+        }
+    }
+
     pub(crate) async fn evaluate_and_persist(&self, pool: DbPool, traffic: PodTraffic) {
         if !self.enabled {
             return;
         }
+
+        // A dropped flow gets classified before anything else. The drop
+        // probe reports a TCP handshake that never completed and cannot
+        // see why, yet the row it produces has always been presented as
+        // a policy denial. Asking the evaluator which policies actually
+        // govern this pod turns that assertion into an answer — and in
+        // a cluster with no policies at all, into a conclusive "not
+        // this".
+        //
+        // Rides the audit queue on purpose: it is already bounded,
+        // already off the ingest hot path, and already capped for
+        // concurrency, so classification cannot back-pressure capture.
+        // Drops are a fraction of a percent of rows, so the added load
+        // is negligible.
+        if traffic.decision.as_deref() == Some("DROP") {
+            self.classify_drop(&pool, &traffic).await;
+        }
+
         let url = format!("{}/evaluate", self.base_url.trim_end_matches('/'));
 
         let flow = match build_flow_for_traffic(&traffic) {

--- a/broker/src/schema.rs
+++ b/broker/src/schema.rs
@@ -75,6 +75,10 @@ diesel::table! {
         peer_workload_kind -> Nullable<Varchar>,
         peer_workload_name -> Nullable<Varchar>,
         peer_resolved_at -> Nullable<Timestamp>,
+        // Drop classification and its evidence. Positional (Queryable),
+        // so these stay last too.
+        drop_cause -> Nullable<Varchar>,
+        syn_retries -> Nullable<Int4>,
     }
 }
 

--- a/broker/src/types.rs
+++ b/broker/src/types.rs
@@ -64,6 +64,32 @@ pub struct PodTraffic {
     /// When the identity was stamped; `None` whenever `peer_kind` is.
     #[serde(default)]
     pub peer_resolved_at: Option<NaiveDateTime>,
+    /// Why this flow was recorded as dropped: `no-policy`,
+    /// `policy-governs` or `unknown`.
+    ///
+    /// The drop probe reports a TCP handshake that retransmitted its SYN
+    /// four times without completing. It cannot see WHY, yet everything
+    /// above it called the result a policy denial — and nothing in
+    /// kguardian read a NetworkPolicy, so it could not have known. In a
+    /// cluster with no policies, every such row is definitionally
+    /// something else.
+    ///
+    /// The broker fills this from the evaluator's `/policy-coverage`
+    /// when a DROP row is ingested. `None` is a row that predates the
+    /// column and reads the same as `unknown`, while staying
+    /// distinguishable from one that was actually classified.
+    /// Positional (Queryable) — stays last, in schema order.
+    #[serde(default)]
+    pub drop_cause: Option<String>,
+    /// SYN retransmissions observed before the flow was reported.
+    ///
+    /// The probe has always captured this and the controller logged it,
+    /// but it was never stored, so the one piece of evidence an
+    /// operator could weigh was discarded. Four retries is about seven
+    /// seconds, which also catches an alive-but-overloaded peer: 4
+    /// versus 40 is the difference between slow and blackholed.
+    #[serde(default)]
+    pub syn_retries: Option<i32>,
 }
 
 #[derive(
@@ -261,4 +287,43 @@ pub struct NodeFact {
 /// doesn't send one; the broker stamps arrival time).
 fn chrono_now() -> NaiveDateTime {
     chrono::Utc::now().naive_utc()
+}
+
+#[cfg(test)]
+mod drop_wire_tests {
+    use super::*;
+
+    // The controller sends `syn_retries` as a u32 and the column is
+    // INTEGER, so the wire crosses a signedness boundary. Real values
+    // are single digits (the probe reports at 4), but pin the shape so
+    // a future widening does not silently start rejecting rows.
+    #[test]
+    fn a_drop_row_from_the_controller_deserialises() {
+        let json = r#"{
+            "uuid":"u1","pod_name":"web","pod_namespace":"prod","pod_ip":"10.0.0.1",
+            "pod_port":"0","ip_protocol":"TCP","traffic_type":"EGRESS",
+            "traffic_in_out_ip":"10.0.0.9","traffic_in_out_port":"443",
+            "decision":"DROP","time_stamp":"2026-09-07T00:00:00","syn_retries":4
+        }"#;
+        let t: PodTraffic = serde_json::from_str(json).expect("controller drop payload must parse");
+        assert_eq!(t.syn_retries, Some(4));
+        // Not classified at ingest: the audit worker fills this in
+        // afterwards, and until it does the row reads as "unknown".
+        assert_eq!(t.drop_cause, None);
+    }
+
+    #[test]
+    fn an_allow_row_without_the_field_still_deserialises() {
+        // Backwards compatibility with a controller that predates the
+        // field, which must keep working against a newer broker.
+        let json = r#"{
+            "uuid":"u2","pod_name":"web","pod_namespace":"prod","pod_ip":"10.0.0.1",
+            "pod_port":"8080","ip_protocol":"TCP","traffic_type":"INGRESS",
+            "traffic_in_out_ip":"10.0.0.9","traffic_in_out_port":"0",
+            "decision":"ALLOW","time_stamp":"2026-09-07T00:00:00"
+        }"#;
+        let t: PodTraffic = serde_json::from_str(json).expect("legacy payload must parse");
+        assert_eq!(t.syn_retries, None);
+        assert_eq!(t.drop_cause, None);
+    }
 }

--- a/broker/tests/read_memory_profile.rs
+++ b/broker/tests/read_memory_profile.rs
@@ -131,6 +131,10 @@ fn representative_row(i: usize) -> PodTraffic {
                 .and_hms_opt(12, 0, 1)
                 .unwrap(),
         ),
+        // An ALLOW row carries no drop classification; the widths below
+        // are what a real response holds for the common case.
+        drop_cause: None,
+        syn_retries: None,
     }
 }
 

--- a/charts/kguardian/templates/evaluator/clusterrole.yaml
+++ b/charts/kguardian/templates/evaluator/clusterrole.yaml
@@ -10,6 +10,16 @@ rules:
   - apiGroups: [""]
     resources: [pods, namespaces]
     verbs: [get, list, watch]
+  # Read the NetworkPolicies actually installed in the cluster, to
+  # classify a reported drop by whether one could have caused it. The
+  # drop probe observes a TCP handshake that never completed and cannot
+  # see why; without this the evaluator reports every drop cause as
+  # "unknown", which is honest but unhelpful. Read-only, and its own
+  # informer is deliberately excluded from the startup sync gate so an
+  # evaluator that rolls out ahead of this rule still starts.
+  - apiGroups: ["networking.k8s.io"]
+    resources: [networkpolicies]
+    verbs: [list, watch]
   # Watch the AuditNetworkPolicy CRDs via the dynamic client.
   - apiGroups: [kguardian.dev]
     resources: [auditnetworkpolicies, auditclusternetworkpolicies]

--- a/controller/src/models.rs
+++ b/controller/src/models.rs
@@ -178,6 +178,15 @@ pub struct PodTraffic {
     pub ip_protocol: Option<String>,
     pub decision: Option<String>,
     pub time_stamp: NaiveDateTime,
+    /// SYN retransmissions observed before a dropped flow was reported;
+    /// `None` for an ALLOW row, which has no such evidence.
+    ///
+    /// The drop probe has always captured this, but it stopped at the
+    /// process boundary, so the operator never saw whether a flow
+    /// retried four times or forty — the difference between a peer that
+    /// is merely slow and one whose packets are being discarded.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub syn_retries: Option<u32>,
 }
 
 #[derive(Debug, Default, Serialize)]

--- a/controller/src/network.rs
+++ b/controller/src/network.rs
@@ -359,6 +359,9 @@ async fn build_traffic_event(data: &NetworkEventData, pod_data: &PodInspect) -> 
         ip_protocol: Some(protocol.to_string()),
         decision: Some("ALLOW".to_string()),
         time_stamp: Utc::now().naive_utc(),
+        // An observed flow that completed has no retransmission
+        // evidence to carry.
+        syn_retries: None,
     };
 
     debug!("Adding traffic event to batch: {:?}", cache_key);
@@ -445,8 +448,14 @@ async fn build_policy_drop_event(
     let d_port = data.dport;
     let protocol_str = proto_to_string(data.protocol);
 
+    // Says what was observed, not what caused it. The probe sees a TCP
+    // handshake that retransmitted its SYN `syn_retries` times without
+    // reaching ESTABLISHED; it has no visibility into why. Calling this
+    // a "Network Policy Drop" sent operators to audit policies that in
+    // many clusters do not exist. The evaluator classifies the cause
+    // later, from the policies actually installed.
     debug!(
-        "Network Policy Drop: Pod: {}, Namespace: {:?}, Src: {}:{}, Dst: {}:{}, Protocol: {}, SYN Retries: {}",
+        "TCP connect never completed: Pod: {}, Namespace: {:?}, Src: {}:{}, Dst: {}:{}, Protocol: {}, SYN Retries: {}",
         pod_data.status.pod_name,
         pod_data.status.pod_namespace,
         s_ip,
@@ -498,6 +507,13 @@ async fn build_policy_drop_event(
         ip_protocol: Some(protocol_str),
         decision: Some("DROP".to_string()),
         time_stamp: Utc::now().naive_utc(),
+        // The probe has always captured this and the line above has
+        // always logged it, but it stopped at the process boundary, so
+        // the only evidence an operator could weigh never reached them.
+        // Four retries is roughly seven seconds of trying, which also
+        // catches a peer that is alive but overloaded: 4 versus 40 is
+        // the difference between slow and blackholed.
+        syn_retries: Some(data.syn_retries),
     };
 
     // Insert into cache immediately to prevent duplicates in same batch
@@ -820,6 +836,7 @@ mod tests {
             traffic_in_out_port: None,
             decision: None,
             time_stamp: chrono::NaiveDateTime::default(),
+            syn_retries: None,
         }
     }
 

--- a/evaluator/pkg/policycoverage/coverage.go
+++ b/evaluator/pkg/policycoverage/coverage.go
@@ -1,0 +1,145 @@
+// Package policycoverage answers one question about a real
+// networking.k8s.io NetworkPolicy set: could a policy have caused this?
+//
+// It exists because kguardian's drop signal asserted a cause it never
+// established. `netpolicy_drop.bpf.c` reports a flow when a TCP
+// handshake retransmits its SYN four times without reaching ESTABLISHED.
+// That is an honest observation of silence, but nothing downstream knew
+// WHY the handshake failed, and every layer — the file name, the
+// `decision: DROP` column, the "Network Policy Drop" log line, the
+// `denied-traffic` finding — presented it as a policy denial.
+//
+// The gap was that kguardian read no NetworkPolicy objects at all. It
+// could not have known: with zero policies in a cluster, every reported
+// "policy drop" is definitionally something else (a port nothing
+// listens on and blackholes, a security group, a route, an overloaded
+// peer), and an operator chasing a policy misconfiguration is chasing
+// nothing.
+//
+// This package does not try to decide whether a policy denied a
+// specific flow — the matcher already does per-flow evaluation for
+// AuditNetworkPolicy, and duplicating it here would drift. It answers
+// the cheaper, decisive question: does ANY policy govern this pod in
+// this direction? A "no" is conclusive and reclassifies the drop. A
+// "yes" is a genuine lead rather than a guess.
+package policycoverage
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+// Direction is the side of the flow being asked about.
+type Direction string
+
+const (
+	// Egress: the pod originated the connection. This is the direction
+	// the drop probe observes, since it hooks outbound connect and
+	// retransmit.
+	Egress Direction = "Egress"
+	// Ingress: the pod was the destination.
+	Ingress Direction = "Ingress"
+)
+
+// Cause classifies a reported drop by what the policy set makes
+// possible. Deliberately about possibility rather than certainty: the
+// probe cannot see a denial, so neither can this.
+type Cause string
+
+const (
+	// CauseNoPolicy: no NetworkPolicy governs this pod in this
+	// direction, so a policy cannot have caused the failure. The
+	// strongest and most useful answer, because it is conclusive and
+	// redirects the operator away from their policies entirely.
+	CauseNoPolicy Cause = "no-policy"
+	// CausePolicyGoverns: at least one policy selects this pod for this
+	// direction, so a denial is plausible. Not a confirmation — the
+	// policy may well permit this flow and the failure lie elsewhere.
+	CausePolicyGoverns Cause = "policy-governs"
+	// CauseUnknown: coverage could not be established — no RBAC for
+	// networkpolicies, the informer has not synced, or the evaluator is
+	// not deployed. Honest ignorance, and it must never be presented as
+	// either of the above.
+	CauseUnknown Cause = "unknown"
+)
+
+// Governs reports whether any policy in `policies` selects `pod` for
+// `dir`.
+//
+// `policies` must already be scoped to the pod's namespace: a
+// NetworkPolicy only ever selects pods in its own namespace, however
+// broad its peer rules are. Callers that pass a cluster-wide list will
+// get wrong answers, which is why the store's accessor is
+// namespace-keyed.
+func Governs(policies []*networkingv1.NetworkPolicy, pod *corev1.Pod, dir Direction) bool {
+	if pod == nil {
+		return false
+	}
+	podLabels := labels.Set(pod.Labels)
+	for _, p := range policies {
+		if p == nil || p.Namespace != pod.Namespace {
+			continue
+		}
+		if !governsDirection(p, dir) {
+			continue
+		}
+		sel, err := metav1.LabelSelectorAsSelector(&p.Spec.PodSelector)
+		if err != nil {
+			// A selector the API server accepted but we cannot parse.
+			// Counting it as governing is the safe direction: it keeps a
+			// possible cause visible instead of telling the operator
+			// their policies are definitively not involved.
+			return true
+		}
+		if sel.Matches(podLabels) {
+			return true
+		}
+	}
+	return false
+}
+
+// governsDirection applies the upstream policyTypes defaulting rule,
+// which is easy to get wrong and changes the answer.
+//
+// From the NetworkPolicy spec: when policyTypes is not set, Ingress is
+// always implied, and Egress is implied only if the policy has egress
+// rules. So an ingress-only policy with no policyTypes does NOT govern
+// egress, and treating an empty list as "governs everything" would make
+// every namespace with any policy look like it governed egress.
+func governsDirection(p *networkingv1.NetworkPolicy, dir Direction) bool {
+	if len(p.Spec.PolicyTypes) > 0 {
+		for _, t := range p.Spec.PolicyTypes {
+			if string(t) == string(dir) {
+				return true
+			}
+		}
+		return false
+	}
+	switch dir {
+	case Ingress:
+		return true
+	case Egress:
+		return len(p.Spec.Egress) > 0
+	default:
+		return false
+	}
+}
+
+// Classify turns a coverage answer into a Cause.
+//
+// `known` is false when the policy set could not be read at all, which
+// is a different answer from "read it and found nothing" and must not
+// collapse into CauseNoPolicy — that would tell an operator their
+// policies are definitively uninvolved on the strength of a failed API
+// call.
+func Classify(known bool, governs bool) Cause {
+	if !known {
+		return CauseUnknown
+	}
+	if governs {
+		return CausePolicyGoverns
+	}
+	return CauseNoPolicy
+}

--- a/evaluator/pkg/policycoverage/coverage_test.go
+++ b/evaluator/pkg/policycoverage/coverage_test.go
@@ -1,0 +1,187 @@
+package policycoverage
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func pod(ns, name string, lbls map[string]string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: name, Labels: lbls},
+	}
+}
+
+func policy(ns, name string, sel metav1.LabelSelector, types []networkingv1.PolicyType, egress bool) *networkingv1.NetworkPolicy {
+	p := &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: name},
+		Spec:       networkingv1.NetworkPolicySpec{PodSelector: sel, PolicyTypes: types},
+	}
+	if egress {
+		p.Spec.Egress = []networkingv1.NetworkPolicyEgressRule{{}}
+	}
+	return p
+}
+
+func matchApp(v string) metav1.LabelSelector {
+	return metav1.LabelSelector{MatchLabels: map[string]string{"app": v}}
+}
+
+// The reclassification this exists for: with no policies, a reported
+// drop cannot have been caused by one, so the operator should be sent
+// looking somewhere else entirely.
+func TestNoPoliciesNeverGoverns(t *testing.T) {
+	p := pod("prod", "web", map[string]string{"app": "web"})
+	if Governs(nil, p, Egress) {
+		t.Error("no policies must not govern")
+	}
+	if Governs([]*networkingv1.NetworkPolicy{}, p, Egress) {
+		t.Error("empty policy set must not govern")
+	}
+	if got := Classify(true, false); got != CauseNoPolicy {
+		t.Errorf("want %q, got %q", CauseNoPolicy, got)
+	}
+}
+
+func TestSelectorMatchingDecidesCoverage(t *testing.T) {
+	p := pod("prod", "web", map[string]string{"app": "web"})
+	governing := policy("prod", "np", matchApp("web"), []networkingv1.PolicyType{networkingv1.PolicyTypeEgress}, true)
+	other := policy("prod", "np2", matchApp("db"), []networkingv1.PolicyType{networkingv1.PolicyTypeEgress}, true)
+
+	if !Governs([]*networkingv1.NetworkPolicy{governing}, p, Egress) {
+		t.Error("a matching selector must govern")
+	}
+	if Governs([]*networkingv1.NetworkPolicy{other}, p, Egress) {
+		t.Error("a non-matching selector must not govern")
+	}
+}
+
+func TestEmptySelectorSelectsEveryPodInTheNamespace(t *testing.T) {
+	// {} is the default-deny idiom, and it is the single most likely
+	// policy to exist in a cluster that has any.
+	p := pod("prod", "web", map[string]string{"app": "web"})
+	all := policy("prod", "deny-all", metav1.LabelSelector{}, []networkingv1.PolicyType{networkingv1.PolicyTypeEgress}, false)
+	if !Governs([]*networkingv1.NetworkPolicy{all}, p, Egress) {
+		t.Error("an empty podSelector must select every pod in the namespace")
+	}
+}
+
+func TestAPolicyNeverReachesAnotherNamespace(t *testing.T) {
+	// A NetworkPolicy only selects pods in its own namespace, however
+	// broad its peer rules are. Getting this wrong would mark pods
+	// cluster-wide as governed the moment one namespace had a policy.
+	p := pod("prod", "web", map[string]string{"app": "web"})
+	elsewhere := policy("staging", "np", metav1.LabelSelector{}, []networkingv1.PolicyType{networkingv1.PolicyTypeEgress}, false)
+	if Governs([]*networkingv1.NetworkPolicy{elsewhere}, p, Egress) {
+		t.Error("a policy in another namespace must not govern")
+	}
+}
+
+// The upstream defaulting rule, which is the subtle part: absent
+// policyTypes implies Ingress always, and Egress only when egress rules
+// exist. Treating an empty list as "governs everything" would make
+// every namespace with any policy look like it governed egress, and the
+// drop probe only ever reports egress.
+func TestPolicyTypesDefaulting(t *testing.T) {
+	p := pod("prod", "web", map[string]string{"app": "web"})
+	sel := matchApp("web")
+
+	ingressOnly := policy("prod", "in", sel, nil, false)
+	if Governs([]*networkingv1.NetworkPolicy{ingressOnly}, p, Egress) {
+		t.Error("no policyTypes and no egress rules must NOT govern egress")
+	}
+	if !Governs([]*networkingv1.NetworkPolicy{ingressOnly}, p, Ingress) {
+		t.Error("no policyTypes always implies Ingress")
+	}
+
+	withEgressRules := policy("prod", "eg", sel, nil, true)
+	if !Governs([]*networkingv1.NetworkPolicy{withEgressRules}, p, Egress) {
+		t.Error("no policyTypes but egress rules present must govern egress")
+	}
+}
+
+func TestExplicitPolicyTypesAreHonouredExactly(t *testing.T) {
+	p := pod("prod", "web", map[string]string{"app": "web"})
+	sel := matchApp("web")
+
+	// Egress rules present but policyTypes says Ingress only: the
+	// explicit list wins and the egress rules are inert.
+	ingressDeclared := policy("prod", "np", sel, []networkingv1.PolicyType{networkingv1.PolicyTypeIngress}, true)
+	if Governs([]*networkingv1.NetworkPolicy{ingressDeclared}, p, Egress) {
+		t.Error("an explicit Ingress-only policyTypes must not govern egress")
+	}
+
+	both := policy("prod", "np", sel, []networkingv1.PolicyType{
+		networkingv1.PolicyTypeIngress, networkingv1.PolicyTypeEgress,
+	}, false)
+	if !Governs([]*networkingv1.NetworkPolicy{both}, p, Egress) {
+		t.Error("both types declared must govern egress")
+	}
+}
+
+func TestMatchExpressionsAreEvaluated(t *testing.T) {
+	// The reason this delegates to apimachinery rather than comparing
+	// maps by hand: matchExpressions is where a hand-rolled selector
+	// silently diverges from what the API server actually selects.
+	p := pod("prod", "web", map[string]string{"tier": "frontend"})
+	sel := metav1.LabelSelector{
+		MatchExpressions: []metav1.LabelSelectorRequirement{{
+			Key:      "tier",
+			Operator: metav1.LabelSelectorOpIn,
+			Values:   []string{"frontend", "edge"},
+		}},
+	}
+	in := policy("prod", "np", sel, []networkingv1.PolicyType{networkingv1.PolicyTypeEgress}, false)
+	if !Governs([]*networkingv1.NetworkPolicy{in}, p, Egress) {
+		t.Error("matchExpressions In must select a matching pod")
+	}
+
+	notIn := policy("prod", "np", metav1.LabelSelector{
+		MatchExpressions: []metav1.LabelSelectorRequirement{{
+			Key:      "tier",
+			Operator: metav1.LabelSelectorOpNotIn,
+			Values:   []string{"frontend"},
+		}},
+	}, []networkingv1.PolicyType{networkingv1.PolicyTypeEgress}, false)
+	if Governs([]*networkingv1.NetworkPolicy{notIn}, p, Egress) {
+		t.Error("matchExpressions NotIn must exclude a matching pod")
+	}
+}
+
+func TestAnyGoverningPolicyIsEnough(t *testing.T) {
+	p := pod("prod", "web", map[string]string{"app": "web"})
+	nonMatching := policy("prod", "a", matchApp("db"), []networkingv1.PolicyType{networkingv1.PolicyTypeEgress}, false)
+	matching := policy("prod", "b", matchApp("web"), []networkingv1.PolicyType{networkingv1.PolicyTypeEgress}, false)
+	if !Governs([]*networkingv1.NetworkPolicy{nonMatching, matching}, p, Egress) {
+		t.Error("one governing policy among several must be enough")
+	}
+}
+
+
+func TestClassifyKeepsIgnoranceDistinct(t *testing.T) {
+	// "read the policies and found none" and "could not read the
+	// policies" are different answers. Collapsing the second into the
+	// first would tell an operator their policies are definitively
+	// uninvolved on the strength of a failed API call.
+	if got := Classify(false, false); got != CauseUnknown {
+		t.Errorf("unknown coverage must stay unknown, got %q", got)
+	}
+	if got := Classify(false, true); got != CauseUnknown {
+		t.Errorf("unknown coverage must stay unknown, got %q", got)
+	}
+	if got := Classify(true, true); got != CausePolicyGoverns {
+		t.Errorf("want %q, got %q", CausePolicyGoverns, got)
+	}
+}
+
+func TestNilsAreSurvivable(t *testing.T) {
+	if Governs(nil, nil, Egress) {
+		t.Error("nil pod must not govern")
+	}
+	p := pod("prod", "web", nil)
+	if Governs([]*networkingv1.NetworkPolicy{nil}, p, Egress) {
+		t.Error("a nil policy entry must be skipped, not panic")
+	}
+}

--- a/evaluator/pkg/server/server.go
+++ b/evaluator/pkg/server/server.go
@@ -17,6 +17,8 @@ import (
 	"time"
 
 	"github.com/kguardian-dev/kguardian/evaluator/pkg/matcher"
+	"github.com/kguardian-dev/kguardian/evaluator/pkg/policycoverage"
+	networkingv1 "k8s.io/api/networking/v1"
 	"github.com/kguardian-dev/kguardian/evaluator/pkg/status"
 	v1alpha1 "github.com/kguardian-dev/kguardian/evaluator/pkg/v1alpha1"
 	"github.com/sirupsen/logrus"
@@ -29,6 +31,12 @@ type PolicyLookup interface {
 	matcher.Lookup
 	PoliciesInNamespace(ns string) []*v1alpha1.AuditNetworkPolicy
 	ClusterPolicies() []*v1alpha1.AuditClusterNetworkPolicy
+	// Real networking.k8s.io policies, for classifying a reported drop
+	// by whether one could have caused it. Separate from the
+	// AuditNetworkPolicy accessors above: those are policies the
+	// operator is trialling, these are the ones actually installed.
+	NetworkPoliciesInNamespace(ns string) []*networkingv1.NetworkPolicy
+	PolicyCoverageKnown() bool
 }
 
 // Server is the HTTP entry point.
@@ -56,6 +64,7 @@ func (s *Server) Start(ctx context.Context) error {
 	mux.HandleFunc("/healthz", s.handleHealth)
 	mux.HandleFunc("/readyz", s.handleReady)
 	mux.HandleFunc("/evaluate", s.handleEvaluate)
+	mux.HandleFunc("/policy-coverage", s.handlePolicyCoverage)
 
 	s.srv = &http.Server{
 		Addr:              s.addr,
@@ -184,4 +193,63 @@ func (s *Server) handleEvaluate(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 	_ = json.NewEncoder(w).Encode(EvaluateResponse{Results: results})
+}
+
+// PolicyCoverageResponse says whether a real NetworkPolicy could have
+// caused a reported drop for a given pod and direction.
+type PolicyCoverageResponse struct {
+	// Cause is "no-policy", "policy-governs" or "unknown".
+	Cause string `json:"cause"`
+}
+
+// handlePolicyCoverage answers "could a policy have caused this?" for
+// one pod and direction.
+//
+// Separate from /evaluate on purpose. /evaluate asks whether a specific
+// AuditNetworkPolicy would deny a specific flow, which is a per-flow
+// question against policies the operator is trialling. This asks a
+// coarser question against the policies actually installed: does
+// anything govern this pod at all? A "no" is conclusive and is the
+// answer that reclassifies a drop, and it needs none of the port,
+// protocol or peer matching /evaluate does.
+//
+// Never fails on missing coverage. An unsynced or unreadable
+// NetworkPolicy cache returns "unknown" with a 200, because the caller
+// is annotating a stored row rather than making a decision, and a 500
+// here would either lose the row or wedge the broker's ingest path.
+func (s *Server) handlePolicyCoverage(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	q := r.URL.Query()
+	ns := q.Get("namespace")
+	name := q.Get("pod")
+	dir := policycoverage.Direction(q.Get("direction"))
+	if ns == "" || name == "" {
+		http.Error(w, "namespace and pod are required", http.StatusBadRequest)
+		return
+	}
+	if dir != policycoverage.Egress && dir != policycoverage.Ingress {
+		http.Error(w, "direction must be Ingress or Egress", http.StatusBadRequest)
+		return
+	}
+
+	known := s.store.PolicyCoverageKnown()
+	pod := s.store.GetPod(ns, name)
+	// A pod we have never seen is not the same as a pod no policy
+	// governs: without its labels there is nothing to match a selector
+	// against, so the honest answer is that we cannot tell.
+	if pod == nil {
+		known = false
+	}
+	governs := false
+	if known {
+		governs = policycoverage.Governs(s.store.NetworkPoliciesInNamespace(ns), pod, dir)
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(PolicyCoverageResponse{
+		Cause: string(policycoverage.Classify(known, governs)),
+	})
 }

--- a/evaluator/pkg/server/server_test.go
+++ b/evaluator/pkg/server/server_test.go
@@ -24,7 +24,17 @@ type fakeLookup struct {
 	nsLabels    map[string]map[string]string
 	policies    map[string][]*v1alpha1.AuditNetworkPolicy
 	clusterPols []*v1alpha1.AuditClusterNetworkPolicy
+	// Real NetworkPolicies, for the drop-cause endpoint. `netpolKnown`
+	// models an unsynced or unreadable cache, which must stay
+	// distinguishable from a synced cache holding nothing.
+	netpols     map[string][]*networkingv1.NetworkPolicy
+	netpolKnown bool
 }
+
+func (f *fakeLookup) NetworkPoliciesInNamespace(ns string) []*networkingv1.NetworkPolicy {
+	return f.netpols[ns]
+}
+func (f *fakeLookup) PolicyCoverageKnown() bool { return f.netpolKnown }
 
 func (f *fakeLookup) GetPod(ns, name string) *corev1.Pod {
 	return f.pods[ns+"/"+name]
@@ -358,4 +368,121 @@ func tcpPort(p int32) networkingv1.NetworkPolicyPort {
 	tcp := corev1.ProtocolTCP
 	port := intstr.FromInt32(p)
 	return networkingv1.NetworkPolicyPort{Protocol: &tcp, Port: &port}
+}
+
+// --- policy coverage -------------------------------------------------
+//
+// The endpoint behind the drop-cause reclassification. kguardian used to
+// label every incomplete TCP handshake a policy drop without reading a
+// single NetworkPolicy, so in a cluster with none, every reported
+// "policy drop" was definitionally something else.
+
+func coverageServer(f *fakeLookup) *Server {
+	return New(":0", f, nil, logrus.New())
+}
+
+func coverageGet(t *testing.T, srv *Server, q string) (int, string) {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/policy-coverage?"+q, nil)
+	rec := httptest.NewRecorder()
+	srv.handlePolicyCoverage(rec, req)
+	return rec.Code, rec.Body.String()
+}
+
+func webPod() *corev1.Pod {
+	return &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+		Namespace: "prod", Name: "web", Labels: map[string]string{"app": "web"},
+	}}
+}
+
+func TestPolicyCoverageNoPolicyIsConclusive(t *testing.T) {
+	f := &fakeLookup{
+		pods:        map[string]*corev1.Pod{"prod/web": webPod()},
+		netpolKnown: true,
+	}
+	code, body := coverageGet(t, coverageServer(f), "namespace=prod&pod=web&direction=Egress")
+	if code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", code, body)
+	}
+	if !strings.Contains(body, `"cause":"no-policy"`) {
+		t.Errorf("a synced cache with no policies must be conclusive, got %s", body)
+	}
+}
+
+func TestPolicyCoverageGoverningPolicyIsReported(t *testing.T) {
+	f := &fakeLookup{
+		pods:        map[string]*corev1.Pod{"prod/web": webPod()},
+		netpolKnown: true,
+		netpols: map[string][]*networkingv1.NetworkPolicy{"prod": {{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "prod", Name: "np"},
+			Spec: networkingv1.NetworkPolicySpec{
+				PodSelector: metav1.LabelSelector{MatchLabels: map[string]string{"app": "web"}},
+				PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeEgress},
+			},
+		}}},
+	}
+	_, body := coverageGet(t, coverageServer(f), "namespace=prod&pod=web&direction=Egress")
+	if !strings.Contains(body, `"cause":"policy-governs"`) {
+		t.Errorf("want policy-governs, got %s", body)
+	}
+}
+
+func TestPolicyCoverageUnsyncedCacheIsUnknownNotNoPolicy(t *testing.T) {
+	// The failure this guards is the original bug arriving by a new
+	// route: an evaluator that cannot list networkpolicies would see an
+	// empty set and declare every drop definitively not policy-caused.
+	f := &fakeLookup{
+		pods:        map[string]*corev1.Pod{"prod/web": webPod()},
+		netpolKnown: false,
+	}
+	_, body := coverageGet(t, coverageServer(f), "namespace=prod&pod=web&direction=Egress")
+	if !strings.Contains(body, `"cause":"unknown"`) {
+		t.Errorf("an unsynced cache must be unknown, got %s", body)
+	}
+}
+
+func TestPolicyCoverageUnseenPodIsUnknown(t *testing.T) {
+	// No pod means no labels, so there is nothing to match a selector
+	// against. That is ignorance, not absence of policy.
+	f := &fakeLookup{netpolKnown: true}
+	_, body := coverageGet(t, coverageServer(f), "namespace=prod&pod=ghost&direction=Egress")
+	if !strings.Contains(body, `"cause":"unknown"`) {
+		t.Errorf("an unknown pod must be unknown, got %s", body)
+	}
+}
+
+func TestPolicyCoverageRejectsBadInput(t *testing.T) {
+	f := &fakeLookup{netpolKnown: true}
+	srv := coverageServer(f)
+	for _, q := range []string{
+		"pod=web&direction=Egress",              // no namespace
+		"namespace=prod&direction=Egress",       // no pod
+		"namespace=prod&pod=web",                // no direction
+		"namespace=prod&pod=web&direction=Both", // not a direction
+	} {
+		if code, _ := coverageGet(t, srv, q); code != http.StatusBadRequest {
+			t.Errorf("query %q: want 400, got %d", q, code)
+		}
+	}
+}
+
+func TestPolicyCoverageRejectsNonGet(t *testing.T) {
+	f := &fakeLookup{netpolKnown: true}
+	req := httptest.NewRequest(http.MethodPost, "/policy-coverage?namespace=prod&pod=web&direction=Egress", nil)
+	rec := httptest.NewRecorder()
+	coverageServer(f).handlePolicyCoverage(rec, req)
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Errorf("want 405, got %d", rec.Code)
+	}
+}
+
+func TestPolicyCoverageNeverFailsWhenCoverageIsMissing(t *testing.T) {
+	// The caller is annotating a stored row, not making a decision. A
+	// 500 here would either lose the row or wedge the broker's ingest
+	// path, so missing coverage must still be a 200.
+	f := &fakeLookup{netpolKnown: false}
+	code, _ := coverageGet(t, coverageServer(f), "namespace=prod&pod=ghost&direction=Ingress")
+	if code != http.StatusOK {
+		t.Errorf("want 200 even with no coverage, got %d", code)
+	}
 }

--- a/evaluator/pkg/store/store.go
+++ b/evaluator/pkg/store/store.go
@@ -16,13 +16,16 @@ import (
 	v1alpha1 "github.com/kguardian-dev/kguardian/evaluator/pkg/v1alpha1"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/dynamic/dynamicinformer"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+	networkinglisters "k8s.io/client-go/listers/networking/v1"
 	"k8s.io/client-go/tools/cache"
 )
 
@@ -35,6 +38,15 @@ type Store struct {
 	anpInformer  cache.SharedIndexInformer
 	acnpInformer cache.SharedIndexInformer
 	stopCh       chan struct{}
+
+	// Real networking.k8s.io NetworkPolicies, used to answer whether a
+	// policy could have caused a reported drop. A typed lister rather
+	// than the hand-maintained map the AuditNetworkPolicy informers
+	// need: those are dynamic/unstructured and must be converted on
+	// insert, whereas this one gives namespace-scoped listing for free
+	// and cannot drift from the informer's cache.
+	netpolInformer cache.SharedIndexInformer
+	netpolLister   networkinglisters.NetworkPolicyLister
 
 	policyMu sync.RWMutex
 	// policiesByNamespace caches the typed projection of the dynamic
@@ -74,10 +86,13 @@ func New(cfg *rest.Config, log *logrus.Logger) (*Store, error) {
 	factory := informers.NewSharedInformerFactory(kc, 30*time.Minute)
 	dynFactory := dynamicinformer.NewDynamicSharedInformerFactory(dc, 30*time.Minute)
 
+	netpols := factory.Networking().V1().NetworkPolicies()
 	s := &Store{
 		log:                 log,
 		podInformer:         factory.Core().V1().Pods().Informer(),
 		nsInformer:          factory.Core().V1().Namespaces().Informer(),
+		netpolInformer:      netpols.Informer(),
+		netpolLister:        netpols.Lister(),
 		anpInformer:         dynFactory.ForResource(AuditNetworkPolicyGVR).Informer(),
 		acnpInformer:        dynFactory.ForResource(AuditClusterNetworkPolicyGVR).Informer(),
 		stopCh:              make(chan struct{}),
@@ -116,7 +131,17 @@ func (s *Store) Start(ctx context.Context) error {
 	go s.nsInformer.Run(s.stopCh)
 	go s.anpInformer.Run(s.stopCh)
 	go s.acnpInformer.Run(s.stopCh)
+	go s.netpolInformer.Run(s.stopCh)
 
+	// The NetworkPolicy informer is started but deliberately EXCLUDED
+	// from the blocking sync set. It only enriches the drop signal, and
+	// the chart and image version independently, so an evaluator that
+	// rolled out ahead of the ClusterRole rule granting
+	// networkpolicies would never sync and would otherwise fail to
+	// start — taking audit evaluation down with it for the sake of a
+	// classification hint. Instead it never syncs, PolicyCoverageKnown
+	// stays false, and coverage reports "unknown", which is the honest
+	// answer.
 	if !cache.WaitForCacheSync(ctx.Done(),
 		s.podInformer.HasSynced,
 		s.nsInformer.HasSynced,
@@ -126,6 +151,10 @@ func (s *Store) Start(ctx context.Context) error {
 		return context.Canceled
 	}
 	s.log.Info("informer caches synced (pods, namespaces, auditnetworkpolicies, auditclusternetworkpolicies)")
+	if !s.netpolInformer.HasSynced() {
+		s.log.Warn("networkpolicy cache not synced yet; drop causes report as unknown until it is " +
+			"(missing RBAC on an older chart would keep it that way)")
+	}
 	return nil
 }
 
@@ -336,4 +365,32 @@ func (s *Store) GetNamespaceLabels(name string) map[string]string {
 		return map[string]string{}
 	}
 	return ns.Labels
+}
+
+// PolicyCoverageKnown reports whether the NetworkPolicy cache has
+// synced, and therefore whether a "no policy governs this pod" answer
+// can be trusted.
+//
+// Load-bearing: without it, an evaluator that cannot list
+// networkpolicies would report an empty policy set and every drop would
+// be classified as definitively not policy-caused. That is the same
+// false-confidence failure the drop signal already had, arriving by a
+// new route.
+func (s *Store) PolicyCoverageKnown() bool {
+	return s.netpolInformer.HasSynced()
+}
+
+// NetworkPoliciesInNamespace returns the real NetworkPolicies scoped to
+// one namespace. A NetworkPolicy only ever selects pods in its own
+// namespace, so callers must not widen this.
+func (s *Store) NetworkPoliciesInNamespace(ns string) []*networkingv1.NetworkPolicy {
+	if ns == "" {
+		return nil
+	}
+	list, err := s.netpolLister.NetworkPolicies(ns).List(labels.Everything())
+	if err != nil {
+		s.log.WithError(err).Debug("listing networkpolicies failed; drop cause will be unknown")
+		return nil
+	}
+	return list
 }

--- a/frontend/src/components/DataTable.tsx
+++ b/frontend/src/components/DataTable.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useMemo, useCallback } from 'react';
 import type { NetworkTraffic, PodInfo, PodNodeData, ServiceInfo } from '../types';
 import { ArrowRight, Activity, ChevronDown, ChevronRight, Filter, MousePointerClick, Inbox } from 'lucide-react';
 import { EmptyState } from './ui/EmptyState';
+import { describeDrop, isDrop } from '../utils/dropCause';
 import { displaySyscallList } from '../utils/syscalls';
 import { UNATTRIBUTED_PEER_TOOLTIP, buildPeerIndex, isPlaceholderPod, resolvePeer } from '../utils/peerResolution';
 
@@ -647,8 +648,19 @@ const DataTable: React.FC<DataTableProps> = ({ selectedPod, allPodsLookup, servi
                                 : traffic.decision === 'DROP'
                                 ? 'bg-hubble-error/20 text-hubble-error'
                                 : 'bg-hubble-border/30 text-secondary'
-                            }`}>
-                              {traffic.decision}
+                            }`}
+                            /* A DROP row means an outbound handshake never
+                               completed; the probe cannot see why. The
+                               title carries the classification so the
+                               badge stops implying a policy denied it. */
+                            title={
+                              isDrop(traffic.decision)
+                                ? describeDrop(traffic.drop_cause, traffic.syn_retries).detail
+                                : undefined
+                            }>
+                              {isDrop(traffic.decision)
+                                ? describeDrop(traffic.drop_cause, traffic.syn_retries).short
+                                : traffic.decision}
                             </span>
                           )}
                           {!traffic.decision && (

--- a/frontend/src/components/FindingsView.tsx
+++ b/frontend/src/components/FindingsView.tsx
@@ -96,7 +96,7 @@ function podLabel(pod: PodNodeData): string {
 
 /**
  * Triage home. Turns the raw graph into a ranked, human-first "what should I
- * look at" surface — denied flows, sensitive syscalls, and egress fan-out —
+ * look at" surface — blocked connections, sensitive syscalls, and egress fan-out —
  * computed entirely from data already loaded for the namespace, plus a
  * would-deny summary pulled from the audit evaluator. No invented scores: each
  * section is a concrete, explainable signal that links back into the map.
@@ -190,7 +190,7 @@ export function FindingsView({ pods, namespace, onSelectPod, onBuildPolicy, onOp
 
   const stats = [
     { label: 'Workloads', value: workloads.length, icon: ShieldCheck, tone: 'text-hubble-accent' },
-    { label: 'Denied flows', value: totalDrops, icon: ShieldAlert, tone: totalDrops > 0 ? 'text-hubble-error' : 'text-secondary' },
+    { label: 'Blocked connections', value: totalDrops, icon: ShieldAlert, tone: totalDrops > 0 ? 'text-hubble-error' : 'text-secondary' },
     { label: 'Sensitive syscalls', value: syscallFindings.length, icon: Terminal, tone: syscallFindings.length > 0 ? 'text-hubble-warning' : 'text-secondary' },
     { label: 'Egress fan-out', value: fanoutFindings.length, icon: Radar, tone: fanoutFindings.length > 0 ? 'text-hubble-warning' : 'text-secondary' },
   ];
@@ -228,7 +228,7 @@ export function FindingsView({ pods, namespace, onSelectPod, onBuildPolicy, onOp
             <EmptyState
               icon={ShieldCheck}
               title="No standout findings"
-              description="No denied flows, sensitive syscalls, or unusual egress fan-out in this namespace. Keep an eye on the map for changes."
+              description="No blocked connections, sensitive syscalls, or unusual egress fan-out in this namespace. Keep an eye on the map for changes."
             />
           </div>
         ) : (
@@ -268,7 +268,7 @@ export function FindingsView({ pods, namespace, onSelectPod, onBuildPolicy, onOp
 
             {/* Denied traffic */}
             {dropFindings.length > 0 && (
-              <Section icon={ShieldAlert} tone="text-hubble-error" title="Denied traffic" hint="Workloads with packets dropped by network policy">
+              <Section icon={ShieldAlert} tone="text-hubble-error" title="Blocked connections" hint="Outbound connections that never completed. The cause is shown per flow: a policy is only one possibility">
                 <ul className="divide-y divide-hubble-border">
                   {dropFindings.slice(0, 8).map(({ pod, drops }) => (
                     <FindingRow

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -71,6 +71,17 @@ export interface NetworkTraffic {
   traffic_in_out_port: string | null;
   decision: string | null; // ALLOW or DROP
   time_stamp: string;
+  /** Why a DROP row was recorded: 'no-policy' | 'policy-governs' |
+   *  'unknown'. Null on an ALLOW row, on a row written before
+   *  classification existed, or when the evaluator could not classify
+   *  it — all of which read as "cause unknown". The drop probe observes
+   *  only that a TCP handshake never completed; it cannot see why, so
+   *  never present a bare DROP as a policy denial. Use
+   *  `describeDrop` from utils/dropCause. */
+  drop_cause?: string | null;
+  /** SYN retransmissions before the flow was reported. The evidence
+   *  behind a drop: 4 retries is a slow peer, 40 is blackholed. */
+  syn_retries?: number | null;
   /** Peer identity stamped by the broker when the row was ingested (or by
    *  its late-resolve pass). Pod IPs are recycled constantly, so this — not
    *  a by-IP lookup at read time — is the authoritative peer. All null on a

--- a/frontend/src/utils/dropCause.test.ts
+++ b/frontend/src/utils/dropCause.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest';
+import { describeDrop, isDrop } from './dropCause';
+
+describe('describeDrop', () => {
+  it('states plainly that a policy is not the cause when none governs the pod', () => {
+    // The reclassification this exists for. In a cluster with no
+    // NetworkPolicies, every reported drop was labelled a policy denial
+    // and sent the operator to audit policies that did not exist.
+    const d = describeDrop('no-policy');
+    expect(d.policyPlausible).toBe(false);
+    expect(d.detail).toMatch(/cannot be the cause/i);
+    // And points somewhere useful instead.
+    expect(d.detail).toMatch(/security groups|routes|listening/i);
+  });
+
+  it('says "may have" rather than "did" when a policy governs the pod', () => {
+    // A governing policy is a lead, not a confirmation: the probe sees
+    // silence, never the denial.
+    const d = describeDrop('policy-governs');
+    expect(d.policyPlausible).toBe(true);
+    expect(d.detail).toMatch(/may have denied/i);
+    expect(d.detail).toMatch(/not the denial itself/i);
+  });
+
+  it('admits ignorance for an unclassified row', () => {
+    for (const cause of ['unknown', null, undefined]) {
+      const d = describeDrop(cause);
+      expect(d.short).toBe('Connection failed');
+      expect(d.detail).toMatch(/could not establish/i);
+    }
+  });
+
+  it('treats a legacy row and an unknown classification identically', () => {
+    // A row written before the column existed carries null, and that
+    // means the same thing to a reader as an explicit "unknown".
+    expect(describeDrop(null)).toEqual(describeDrop('unknown'));
+  });
+
+  it('never claims a policy denied the flow', () => {
+    // Regression guard on the wording this replaced. The probe cannot
+    // observe a denial, so no branch may assert one.
+    for (const cause of ['no-policy', 'policy-governs', 'unknown', null]) {
+      const d = describeDrop(cause, 4);
+      expect(d.detail).not.toMatch(/denied by (a )?NetworkPolicy\b(?! selects)/i);
+      expect(d.short).not.toMatch(/^Denied by policy$/i);
+    }
+  });
+
+  it('surfaces the retry evidence when there is any', () => {
+    // The probe always captured this and the controller logged it, but
+    // it was never stored, so the operator could not tell 4 retries
+    // (slow peer) from 40 (blackholed).
+    expect(describeDrop('unknown', 4).detail).toMatch(/retried 4 times/);
+    expect(describeDrop('no-policy', 12).detail).toMatch(/retried 12 times/);
+  });
+
+  it('omits the evidence clause when there is none', () => {
+    for (const n of [undefined, null, 0]) {
+      expect(describeDrop('unknown', n)).not.toHaveProperty('detail', expect.stringMatching(/retried/));
+      expect(describeDrop('unknown', n).detail).not.toMatch(/retried/);
+    }
+  });
+});
+
+describe('isDrop', () => {
+  it('recognises a dropped row and nothing else', () => {
+    expect(isDrop('DROP')).toBe(true);
+    expect(isDrop('ALLOW')).toBe(false);
+    expect(isDrop(null)).toBe(false);
+    expect(isDrop(undefined)).toBe(false);
+  });
+});

--- a/frontend/src/utils/dropCause.ts
+++ b/frontend/src/utils/dropCause.ts
@@ -1,0 +1,96 @@
+/**
+ * How to describe a dropped flow to an operator.
+ *
+ * The underlying signal is narrower than its name suggests.
+ * `netpolicy_drop.bpf.c` reports a flow when an outbound TCP handshake
+ * retransmits its SYN four times without reaching ESTABLISHED. That is
+ * an honest observation of silence: the probe has no visibility into
+ * why the handshake failed. It cannot distinguish a NetworkPolicy from
+ * a security group, a route, a port nothing listens on that blackholes
+ * rather than refuses, or a peer that is simply overloaded.
+ *
+ * Everything above it nonetheless said "policy": the file name, the
+ * `decision: DROP` column, the "Network Policy Drop" log line, the
+ * `denied-traffic` finding. And kguardian read no NetworkPolicy objects
+ * at all, so it could not have known — in a cluster with none, every
+ * reported policy drop was definitionally something else, and an
+ * operator sent to audit their policies was sent nowhere.
+ *
+ * The broker now asks the evaluator which policies actually govern the
+ * pod and stores the answer in `drop_cause`. This module turns that into
+ * wording that claims only what is known.
+ */
+
+/** Values the broker stores in `drop_cause`. */
+export type DropCause = 'no-policy' | 'policy-governs' | 'unknown';
+
+export interface DropLabel {
+  /** Short label for a badge or table cell. */
+  short: string;
+  /** One sentence an operator can act on. */
+  detail: string;
+  /**
+   * Whether a NetworkPolicy is a plausible cause. Drives whether the UI
+   * should offer to open the policy builder — sending someone to edit
+   * policies that provably cannot be involved is the specific harm the
+   * old wording caused.
+   */
+  policyPlausible: boolean;
+}
+
+/**
+ * Describe a dropped flow.
+ *
+ * `cause` of null covers a row written before classification existed and
+ * a row the evaluator could not classify. Both mean the same thing to a
+ * reader — the cause is not known — so they share the wording, and
+ * neither is allowed to imply a policy was or was not involved.
+ */
+export function describeDrop(cause: string | null | undefined, synRetries?: number | null): DropLabel {
+  const evidence =
+    typeof synRetries === 'number' && synRetries > 0
+      ? ` The handshake was retried ${synRetries} times with no reply.`
+      : '';
+
+  switch (cause) {
+    case 'no-policy':
+      return {
+        short: 'Blocked, not by policy',
+        detail:
+          'No NetworkPolicy governs this pod for egress, so a policy cannot be the cause. ' +
+          'Look at security groups, routes, or whether anything is listening on that port.' +
+          evidence,
+        policyPlausible: false,
+      };
+    case 'policy-governs':
+      return {
+        short: 'Possibly denied by policy',
+        detail:
+          'A NetworkPolicy selects this pod for egress, so it may have denied this flow. ' +
+          'kguardian observes only that the connection never completed, not the denial itself.' +
+          evidence,
+        policyPlausible: true,
+      };
+    default:
+      return {
+        short: 'Connection failed',
+        detail:
+          'The connection never completed. kguardian could not establish whether a NetworkPolicy ' +
+          'was involved, so the cause is unknown.' +
+          evidence,
+        policyPlausible: true,
+      };
+  }
+}
+
+/**
+ * True when the row is a dropped flow.
+ *
+ * Kept as a helper rather than comparing to `'DROP'` inline so the
+ * stored value stays in one place: the column records that a handshake
+ * did not complete, which is a weaker claim than its name, and callers
+ * should be reading `describeDrop` for anything user-facing.
+ */
+export function isDrop(decision: string | null | undefined): boolean {
+  return decision === 'DROP';
+}


### PR DESCRIPTION
`netpolicy_drop.bpf.c` reports a flow when an outbound TCP handshake retransmits its SYN four times without reaching ESTABLISHED. That is an honest observation of silence: the probe cannot see why the handshake failed, and cannot distinguish a NetworkPolicy from a security group, a route, a port nothing listens on that blackholes rather than refuses, or a peer that is merely overloaded. Every layer above it nonetheless said "policy", including the log line, the `decision` column, and a Findings section reading "Workloads with packets dropped by network policy". Nothing in kguardian read a NetworkPolicy object, so it could not have known. The development cluster this was found in has zero policies, which makes the claim wrong for every row it shows.

The evaluator now answers the cheap, decisive question instead: does any policy govern this pod in this direction? A no is conclusive and reclassifies the drop, a yes is a real lead. It deliberately does not re-evaluate whether a policy denied a specific flow, since the matcher already does per-flow evaluation and a second implementation would drift. It lives there rather than in the controller because it has apimachinery's LabelSelector implementation, and because one Deployment means one NetworkPolicy watch instead of one per node. The broker records the answer as `drop_cause` and finally stores `syn_retries`; the lookup rides the bounded audit queue so it cannot back-pressure capture, and every failure path leaves the column NULL, which readers treat as unknown.

Two properties are load-bearing and were checked rather than assumed: the `policyTypes` defaulting rule matches upstream and the existing `effectivePolicyTypes` in `pkg/matcher` (absent means Ingress always, Egress only with egress rules, and egress is the only direction this probe observes), and "could not read the policies" never collapses into "read them and found none". The NetworkPolicy informer is excluded from the startup sync gate, so an evaluator rolling ahead of the new ClusterRole rule still starts and reports unknown.

Rebased onto main after #1503 and squashed to one commit. Verified on the rebase: controller 214, broker 269, frontend 282, plus the evaluator suite; clippy `-D warnings` on controller and broker, fmt, `go vet`, lint and typecheck clean. The migration adds two nullable columns with no default, so it does not rewrite a table measured in the millions of rows, and both are last in the diesel `table!` block because Queryable is positional.

One claim I could not verify safely: that drops are a fraction of a percent of rows, which is the basis for calling the added evaluator round trip negligible. Measuring it means querying the deployed broker, which predates the read-admission control added in #1473. It affects performance framing only, since the audit queue is bounded and sheds rather than breaking.