### PR TITLE
fix(frontend): decorate Service map nodes from the resolved backing pod, not an IP map

### DIFF
--- a/frontend/src/components/NetworkGraph.tsx
+++ b/frontend/src/components/NetworkGraph.tsx
@@ -119,17 +119,6 @@ const NetworkGraphInner: React.FC<NetworkGraphProps> = ({
     [onFocusChange, focusedNodeId],
   );
 
-  // Build IP-to-PodInfo lookup from allPodsLookup for cross-namespace resolution
-  const ipToAllPodsMap = useMemo(() => {
-    const map = new Map<string, PodInfo>();
-    allPodsLookup.forEach((pod) => {
-      if (pod.pod_ip) {
-        map.set(pod.pod_ip, pod);
-      }
-    });
-    return map;
-  }, [allPodsLookup]);
-
   // Peer attribution per traffic ROW (utils/peerResolution): the row's
   // stored peer_* identity first, else a by-IP lookup guarded by the flow
   // time. Pod IPs are recycled, so this — not an IP → pod map — decides
@@ -188,8 +177,8 @@ const NetworkGraphInner: React.FC<NetworkGraphProps> = ({
     return map;
   }, [services, pods]);
 
-  // Map backing pod NAME → service ClusterIP, for peers resolved to a pod
-  // record (the by-IP map above is ambiguous once an IP has changed hands).
+  // Map backing pod NAME → service ClusterIP. A resolved peer is matched by
+  // NAME — an IP is ambiguous once it has changed hands.
   const podNameToSvcIp = useMemo(() => {
     const map = new Map<string, string>();
     services.forEach((svc) => {
@@ -220,9 +209,8 @@ const NetworkGraphInner: React.FC<NetworkGraphProps> = ({
       localPodByName,
       svcIpToLocalPod: svcIpToLocalPodMap,
       podNameToSvcIp,
-      ipToAllPods: ipToAllPodsMap,
     });
-  }, [pods, showExternalNodes, showTraffic, ipToAllPodsMap, svcIpToLocalPodMap, services, podNameToSvcIp, rowPeers, localPodByName]);
+  }, [pods, showExternalNodes, showTraffic, svcIpToLocalPodMap, services, podNameToSvcIp, rowPeers, localPodByName]);
 
   // Combine in-namespace and external pods for rendering
   // When traffic is enabled, hide local pods that have no traffic

--- a/frontend/src/utils/daemonSetPeers.ts
+++ b/frontend/src/utils/daemonSetPeers.ts
@@ -19,8 +19,10 @@ export function isDaemonSetOrHostNetworkPod(p: PodInfo | undefined | null): bool
 
 /**
  * Whether a graph node is a DaemonSet / host-network PEER. In-namespace
- * workloads (`isExternal` false), the Internet node and Service nodes with
- * synthetic member pods never qualify.
+ * workloads (`isExternal` false) and the Unattributed / Internet aggregates
+ * never qualify. A Service node DOES qualify when any of its synthetic
+ * members — decorated from the backing pods `resolvePeer` attributed
+ * (utils/externalPeers) — is a DaemonSet or host-network pod.
  */
 export function isDaemonSetPeer(node: PodNodeData): boolean {
   if (!node.isExternal) return false;

--- a/frontend/src/utils/externalPeers.test.ts
+++ b/frontend/src/utils/externalPeers.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'vitest';
 import type { NetworkTraffic, PodInfo, PodNodeData, ServiceInfo } from '../types';
 import { buildPeerIndex, resolvePeer, type PeerResolution } from './peerResolution';
 import { buildExternalNodes, remoteNodeForRow } from './externalPeers';
+import { isDaemonSetPeer } from './daemonSetPeers';
 
 // The map's external-node builder, driven exactly like NetworkGraph drives
 // it. Live finding on cluster-00 (2026-09-03): with External on, the
@@ -49,8 +50,7 @@ function build(localPods: PodInfo[], allPods: PodInfo[], services: ServiceInfo[]
     if (local) svcIpToLocalPod.set(svc.svc_ip, local);
     allPods.forEach((p) => { if (p.pod_namespace === svc.svc_namespace && matches(p.workload_selector_labels, selector(svc))) podNameToSvcIp.set(p.pod_name, svc.svc_ip); });
   });
-  const ipToAllPods = new Map(allPods.map((p) => [p.pod_ip, p]));
-  const external = buildExternalNodes({ pods: nodes, services, rowPeers, localPodByName, svcIpToLocalPod, podNameToSvcIp, ipToAllPods });
+  const external = buildExternalNodes({ pods: nodes, services, rowPeers, localPodByName, svcIpToLocalPod, podNameToSvcIp });
   const byKey = (dir: 'in' | 'out') => {
     const m = new Map<string, PodNodeData>();
     external.filter((n) => n.id.endsWith(`-${dir}`)).forEach((n) => n.peerKeys?.forEach((k) => m.set(k, n)));
@@ -110,5 +110,84 @@ describe('buildExternalNodes — a Service is never derived from a raw IP', () =
     expect(external.map((n) => n.id)).toEqual(['external-internet-in']);
     expect(remote(internet)?.id).toBe('external-internet-in');
     expect(remote(local)?.id).toBe('game-servers-cmangos-database-0');
+  });
+});
+
+// #1565: the synthetic member pods of a Service node used to be decorated
+// from a last-write-wins IP → pod map over the whole /pod/info listing (dead
+// rows included). pod_details keeps a row per pod ever seen, so a recycled
+// address resolved to whichever former holder sorted last in (namespace,
+// name) order — on EKS the node agents — and a Deployment-backed Service
+// inherited workload_kind DaemonSet / host_network true from a dead
+// ebs-csi-node or datadog-agent row, and the DaemonSets toggle hid it.
+describe('buildExternalNodes — Service members carry the RESOLVED backing pod\'s workload facts (#1565)', () => {
+  const RECYCLED_IP = '10.0.0.9';
+  const flowAt = '2026-09-12T10:00:00';
+  const live = pod({
+    pod_name: 'web-7c9d-abcde', pod_ip: RECYCLED_IP, pod_namespace: 'shop', node_name: 'ip-10-0-0-1',
+    is_dead: false, started_at: '2026-09-12T09:00:00', time_stamp: flowAt,
+    workload_kind: 'Deployment', workload_name: 'web', workload_selector_labels: { app: 'web' }, host_network: false,
+  });
+  // Held the same address months ago. Namespace sorts after "shop", so in the
+  // (pod_namespace, pod_name) order /pod/info returns it is the map's winner.
+  const deadAgent = pod({
+    pod_name: 'ebs-csi-node-zzzzz', pod_ip: RECYCLED_IP, pod_namespace: 'zz-system', node_name: 'ip-10-0-0-2',
+    is_dead: true, started_at: '2026-06-01T00:00:00', time_stamp: '2026-07-01T00:00:00',
+    workload_kind: 'DaemonSet', workload_name: 'ebs-csi-node', host_network: true,
+  });
+  const webSvc: ServiceInfo = {
+    svc_ip: '10.96.0.30', svc_name: 'web', svc_namespace: 'shop', service_spec: { spec: { selector: { app: 'web' } } },
+  };
+
+  test('regression: a dead DaemonSet/host-network row that once held the backing pod\'s IP does not make the Service node a DaemonSet peer', () => {
+    const t = row({ traffic_type: 'EGRESS', traffic_in_out_ip: RECYCLED_IP, traffic_in_out_port: '8080', time_stamp: flowAt });
+    // Listed AFTER the live pod: that is the order in which the removed
+    // last-write-wins IP → pod map picked the dead row, so this fixture fails
+    // on the unpatched code and passes here.
+    const listing = [cmangosDatabase, live, deadAgent];
+    const index = buildPeerIndex(listing, [webSvc]);
+    const resolved = resolvePeer(t, index);
+    expect(resolved).toMatchObject({ kind: 'pod', pod: { pod_name: live.pod_name } });
+
+    const { external } = build([cmangosDatabase], listing, [webSvc], [t]);
+    expect(external.map((n) => n.id)).toEqual(['external-svc-shop-web-out']);
+    const node = external[0];
+    expect(node.pods).toHaveLength(1);
+    expect(node.pods[0].workload_kind).toBe('Deployment');
+    expect(node.pods[0].workload_name).toBe('web');
+    expect(node.pods[0].host_network).toBe(false);
+    expect(node.pods[0].node_name).toBe(live.node_name);
+    expect(isDaemonSetPeer(node)).toBe(false);
+  });
+
+  test('control: a Service whose resolved backing pod really is a DaemonSet (or host-network) is still flagged', () => {
+    const nodeExporter = pod({
+      pod_name: 'node-exporter-k7f2p', pod_ip: '10.0.0.40', pod_namespace: 'monitoring',
+      started_at: '2026-09-01T00:00:00', time_stamp: flowAt,
+      workload_kind: 'DaemonSet', workload_name: 'node-exporter', workload_selector_labels: { app: 'node-exporter' }, host_network: false,
+    });
+    const nodeExporterSvc: ServiceInfo = {
+      svc_ip: '10.96.0.40', svc_name: 'node-exporter', svc_namespace: 'monitoring', service_spec: { spec: { selector: { app: 'node-exporter' } } },
+    };
+    const t = row({ traffic_type: 'EGRESS', traffic_in_out_ip: '10.0.0.40', traffic_in_out_port: '9100', time_stamp: flowAt });
+    const { external } = build([cmangosDatabase], [cmangosDatabase, nodeExporter], [nodeExporterSvc], [t]);
+    expect(external.map((n) => n.id)).toEqual(['external-svc-monitoring-node-exporter-out']);
+    expect(external[0].pods[0].workload_kind).toBe('DaemonSet');
+    expect(isDaemonSetPeer(external[0])).toBe(true);
+
+    // host_network alone (a Deployment sharing the node's network) also qualifies.
+    const hostNet = pod({
+      pod_name: 'kube-proxy-shim-9x1', pod_ip: '10.0.0.41', pod_namespace: 'monitoring',
+      started_at: '2026-09-01T00:00:00', time_stamp: flowAt,
+      workload_kind: 'Deployment', workload_name: 'kube-proxy-shim', workload_selector_labels: { app: 'shim' }, host_network: true,
+    });
+    const hostNetSvc: ServiceInfo = {
+      svc_ip: '10.96.0.41', svc_name: 'shim', svc_namespace: 'monitoring', service_spec: { spec: { selector: { app: 'shim' } } },
+    };
+    const t2 = row({ traffic_type: 'EGRESS', traffic_in_out_ip: '10.0.0.41', traffic_in_out_port: '9100', time_stamp: flowAt });
+    const r2 = build([cmangosDatabase], [cmangosDatabase, hostNet], [hostNetSvc], [t2]);
+    expect(r2.external.map((n) => n.id)).toEqual(['external-svc-monitoring-shim-out']);
+    expect(r2.external[0].pods[0].host_network).toBe(true);
+    expect(isDaemonSetPeer(r2.external[0])).toBe(true);
   });
 });

