### PR TITLE
chore(chart): point the broker at 1.16.1

### DIFF
--- a/charts/kguardian/README.md
+++ b/charts/kguardian/README.md
@@ -104,7 +104,7 @@ The following table lists the configurable parameters of the kguardian chart and
 | broker.image.pullPolicy | string | `"IfNotPresent"` | Broker image pull policy |
 | broker.image.repository | string | `"ghcr.io/kguardian-dev/kguardian/broker"` | Broker container image repository |
 | broker.image.sha | string | `""` | Overrides the image tag using SHA digest |
-| broker.image.tag | string | `"1.16.0"` | Broker version tag (auto-updated by release-please) |
+| broker.image.tag | string | `"1.16.1"` | Broker version tag. Bump by hand on each broker release: release-please updates broker/VERSION, not this file. |
 | broker.imagePullSecrets | list | `[]` | List of image pull secrets for private registries |
 | broker.initContainer.image.pullPolicy | string | `"IfNotPresent"` | Broker init container image pull policy. See the controller's init container for why this is not `Always`. |
 | broker.initContainer.image.repository | string | `"busybox"` | Broker init container image repository |

--- a/charts/kguardian/values.yaml
+++ b/charts/kguardian/values.yaml
@@ -278,8 +278,9 @@ broker:
     repository: ghcr.io/kguardian-dev/kguardian/broker
     # -- Broker image pull policy
     pullPolicy: IfNotPresent
-    # -- Broker version tag (auto-updated by release-please)
-    tag: "1.16.0"
+    # -- Broker version tag. Bump by hand on each broker release: release-please
+    # updates broker/VERSION, not this file.
+    tag: "1.16.1"
     # -- Overrides the image tag using SHA digest
     sha: ""
   initContainer:


### PR DESCRIPTION
Picks up the seccomp profile list fix (#1518), which stops that endpoint reading every workload's syscall blob to emit a count. That is the read behind the broker OOMKill in #1514.

Held until `v1.16.1` was actually in the registry: the manifest index is published with both linux/amd64 and linux/arm64, verified against ghcr rather than inferred from the workflow, because merging a tag ahead of its build points Argo at something it cannot pull.

The tag comment claimed release-please updates this value. It does not, since the broker's `extra-files` entry is `broker/VERSION`, so the chart tag is bumped by hand on each release. Corrected rather than left to mislead, and the README regenerated with helm-docs.