### PR TITLE
fix(broker): stop the seccomp profile list allocating per syscall name

### DIFF
--- a/broker/src/read_budget.rs
+++ b/broker/src/read_budget.rs
@@ -164,6 +164,94 @@ pub const MAX_PODS_PER_NODE: i64 = 128;
 /// (~16 KiB) so the blob is covered rather than the row count.
 pub const SYSCALL_ROWS_CHARGED: i64 = 4;
 
+/// Peak in-flight heap per workload for `GET /seccomp/profiles`, in bytes.
+///
+/// READ THIS BEFORE TRUSTING THE NUMBER: it describes the list path as it
+/// behaved BEFORE the `Observed::build_for_summary` change in this same
+/// commit, and the post-change cost has not been measured. Deploying the
+/// binary is the only way to measure it, and that had not happened when this
+/// was written. So this is a deliberately retained upper bound, not a
+/// description of the shipped path — which is a weaker claim than
+/// [`TRAFFIC_ROW_COST_BYTES`] makes, and the difference is stated rather
+/// than papered over.
+///
+/// What WAS measured, against the running dev cluster on 2026-09-08 — four
+/// sequential unbatched calls, `kubectl top` on the broker pod between each,
+/// 25s apart, 1696 workload summaries per response (1.57 MB of JSON):
+///
+///   baseline 352 MiB -> 366 -> 381 -> 396 -> 411     (+14, +15, +15, +15)
+///
+/// Linear, with nothing reclaimed between calls. Two things follow, and the
+/// second one is why this constant does not carry the weight it looks like
+/// it carries:
+///
+///   - ~15 MiB retained per call over 1696 workloads is ~9.1 KiB/workload.
+///     16 KiB sits ~1.8x above that, covering the transient peak `kubectl
+///     top` cannot see at its ~15s sampling cadence.
+///   - Sequential calls ACCUMULATE. A budget bounds concurrent in-flight
+///     cost; it does not bound monotonic retention across calls made one at
+///     a time, which is what the UI's 15s poll actually produces. So this
+///     reservation is NOT what fixes the OOMKill — see the note above
+///     `list_seccomp_profiles`. It closes a structural gap (this module was
+///     referenced only from `get.rs`, so every seccomp read was admitted
+///     unconditionally) and bounds the concurrent case. The retention itself
+///     is tracked separately and is not fixed here.
+///
+/// A workload's cost is dominated by its `workload_syscalls.syscalls` blob —
+/// a comma-joined list averaging 67 names on the dev cluster, 113,995 names
+/// cluster-wide. The summary emits only `syscallCount`, so those names are no
+/// longer allocated on the list path, but the charge stays sized for the blob:
+/// the row is still read out of libpq in full, and a workload with a mirrored
+/// CR does still materialise the set for drift detection.
+///
+/// Re-derive from a fresh set of readings against a deployed build; do not
+/// adjust it to make a reservation fit.
+pub const SECCOMP_WORKLOAD_COST_BYTES: u64 = 16_384;
+
+/// Assumed worst-case workload count for `GET /seccomp/profiles`.
+///
+/// Same reservation shape as [`ASSUMED_MAX_PODS`], and the same reason it
+/// cannot be computed from a caller-supplied limit: the endpoint returns one
+/// summary per workload ever observed and must not truncate, because the UI
+/// lists it and a short list reads as "this workload has no profile" rather
+/// than as an error.
+///
+/// 4000 is 2.4x the dev cluster's 1696 workloads. `workload_syscalls` is
+/// keyed by (namespace, kind, name), so its ROW COUNT is bounded by distinct
+/// workloads rather than by pod churn or telemetry volume — that half of the
+/// [`ASSUMED_MAX_PODS`] argument transfers.
+///
+/// The other half does not, and it is the reason this constant is weaker
+/// than its neighbour. A `pod_details` row is bounded in width; a
+/// `workload_syscalls` row is not. `recompute_workload` unions each new
+/// observation into `syscalls` and never prunes, so the per-workload cost
+/// grows monotonically over a cluster's life even if no workload is ever
+/// added. A flat `rows x bytes-per-row` reservation therefore decays in
+/// accuracy in two independent directions at once, and past this bound the
+/// two errors compound.
+///
+/// The better shape is to charge from a cheap aggregate — `SELECT count(*),
+/// sum(length(syscalls)) FROM workload_syscalls` before the acquire — which
+/// is exact, index-bounded, and would delete this constant. That is the
+/// change worth making next here; it is not in this commit because the
+/// commit's purpose is the allocation fix and it should not also carry a
+/// query-shape change to the same handler.
+pub const ASSUMED_MAX_WORKLOADS: i64 = 4_000;
+
+/// Workload-equivalents charged for the per-workload seccomp endpoints.
+///
+/// `one_observed` reads a single `workload_syscalls` row, but the same
+/// handlers also call `distribution_index`, which loads every
+/// `seccomp_node_status.paths` JSON blob — one per node, so tens of rows on
+/// the clusters this runs on rather than thousands. 64 workload-equivalents
+/// (64 x 16 KiB = 1 MiB) is an ESTIMATE, not a measurement — unlike
+/// [`SECCOMP_WORKLOAD_COST_BYTES`], nothing was profiled here. The dev
+/// cluster has 44 nodes and `seccomp_node_status.paths` is a JSON blob of
+/// unstated size per node, so "tens of rows" is reasoned from the row count
+/// rather than from bytes. It covers that comfortably while staying small enough that the UI
+/// opening a profile never contends with the list poll.
+pub const SECCOMP_DETAIL_ROWS_CHARGED: i64 = 64;
+
 /// Default total read budget, in MiB.
 ///
 /// Sized from the incident: the container limit is 1 GiB (confirmed against