--- a/frontend/src/utils/externalPeers.ts
+++ b/frontend/src/utils/externalPeers.ts
@@ -35,15 +35,13 @@ export interface ExternalNodesInput {
   svcIpToLocalPod: ReadonlyMap<string, PodNodeData>;
   /** Backing pod NAME → ClusterIP of the Service selecting it. */
   podNameToSvcIp: ReadonlyMap<string, string>;
-  /** Current pod record by IP — only to decorate synthetic Service members. */
-  ipToAllPods: ReadonlyMap<string, PodInfo>;
 }
 
 /** `svc:<ns>/<name>` — the peer key a Service node answers for. */
 export const serviceKey = (svc: ServiceInfo): string => `svc:${svc.svc_namespace ?? ''}/${svc.svc_name ?? svc.svc_ip}`;
 
 export function buildExternalNodes(input: ExternalNodesInput): PodNodeData[] {
-  const { pods, services, rowPeers, localPodByName, svcIpToLocalPod, podNameToSvcIp, ipToAllPods } = input;
+  const { pods, services, rowPeers, localPodByName, svcIpToLocalPod, podNameToSvcIp } = input;
 
   const svcByIp = new Map<string, ServiceInfo>();
   services.forEach((svc) => { if (svc.svc_ip) svcByIp.set(svc.svc_ip, svc); });
@@ -105,24 +103,25 @@ export function buildExternalNodes(input: ExternalNodesInput): PodNodeData[] {
   // Step 2: merge ACCEPTED pod peers that back a Service into that Service's
   // entry, so curl→ClusterIP and curl→backing-pod-IP produce one node (and
   // one edge). Matched by pod NAME — the pod resolvePeer chose — never by IP.
-  const mergedBackingIps = new Map<string, string[]>(); // svc key → [backing IP, ...]
+  const mergedBackingPods = new Map<string, PodInfo[]>(); // svc key → [resolved backing pod, ...]
   const mergedPeerKeys = new Map<string, string[]>(); // svc key → [pod peer key, ...]
-  const toMerge: Array<[string, ServiceInfo]> = [];
+  const toMerge: Array<[string, ServiceInfo, PodInfo]> = [];
   entries.forEach((e, key) => {
-    if (!e.podInfo) return;
-    const svcIp = podNameToSvcIp.get(e.podInfo.pod_name);
+    const backing = e.podInfo;
+    if (!backing) return;
+    const svcIp = podNameToSvcIp.get(backing.pod_name);
     const svc = svcIp ? svcByIp.get(svcIp) : undefined;
-    if (svc) toMerge.push([key, svc]);
+    if (svc) toMerge.push([key, svc, backing]);
   });
-  toMerge.forEach(([key, svc]) => {
+  toMerge.forEach(([key, svc, backing]) => {
     const e = entries.get(key)!;
     const target = entry(serviceKey(svc), { podInfo: null, svc, ip: svc.svc_ip, stored: false, unattributed: false });
     target.ingressTraffic.push(...e.ingressTraffic);
     target.egressTraffic.push(...e.egressTraffic);
     entries.delete(key);
     const sk = serviceKey(svc);
-    if (!mergedBackingIps.has(sk)) mergedBackingIps.set(sk, []);
-    mergedBackingIps.get(sk)!.push(e.ip);
+    if (!mergedBackingPods.has(sk)) mergedBackingPods.set(sk, []);
+    mergedBackingPods.get(sk)!.push(backing);
     if (!mergedPeerKeys.has(sk)) mergedPeerKeys.set(sk, []);
     mergedPeerKeys.get(sk)!.push(key);
   });
@@ -164,26 +163,31 @@ export function buildExternalNodes(input: ExternalNodesInput): PodNodeData[] {
       const g = group(`external-svc-${ns}-${name}`);
       g.peerKeys.add(entryKey);
       mergedPeerKeys.get(entryKey)?.forEach((k) => g.peerKeys.add(k));
-      const backingIps = mergedBackingIps.get(entryKey) || [];
-      if (backingIps.length > 0) {
-        // Use only the real backing pod IPs so the pod count reflects actual pods.
+      const backingPods = mergedBackingPods.get(entryKey) || [];
+      if (backingPods.length > 0) {
+        // Use only the real backing pods so the pod count reflects actual pods.
         // The service ClusterIP is a virtual IP and should not count as a pod.
-        backingIps.forEach((backingIp) => {
+        backingPods.forEach((backing) => {
           // Carry the backing pod's workload facts onto the synthetic member so
           // the DaemonSets toggle can recognise a Service fronting a DaemonSet or
           // host-network pods (node-exporter, CSI node plugins, ...).
-          const known = ipToAllPods.get(backingIp);
+          //
+          // Taken from the pod `resolvePeer` attributed to the flow, never from
+          // an IP → pod map: pod_details keeps every pod that ever held an
+          // address, so a by-IP lookup lands on an arbitrary former holder — on
+          // EKS a dead node agent — and a Deployment-backed Service rendered
+          // (and hid) as a DaemonSet peer (#1565).
           g.memberPods.push({
             pod_name: name,
-            pod_ip: backingIp,
+            pod_ip: backing.pod_ip,
             pod_namespace: ns,
             pod_identity: name,
             time_stamp: '',
-            node_name: known?.node_name ?? '',
+            node_name: backing.node_name ?? '',
             is_dead: false,
-            workload_kind: known?.workload_kind ?? null,
-            workload_name: known?.workload_name ?? null,
-            host_network: known?.host_network ?? null,
+            workload_kind: backing.workload_kind ?? null,
+            workload_name: backing.workload_name ?? null,
+            host_network: backing.host_network ?? null,
           });
         });
       } else if (ext.ip) {


### PR DESCRIPTION
#1447 moved peer attribution to per-row resolvePeer under the start-time
guard but left one IP -> pod map behind: the synthetic member pods of a
Service node took their workload facts from a last-write-wins map over
the whole /pod/info listing, dead rows included. A recycled address
resolved to whichever former holder sorted last in (namespace, name)
order, on EKS the node agents, so a Deployment-backed Service inherited
workload_kind DaemonSet / host_network true from a dead ebs-csi-node or
datadog-agent row and the DaemonSets toggle hid it by default. Measured
on one EKS cluster, 97% of the flags the decoration produced were wrong.

Decorate from the pod resolvePeer attributed to the flow instead: step 2
of buildExternalNodes already holds it and only kept its IP. The map has
no other consumer and is removed from ExternalNodesInput and
NetworkGraph. isDaemonSetPeer's docstring now states that a Service node
qualifies through its decorated members; it previously claimed the
opposite of what the code did.

The regression test fails on the old code with 'DaemonSet' where
'Deployment' is expected; a control pins that a Service really fronting
a DaemonSet or host-network pod is still flagged.

Closes #1565

## Validation
- Independent validator reproduced the failure on main with its own test (member reads DaemonSet where Deployment is expected while resolvePeer had picked the right pod) and confirmed the blast radius: generated NetworkPolicy, advisor and llm-bridge never use the IP map.
- Regression hunter ran a harness against the old and new module for every consumer of Service member pods: no observable change except a dual-stack pod hit on its IPv6 address, which is now decorated where before it got nothing.
- Design review: resolved pod is the correct source (workload_kind and host_network are immutable per pod, so the only question was which pod, and resolvePeer already answers it under the start-time guard).
- Gates: lint 0 errors (one pre-existing warning), tsc clean, 41 files / 398 tests, build ok.

Follow-ups, pre-existing and out of scope: DataTable.tsx keeps a second last-write-wins IP map for the local side of a row; DataTable keys Service member rows by pod name.

https://claude.ai/code/session_013uBTphXbBk2V2BprxmQ33n