### PR TITLE
chore(chart): re-release the pending chart changes as 1.23.0, not 2.0.0

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -3,7 +3,7 @@
   "broker": "1.17.0",
   "frontend": "1.17.0",
   "advisor": "1.10.0",
-  "charts/kguardian": "2.0.0",
+  "charts/kguardian": "1.22.0",
   "llm-bridge": "1.11.0",
   "evaluator": "0.4.1"
 }

--- a/charts/kguardian/CHANGELOG.md
+++ b/charts/kguardian/CHANGELOG.md
@@ -1,24 +1,5 @@
 # Changelog
 
-## [2.0.0](https://github.com/kguardian-dev/kguardian/compare/chart/v1.22.0...chart/v2.0.0) (2026-09-11)
-
-
-### ⚠ BREAKING CHANGES
-
-* **chart:** autoscaling.enabled=true is now refused at template time for broker, frontend and llm-bridge, where it previously rendered. Any values file setting it must remove it and use the component's replicaCount instead. Such an install is already broken - it is running a single replica, and if its PDB is enabled it cannot be drained - so this converts a silent misconfiguration into a loud one at upgrade time.
-
-### Features
-
-* live compute gauges and noisy-neighbour detection ([#1531](https://github.com/kguardian-dev/kguardian/issues/1531)) ([62959c2](https://github.com/kguardian-dev/kguardian/commit/62959c2be3d1fb71611c0ab77308a5d56af6ac91))
-
-
-### Bug Fixes
-
-* **broker:** stop the seccomp profile list allocating per syscall name ([1cae69b](https://github.com/kguardian-dev/kguardian/commit/1cae69bba1d5170c6d06f7249861c874955a6a94))
-* **chart:** refuse to render autoscaling.enabled instead of silently scaling to one replica ([9bfc0ef](https://github.com/kguardian-dev/kguardian/commit/9bfc0efce8fe682a97b32e9ba9ebb162eb26c518))
-* **deps:** update busybox docker tag to v1.38.0 ([#1509](https://github.com/kguardian-dev/kguardian/issues/1509)) ([5d35718](https://github.com/kguardian-dev/kguardian/commit/5d3571835c2943f1e06066ee0529bdba19afd72a))
-* **deps:** update ghcr.io/kguardian-dev/kguardian/broker docker tag to v1.16.1 ([#1520](https://github.com/kguardian-dev/kguardian/issues/1520)) ([7c6823d](https://github.com/kguardian-dev/kguardian/commit/7c6823d08951b4923d964cf40d166ca06771a456))
-
 ## [1.22.0](https://github.com/kguardian-dev/kguardian/compare/chart/v1.21.2...chart/v1.22.0) (2026-09-08)
 
 

--- a/charts/kguardian/Chart.yaml
+++ b/charts/kguardian/Chart.yaml
@@ -6,7 +6,7 @@ home: https://github.com/kguardian-dev/kguardian
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.0.0
+version: 1.22.0
 
 # appVersion is intentionally omitted: kguardian is multi-component and each
 # service pins its own image tag in values.yaml, so no single application

--- a/charts/kguardian/README.md
+++ b/charts/kguardian/README.md
@@ -2,7 +2,7 @@
 
 This chart bootstraps the [kguardian]() controlplane onto a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
 
-![Version: 2.0.0](https://img.shields.io/badge/Version-2.0.0-informational?style=flat-square)
+![Version: 1.22.0](https://img.shields.io/badge/Version-1.22.0-informational?style=flat-square)
 
 ## Overview
 


### PR DESCRIPTION
Reverts the chart 2.0.0 release commit and carries a `Release-As: 1.23.0` footer so release-please cuts the same changes as a minor. Merge only after the `chart/v2.0.0` tag and GitHub release have been deleted, otherwise release-please will treat 2.0.0 as the latest release.

https://claude.ai/code/session_013uBTphXbBk2V2BprxmQ33n