@@ -709,6 +797,50 @@ mod tests {
             worst_case_mb < 656,
             "worst-case concurrent read heap {worst_case_mb} MiB must fit \
              the 656 MiB of measured headroom"
+        );
+    }
+
+    /// The seccomp list reservation is the one that OOMKilled the broker, so
+    /// its sizing needs the same guard the traffic read has: big enough to
+    /// bind, small enough that a normal UI poll is not competing with the
+    /// whole budget.
+    #[test]
+    fn seccomp_list_reservation_binds_without_monopolising_the_budget() {
+        let seccomp_kib = cost_kib(ASSUMED_MAX_WORKLOADS, SECCOMP_WORKLOAD_COST_BYTES);
+        let budget_kib = DEFAULT_READ_MEMORY_BUDGET_MB * 1024;
+        let concurrent = budget_kib / seccomp_kib;
+
+        // A RANGE, not an equality. The requirement is "binds well before the
+        // 64 actix workers, without monopolising the budget" — not one exact
+        // number. An equality here would fail the moment anyone follows the
+        // instruction three lines above SECCOMP_WORKLOAD_COST_BYTES to
+        // re-derive it against a deployed build, i.e. this test would break
+        // when a maintainer does the right thing.
+        assert!(
+            (2..=8).contains(&concurrent),
+            "expected 2-8 concurrent seccomp list reads, got {concurrent}: \
+             below 2 a single UI poll monopolises the budget, above 8 it no \
+             longer binds meaningfully before the worker count does"
+        );
+
+        // But one call must not eat the whole budget, or a single UI poll
+        // would shed every concurrent traffic read and the fix would trade
+        // one outage for another.
+        let hard_cap_read_kib = cost_kib(20_000, TRAFFIC_ROW_COST_BYTES);
+        assert!(
+            seccomp_kib + hard_cap_read_kib <= budget_kib,
+            "one seccomp list read ({seccomp_kib} KiB) plus one hard-cap traffic \
+             read ({hard_cap_read_kib} KiB) must both fit the {budget_kib} KiB budget"
+        );
+
+        // And the reservation must actually exceed what was measured on the
+        // dev cluster (1696 workloads), or it would under-charge the very
+        // call that caused the incident.
+        let measured_kib = cost_kib(1_696, SECCOMP_WORKLOAD_COST_BYTES);
+        assert!(
+            seccomp_kib > measured_kib,
+            "the flat reservation {seccomp_kib} KiB must cover the observed \
+             1696-workload cluster ({measured_kib} KiB)"
         );
     }
 

--- a/broker/src/seccomp.rs
+++ b/broker/src/seccomp.rs
@@ -43,6 +43,10 @@
 //! The observed union is never edited here; an "override" is an edit to
 //! the CR. One file per CR on a node: `kguardian/<namespace>/<cr>.json`.
 
+use crate::read_budget::{
+    cost_kib, ReadBudget, ASSUMED_MAX_WORKLOADS, SECCOMP_DETAIL_ROWS_CHARGED,
+    SECCOMP_WORKLOAD_COST_BYTES,
+};
 use crate::schema;
 use actix_web::{get, post, web, HttpResponse, Responder};
 use diesel::prelude::*;
@@ -204,6 +208,32 @@ fn split_set(joined: &str) -> BTreeSet<String> {
         .filter(|s| !s.is_empty())
         .map(String::from)
         .collect()
+}
+
+/// Cardinality of what [`split_set`] would return, without allocating it.
+///
+/// The list endpoint emits `syscallCount` and nothing else derived from the
+/// names, and on a cluster with no mirrored CRs (1696 of 1696 workloads on
+/// the dev cluster) that count is the *only* consumer. Building the
+/// `BTreeSet<String>` to call `.len()` on it allocated one `String` per
+/// syscall name per workload — 113,995 of them cluster-wide, on every 15s
+/// UI poll — which is the allocation churn behind the OOMKill this pairs
+/// with the read budget to fix.
+///
+/// Must agree with `split_set(joined).len()` for every input; the property
+/// test `count_set_agrees_with_split_set` pins that.
+fn count_set(joined: &str) -> usize {
+    // Borrowed slices into `joined`, sorted and deduped in one buffer: a
+    // single allocation for the whole field, against one per name for the
+    // `BTreeSet<String>` this replaces on the list path.
+    let mut toks: Vec<&str> = joined
+        .split(',')
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .collect();
+    toks.sort_unstable();
+    toks.dedup();
+    toks.len()
 }
 
 fn join_set(set: &BTreeSet<String>) -> String {
@@ -942,26 +972,69 @@ impl CrBlock {
 /// mirrored CRs that reference it.
 struct Observed {
     row: WorkloadSyscallsRow,
+    /// The syscall names. Empty on the list path for a workload with no
+    /// mirrored CR, where nothing reads them — use [`Observed::syscall_count`]
+    /// for the cardinality, which is correct in both cases.
     syscalls: BTreeSet<String>,
+    /// Cardinality of the observed set, always populated. Kept separate
+    /// because `syscalls` is not materialised on the list path.
+    syscall_count: usize,
     arches: BTreeSet<String>,
     capture: CaptureSummary,
     crs: Vec<CrRow>,
 }
 
 impl Observed {
+    /// Materialises the syscall names. Every caller that renders a profile
+    /// document, exports, or diffs against a CR needs this.
     fn build(row: WorkloadSyscallsRow, captures: &CaptureIndex, crs: &CrIndex) -> Self {
+        Self::build_inner(row, captures, crs, true)
+    }
+
+    /// List-path build: skips the `BTreeSet<String>` of syscall names when
+    /// nothing will read them.
+    ///
+    /// [`ProfileSummary`] touches `syscalls` in exactly two places —
+    /// `syscall_count` (a length) and `CrBlock::build` (drift, only when the
+    /// workload has a mirrored CR). So a workload with no CR needs the count
+    /// and never the names, which is every workload on the dev cluster. The
+    /// names are still materialised when a CR exists, so drift detection is
+    /// bit-for-bit unchanged.
+    fn build_for_summary(row: WorkloadSyscallsRow, captures: &CaptureIndex, crs: &CrIndex) -> Self {
         let key = (
             row.pod_namespace.clone(),
             row.workload_kind.clone(),
             row.workload_name.clone(),
         );
-        let syscalls = split_set(&row.syscalls);
+        let needs_names = !crs.for_workload(&key).is_empty();
+        Self::build_inner(row, captures, crs, needs_names)
+    }
+
+    fn build_inner(
+        row: WorkloadSyscallsRow,
+        captures: &CaptureIndex,
+        crs: &CrIndex,
+        with_names: bool,
+    ) -> Self {
+        let key = (
+            row.pod_namespace.clone(),
+            row.workload_kind.clone(),
+            row.workload_name.clone(),
+        );
+        let (syscalls, syscall_count) = if with_names {
+            let set = split_set(&row.syscalls);
+            let n = set.len();
+            (set, n)
+        } else {
+            (BTreeSet::new(), count_set(&row.syscalls))
+        };
         let arches = split_set(&row.arches);
         Observed {
             capture: captures.summary_for(&key),
             crs: crs.for_workload(&key).to_vec(),
             row,
             syscalls,
+            syscall_count,
             arches,
         }
     }
@@ -1010,7 +1083,7 @@ impl ProfileSummary {
             kind: r.workload_kind.clone(),
             name: r.workload_name.clone(),
             hash: r.hash.clone(),
-            syscall_count: obs.syscalls.len(),
+            syscall_count: obs.syscall_count,
             architectures: obs
                 .arches
                 .iter()
@@ -1047,7 +1120,7 @@ fn all_observed(conn: &mut PgConnection) -> Result<Vec<Observed>, DbError> {
     let crs = cr_index(conn, None)?;
     Ok(rows
         .into_iter()
-        .map(|row| Observed::build(row, &captures, &crs))
+        .map(|row| Observed::build_for_summary(row, &captures, &crs))
         .collect())
 }
 
@@ -1084,6 +1157,7 @@ fn render(obs: &Observed) -> SeccompProfile {
 pub async fn list_seccomp_profiles(
     req: actix_web::HttpRequest,
     pool: web::Data<DbPool>,
+    budget: web::Data<ReadBudget>,
 ) -> actix_web::Result<impl Responder> {
     // The v1 `?state=published` filter is gone. Fail loudly rather than
     // return everything: a distributor that predates CR-driven
@@ -1094,6 +1168,46 @@ pub async fn list_seccomp_profiles(
         ));
     }
     info!("list seccomp profiles");
+
+    // A whole-result-set read that took no permit — the only one in the
+    // broker that did not. This endpoint OOMKilled the broker in the dev
+    // cluster: the UI polls it every 15s (frontend useSeccompProfiles) and
+    // the container died at steady ingest with zero `/pod/traffic` reads in
+    // its log, so the budget that already existed never engaged.
+    //
+    // BUT THE PERMIT IS NOT WHAT FIXES THAT, and it should not be read as
+    // the remedy. Measured on the dev cluster, four SEQUENTIAL calls 25s
+    // apart moved RSS 352 -> 366 -> 381 -> 396 -> 411 MiB: ~15 MiB per call,
+    // linear, nothing reclaimed in between. A permit is released when the
+    // handler returns, so retention that outlives the response is invisible
+    // to the budget — it holds no permit and `available_kib` counts it free.
+    // A semaphore cannot bound a quantity that persists after the request
+    // completes.
+    //
+    // Nor would it have fired here. Both callers are self-limiting to one
+    // in-flight request each: `useSeccompProfiles` holds an `inflight` ref
+    // and returns early while a call is outstanding, and the seccomp
+    // distributor ticks a single reconciler loop every 30s. Steady state is
+    // 2 concurrent against a reservation that admits 4, so in the exact
+    // configuration that killed the broker this permit would never have been
+    // contended.
+    //
+    // What attacks the measured growth is `count_set` +
+    // `Observed::build_for_summary` below, which stop this path allocating a
+    // String per syscall name (113,995 of them cluster-wide) purely to emit
+    // an integer. The permit is a guardrail for a future caller with no
+    // in-flight guard, and it closes the structural gap that every read in
+    // get.rs is admitted while every read here was not. Charged the way
+    // `/pod/info` is, because it has no caller-supplied limit and must not
+    // truncate.
+    let _permit = match budget
+        .acquire(cost_kib(ASSUMED_MAX_WORKLOADS, SECCOMP_WORKLOAD_COST_BYTES))
+        .await
+    {
+        Ok(p) => p,
+        Err(shed) => return Ok(shed.into_response()),
+    };
+
     let out: Vec<ProfileSummary> = web::block(move || -> Result<_, DbError> {
         let mut conn = pool.get()?;
         let all = all_observed(&mut conn)?;
@@ -1127,10 +1241,26 @@ struct ProfileDetail {
 #[get("/seccomp/profiles/{namespace}/{kind}/{name}")]
 pub async fn get_seccomp_profile(
     pool: web::Data<DbPool>,
+    budget: web::Data<ReadBudget>,
     path: web::Path<(String, String, String)>,
 ) -> actix_web::Result<impl Responder> {
     let (namespace, kind, name) = path.into_inner();
     info!(%namespace, %kind, %name, "get seccomp profile");
+
+    // One workload, but `distribution_index` below is still a whole-table read
+    // of `seccomp_node_status` (one JSON `paths` blob per node). Bounded by
+    // node count rather than workload count, so it is charged as a small
+    // multiple of one workload rather than the list endpoint's reservation.
+    let _permit = match budget
+        .acquire(cost_kib(
+            SECCOMP_DETAIL_ROWS_CHARGED,
+            SECCOMP_WORKLOAD_COST_BYTES,
+        ))
+        .await
+    {
+        Ok(p) => p,
+        Err(shed) => return Ok(shed.into_response()),
+    };
 
     let result = web::block(move || -> Result<_, DbError> {
         let mut conn = pool.get()?;
@@ -2071,6 +2201,126 @@ mod tests {
         assert!(split_set("").is_empty());
     }
 
+    /// `count_set` exists so the list path can report `syscallCount` without
+    /// allocating a `String` per syscall name. It is only safe to substitute
+    /// if it agrees with `split_set(..).len()` on every input, including the
+    /// messy ones the field is known to carry (leading, trailing and doubled
+    /// commas, surrounding whitespace, and repeats).
+    #[test]
+    fn count_set_agrees_with_split_set() {
+        for input in [
+            "",
+            ",",
+            ",,,",
+            "read",
+            " read ",
+            "read,write",
+            ",read,, write ,read,",
+            "read,read,read",
+            "a,b,c,d,e,f,g",
+            " , a , a , b , ",
+            "openat,close,read,write,mmap,mprotect,futex,epoll_wait",
+        ] {
+            assert_eq!(
+                count_set(input),
+                split_set(input).len(),
+                "count_set disagreed with split_set on {input:?}"
+            );
+        }
+    }
+
+    /// The list path must report the same `syscallCount` whether or not the
+    /// names were materialised. This is the substitution the OOM fix rests
+    /// on: if these two ever diverge, the UI silently misreports every
+    /// workload's syscall count.
+    #[test]
+    fn summary_build_reports_the_same_count_as_the_full_build() {
+        let mk = || WorkloadSyscallsRow {
+            pod_namespace: "prod".into(),
+            workload_kind: "Deployment".into(),
+            workload_name: "web".into(),
+            syscalls: ",openat,, read , write ,openat,".into(),
+            arches: "SCMP_ARCH_X86_64".into(),
+            hash: "abc123".into(),
+            updated_at: chrono::NaiveDateTime::default(),
+        };
+        let captures = CaptureIndex {
+            pods: HashMap::new(),
+        };
+        let crs = CrIndex::from_rows(Vec::new());
+
+        let full = Observed::build(mk(), &captures, &crs);
+        let summary = Observed::build_for_summary(mk(), &captures, &crs);
+
+        assert_eq!(full.syscall_count, 3, "openat/read/write, deduped");
+        assert_eq!(summary.syscall_count, full.syscall_count);
+        // The whole point: the names are not allocated on the summary path
+        // for a workload with no CR, while the count is still right.
+        assert!(full.syscalls.contains("openat"));
+        assert!(
+            summary.syscalls.is_empty(),
+            "no CR for this workload, so the names must not be materialised"
+        );
+    }
+
+    /// The invariant the whole optimisation rests on, and the one the test
+    /// above does NOT cover: when a workload HAS a mirrored CR, the summary
+    /// path must materialise the names, because `CrBlock::build` diffs them.
+    ///
+    /// The failure mode if this ever regresses is silent in the dangerous
+    /// direction. `drift(observed, allowed)` with an empty `observed` yields
+    /// `missing: []` and `extra: [everything]`. `missing` is the
+    /// security-relevant half — it is what gets BLOCKED when the CR is
+    /// enforced — so a broken gate would report "nothing will break" for a
+    /// workload where everything is about to.
+    #[test]
+    fn summary_build_materialises_names_when_the_workload_has_a_cr() {
+        let mk = || WorkloadSyscallsRow {
+            pod_namespace: "prod".into(),
+            workload_kind: "Deployment".into(),
+            workload_name: "web".into(),
+            syscalls: "openat,read,write".into(),
+            arches: "SCMP_ARCH_X86_64".into(),
+            hash: "abc123".into(),
+            updated_at: chrono::NaiveDateTime::default(),
+        };
+        let captures = CaptureIndex {
+            pods: HashMap::new(),
+        };
+        // cr_row's CR allows exactly "read,write"; the observed set below adds
+        // `openat`, so `openat` is the syscall the CR would block.
+        let crs = CrIndex::from_rows(vec![cr_row(
+            "web-profile",
+            Some(("Deployment", "web")),
+            "h1",
+            100,
+        )]);
+
+        let summary = Observed::build_for_summary(mk(), &captures, &crs);
+        let full = Observed::build(mk(), &captures, &crs);
+
+        assert!(
+            !summary.syscalls.is_empty(),
+            "a workload WITH a CR must have its names materialised, or drift \
+             detection silently reports an empty `missing` set"
+        );
+        assert_eq!(summary.syscalls, full.syscalls);
+        assert_eq!(summary.syscall_count, full.syscall_count);
+
+        // And the rendered drift must be identical between the two paths.
+        let idx = empty_index();
+        let a = serde_json::to_value(ProfileSummary::build(&summary, &idx)).unwrap();
+        let b = serde_json::to_value(ProfileSummary::build(&full, &idx)).unwrap();
+        assert_eq!(a["cr"]["drift"], b["cr"]["drift"]);
+        assert_eq!(
+            a["cr"]["drift"]["missing"],
+            serde_json::json!(["openat"]),
+            "the CR allows read+write while openat was observed, so openat is \
+             what enforcing the CR would block — this is the field that must \
+             never be empty by accident"
+        );
+    }
+
     #[test]
     fn validated_action_accepts_crd_enum_and_rejects_garbage() {
         for ok in [
@@ -2448,6 +2698,7 @@ mod tests {
         };
         Observed {
             syscalls: split_set(syscalls),
+            syscall_count: split_set(syscalls).len(),
             arches: split_set(arches),
             capture: capture_summary(&pods(&[("web-1", Some("full"))])),
             crs,
@@ -2947,6 +3198,13 @@ spec:
         let app = test::init_service(
             App::new()
                 .app_data(web::Data::new(dummy_pool()))
+                // The seccomp read handlers take a ReadBudget extractor, so
+                // without this every route 500s on a missing app_data before
+                // the handler body runs, masking the status each case asserts.
+                .app_data(web::Data::new(ReadBudget::with_budget_kib(
+                    64 * 1024,
+                    std::time::Duration::from_millis(0),
+                )))
                 .service(list_seccomp_profiles)
                 .service(get_seccomp_profile)
                 .service(get_seccomp_profile_file)

--- a/charts/kguardian/templates/broker/deployment.yaml
+++ b/charts/kguardian/templates/broker/deployment.yaml
@@ -6,9 +6,29 @@ metadata:
   labels:
     {{- include "kguardian.labels" . | nindent 4 }}
 spec:
-  {{- if not .Values.broker.autoscaling.enabled }}
-  replicas: {{ .Values.broker.replicaCount }}
+  {{- /*
+    autoscaling.enabled is not implemented. The chart ships no HPA template
+    for any component (no HorizontalPodAutoscaler anywhere under templates/),
+    so setting it does not autoscale — it deletes `replicas` from this
+    Deployment and nothing takes ownership of the field, which means the
+    API server defaults it to 1 and a Helm upgrade of an existing release
+    scales it DOWN to a single pod.
+
+    It also silently disarms the singleton-PDB guardrail next door in
+    pdb.yaml: that check reads `.Values.broker.replicaCount`, not the
+    effective replica count, so with replicaCount=3 and autoscaling on it
+    sees 3, renders `minAvailable: 1` against the one pod that actually
+    exists, and every voluntary eviction is refused — the exact drain
+    deadlock the guardrail was written to prevent.
+
+    Failing loudly rather than honouring it, which is what the evaluator
+    already does for its own reason. Implementing real HPAs is a feature,
+    and not every component can take one (the controller is a DaemonSet).
+  */ -}}
+  {{- if .Values.broker.autoscaling.enabled }}
+  {{- fail "broker.autoscaling.enabled=true is not supported: this chart ships no HorizontalPodAutoscaler, so enabling it removes spec.replicas, lets the replica count default to 1, and disarms the PDB singleton guard (causing kubectl drain to stall). Set broker.autoscaling.enabled=false and use broker.replicaCount." }}
   {{- end }}
+  replicas: {{ .Values.broker.replicaCount }}
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ .Values.broker.service.name }}

--- a/charts/kguardian/templates/frontend/deployment.yaml
+++ b/charts/kguardian/templates/frontend/deployment.yaml
@@ -6,9 +6,11 @@ metadata:
   labels:
     {{- include "kguardian.labels" . | nindent 4 }}
 spec:
-  {{- if not .Values.frontend.autoscaling.enabled }}
-  replicas: {{ .Values.frontend.replicaCount }}
+  {{- /* Not implemented — see the comment in broker/deployment.yaml. */ -}}
+  {{- if .Values.frontend.autoscaling.enabled }}
+  {{- fail "frontend.autoscaling.enabled=true is not supported: this chart ships no HorizontalPodAutoscaler, so enabling it removes spec.replicas and lets the replica count default to 1. Set frontend.autoscaling.enabled=false and use frontend.replicaCount." }}
   {{- end }}
+  replicas: {{ .Values.frontend.replicaCount }}
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ .Values.frontend.service.name }}

--- a/charts/kguardian/templates/llm-bridge/deployment.yaml
+++ b/charts/kguardian/templates/llm-bridge/deployment.yaml
@@ -7,9 +7,11 @@ metadata:
   labels:
     {{- include "kguardian.labels" . | nindent 4 }}
 spec:
-  {{- if not .Values.llmBridge.autoscaling.enabled }}
-  replicas: {{ .Values.llmBridge.replicaCount }}
+  {{- /* Not implemented — see the comment in broker/deployment.yaml. */ -}}
+  {{- if .Values.llmBridge.autoscaling.enabled }}
+  {{- fail "llmBridge.autoscaling.enabled=true is not supported: this chart ships no HorizontalPodAutoscaler, so enabling it removes spec.replicas and lets the replica count default to 1. Set llmBridge.autoscaling.enabled=false and use llmBridge.replicaCount." }}
   {{- end }}
+  replicas: {{ .Values.llmBridge.replicaCount }}
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ .Values.llmBridge.service.name }}

--- a/controller/src/network.rs
+++ b/controller/src/network.rs
@@ -444,6 +444,21 @@ async fn build_policy_drop_event(
 ) -> Option<PodTraffic> {
     let s_ip = wire_addr_to_ip(data.saddr);
     let d_ip = wire_addr_to_ip(data.daddr);
+    // Deliberately 0, not `data.sport`, even though the probe captures the
+    // real source port and this looks like an oversight. It feeds the dedup
+    // cache key below, and every connect attempt draws a fresh ephemeral
+    // source port: keying on it would make each retry of the same blocked
+    // flow a distinct key, so the dedup would never hit, every failed
+    // connect would take a slot in the 10,000-entry TRAFFIC_CACHE shared
+    // with the ALLOW path, and each would evict a live ALLOW entry. The
+    // ALLOW EGRESS arms zero pod_port for the same reason.
+    //
+    // It also reaches `pod_port` on the emitted row, where the broker's TCP
+    // dedup (add.rs get_row) includes pod_port — so a real port there would
+    // additionally defeat dedup at the DB and insert a row per attempt.
+    //
+    // Reviewed 2026-09 and kept: if you want the port for forensics, add a
+    // separate field, do not thread it through here.
     let s_port = 0;
     let d_port = data.dport;
     let protocol_str = proto_to_string(data.protocol);


### PR DESCRIPTION
The broker OOMKilled on the dev cluster with zero reads of any budgeted endpoint in its log. The container that died had served ten `GET /seccomp/profiles` calls in its 134-second life and was killed at completely steady ingest. The container that replaced it has served none and has been up over six hours with zero restarts. That endpoint builds a whole result set and was the only one in the broker taking no admission permit, since `read_budget` was referenced solely from `get.rs`, and the frontend polls it every 15 seconds.

The cost is `all_observed` splitting every workload's comma-joined `syscalls` field into a `BTreeSet<String>`: 1696 workloads and 113,995 individually-allocated syscall names per call, to produce a single integer, because the summary emits only `syscallCount` and no workload on this cluster has a mirrored CR. `count_set` counts distinct names in one borrowed buffer instead, and `build_for_summary` uses it only when the workload has no CR, so drift detection still gets the real set.

**The permit is not the fix, and the comments say so.** Four sequential calls 25s apart moved RSS 352, 366, 381, 396, 411 MiB: about 15 MiB per call, linear, nothing reclaimed. A permit is released when the handler returns, so retention that outlives the response holds no permit and reads as free. It is kept as a guardrail (ten engineers with the dashboard open is ten concurrent pollers) and because "every read in `get.rs` admitted, every read in `seccomp.rs` not" was a real structural gap.

## Two commits, and please do not squash

Squashing collapses them and release-please loses the per-component attribution, which is the entire point of the split.

1. `fix:` the broker allocation change plus a comment-only note in `controller/src/network.rs`.
2. `fix(chart)!:` the autoscaling guard, carrying a `BREAKING CHANGE` footer.

The chart change is separate because a `{{ fail }}` on a documented values knob is an API break that really happened, and shipping it unlabelled under `fix:` would hand a consumer who pins minors a hard render failure with no signal. Same reasoning as #1503, which split its chart default out so the major bump landed on the chart alone.

`autoscaling.enabled` promised autoscaling and delivered one replica (the chart ships no HPA template anywhere) while disarming the singleton-PDB guardrail, which reads `replicaCount` rather than the effective count. So `replicaCount=3` plus autoscaling rendered `minAvailable: 1` against the single pod that existed and stalled drains. Verified safe to ship: `f:replicas` on the live broker and frontend Deployments is owned by `argocd-controller`, so the flag is off in the deployed values and no upgrade can be blocked.

## Review

Six reviewers. Two returned DO NOT MERGE and both objections were acted on: the chart split above, and the framing below. The tree is byte-identical to the head they reviewed; only the commit boundary moved.

**#1514 should not be closed on this merge.** A 20-call RSS ladder on the unpatched binary ran 415 to 643 MiB with no plateau, about 11.4 MiB per call sustained. That argues against bounded fragmentation. A separate reviewer then searched for a retention structure and found none: no `lazy_static`, `OnceCell`, `DashMap` or static lock holding those sets anywhere in the broker. Neither mechanism is established. The deciding measurement is the same ladder against the deployed build.

Merging on an unmeasured prediction is defensible for a narrow reason: removing 113,995 allocations cannot increase RSS, so the risk is that it under-delivers rather than regresses. Closing the bug on it is not.

**A limitation worth stating plainly.** `count_set` only replaces `split_set` for workloads with no mirrored CR, because drift detection needs the names. 1696 of 1696 is the best case and it is the unadopted state. On a cluster where operators have actually mirrored their profiles this does nothing, and the structural problem, loading every workload's syscall set to serve a list that emits a count, is untouched. Aggregating in SQL or paginating is still owed.

Follow-ups filed: #1514 (the retention itself), #1515 (`Observed.syscalls` empty meaning two different things).

Verified: broker 316 tests, `clippy -D warnings`, `cargo fmt`, `helm template` on defaults and with each autoscaling flag set. The new gate test was confirmed to fail when the gate is regressed.
